### PR TITLE
Buffer requests during connection establishment

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,14 @@ server := aprot.NewServer(registry, aprot.ServerOptions{
 
 The server automatically sends this configuration to clients on connect. TypeScript clients apply it automatically, overriding any client-side defaults.
 
+### Request Buffering
+
+The generated TypeScript client automatically buffers requests made while a connection is being established or re-established. If you call an API method during the `connecting` or `reconnecting` state, the request is queued and sent once the connection succeeds. If the connection ultimately fails (transitions to `disconnected`), all buffered requests are rejected.
+
+This is transparent — no configuration needed. Requests made while fully `disconnected` (no connection attempt in progress) still reject immediately with `"Not connected"`.
+
+Buffered requests support `AbortSignal` cancellation: aborting a signal removes the request from the buffer.
+
 ### Transport
 
 aprot supports two transports that share the same handler dispatch, middleware, connection management, and generated client API:

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -235,6 +235,13 @@ export class ApiClient {
         reject: (error: Error) => void;
         onProgress?: (current: number, total: number, message: string) => void;
     }>();
+    private buffer: Array<{
+        method: string;
+        params: any;
+        options?: RequestOptions;
+        resolve: (value: any) => void;
+        reject: (error: Error) => void;
+    }> = [];
     private pushHandlers = new Map<string, Set<(data: any) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private state: ConnectionState = 'disconnected';
@@ -339,6 +346,11 @@ export class ApiClient {
     private setState(state: ConnectionState): void {
         if (this.state === state) return;
         this.state = state;
+        if (state === 'connected') {
+            this.flushBuffer();
+        } else if (state === 'disconnected') {
+            this.rejectBuffer(new Error('Not connected'));
+        }
         for (const listener of this.stateListeners) {
             listener(state);
         }
@@ -467,21 +479,70 @@ export class ApiClient {
 
     request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
-            if (!this.transport.isConnected()) {
-                reject(new Error('Not connected'));
+            if (this.transport.isConnected()) {
+                this.sendRequest(method, params, options, resolve, reject);
                 return;
             }
-            const id = String(++this.requestId);
-            this.pending.set(id, { resolve, reject, onProgress: options?.onProgress });
-            if (options?.signal) {
-                options.signal.addEventListener('abort', () => {
-                    this.transport.send({ type: 'cancel', id });
-                    this.pending.delete(id);
-                    reject(new Error('Request aborted'));
-                });
+            if (this.state === 'connecting' || this.state === 'reconnecting') {
+                const entry = { method, params, options, resolve, reject };
+                this.buffer.push(entry);
+                if (options?.signal) {
+                    if (options.signal.aborted) {
+                        this.buffer.pop();
+                        reject(new Error('Request aborted'));
+                        return;
+                    }
+                    options.signal.addEventListener('abort', () => {
+                        const idx = this.buffer.indexOf(entry);
+                        if (idx !== -1) {
+                            this.buffer.splice(idx, 1);
+                            reject(new Error('Request aborted'));
+                        }
+                    }, { once: true });
+                }
+                return;
             }
-            this.transport.send({ type: 'request', id, method, params });
+            reject(new Error('Not connected'));
         });
+    }
+
+    private sendRequest(method: string, params: any, options: RequestOptions | undefined,
+        resolve: (value: any) => void, reject: (error: Error) => void): void {
+        const id = String(++this.requestId);
+        this.pending.set(id, { resolve, reject, onProgress: options?.onProgress });
+        if (options?.signal) {
+            if (options.signal.aborted) {
+                this.pending.delete(id);
+                reject(new Error('Request aborted'));
+                return;
+            }
+            options.signal.addEventListener('abort', () => {
+                this.transport.send({ type: 'cancel', id });
+                this.pending.delete(id);
+                reject(new Error('Request aborted'));
+            }, { once: true });
+        }
+        this.transport.send({ type: 'request', id, method, params });
+    }
+
+    private flushBuffer(): void {
+        const buffered = this.buffer;
+        this.buffer = [];
+        for (const entry of buffered) {
+            if (entry.options?.signal?.aborted) {
+                entry.reject(new Error('Request aborted'));
+                continue;
+            }
+            this.sendRequest(entry.method, entry.params, entry.options, entry.resolve, entry.reject);
+        }
+    }
+
+    private rejectBuffer(error: Error): void {
+        const buffered = this.buffer;
+        this.buffer = [];
+        for (const entry of buffered) {
+            entry.reject(error);
+        }
     }
 
     onPush<T>(event: string, handler: PushHandler<T>): () => void {

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -144,6 +144,13 @@ export class ApiClient {
         reject: (error: Error) => void;
         onProgress?: (current: number, total: number, message: string) => void;
     }>();
+    private buffer: Array<{
+        method: string;
+        params: any;
+        options?: RequestOptions;
+        resolve: (value: any) => void;
+        reject: (error: Error) => void;
+    }> = [];
     private pushHandlers = new Map<string, Set<(data: any) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private state: ConnectionState = 'disconnected';
@@ -244,6 +251,11 @@ export class ApiClient {
     private setState(state: ConnectionState): void {
         if (this.state === state) return;
         this.state = state;
+        if (state === 'connected') {
+            this.flushBuffer();
+        } else if (state === 'disconnected') {
+            this.rejectBuffer(new Error('Not connected'));
+        }
         for (const listener of this.stateListeners) {
             listener(state);
         }
@@ -338,21 +350,70 @@ export class ApiClient {
 
     private request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
-            if (!this.transport.isConnected()) {
-                reject(new Error('Not connected'));
+            if (this.transport.isConnected()) {
+                this.sendRequest(method, params, options, resolve, reject);
                 return;
             }
-            const id = String(++this.requestId);
-            this.pending.set(id, { resolve, reject, onProgress: options?.onProgress });
-            if (options?.signal) {
-                options.signal.addEventListener('abort', () => {
-                    this.transport.send({ type: 'cancel', id });
-                    this.pending.delete(id);
-                    reject(new Error('Request aborted'));
-                });
+            if (this.state === 'connecting' || this.state === 'reconnecting') {
+                const entry = { method, params, options, resolve, reject };
+                this.buffer.push(entry);
+                if (options?.signal) {
+                    if (options.signal.aborted) {
+                        this.buffer.pop();
+                        reject(new Error('Request aborted'));
+                        return;
+                    }
+                    options.signal.addEventListener('abort', () => {
+                        const idx = this.buffer.indexOf(entry);
+                        if (idx !== -1) {
+                            this.buffer.splice(idx, 1);
+                            reject(new Error('Request aborted'));
+                        }
+                    }, { once: true });
+                }
+                return;
             }
-            this.transport.send({ type: 'request', id, method, params });
+            reject(new Error('Not connected'));
         });
+    }
+
+    private sendRequest(method: string, params: any, options: RequestOptions | undefined,
+        resolve: (value: any) => void, reject: (error: Error) => void): void {
+        const id = String(++this.requestId);
+        this.pending.set(id, { resolve, reject, onProgress: options?.onProgress });
+        if (options?.signal) {
+            if (options.signal.aborted) {
+                this.pending.delete(id);
+                reject(new Error('Request aborted'));
+                return;
+            }
+            options.signal.addEventListener('abort', () => {
+                this.transport.send({ type: 'cancel', id });
+                this.pending.delete(id);
+                reject(new Error('Request aborted'));
+            }, { once: true });
+        }
+        this.transport.send({ type: 'request', id, method, params });
+    }
+
+    private flushBuffer(): void {
+        const buffered = this.buffer;
+        this.buffer = [];
+        for (const entry of buffered) {
+            if (entry.options?.signal?.aborted) {
+                entry.reject(new Error('Request aborted'));
+                continue;
+            }
+            this.sendRequest(entry.method, entry.params, entry.options, entry.resolve, entry.reject);
+        }
+    }
+
+    private rejectBuffer(error: Error): void {
+        const buffered = this.buffer;
+        this.buffer = [];
+        for (const entry of buffered) {
+            entry.reject(error);
+        }
     }
 
     onPush<T>(event: string, handler: PushHandler<T>): () => void {

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -142,6 +142,13 @@ export class ApiClient {
         reject: (error: Error) => void;
         onProgress?: (current: number, total: number, message: string) => void;
     }>();
+    private buffer: Array<{
+        method: string;
+        params: any;
+        options?: RequestOptions;
+        resolve: (value: any) => void;
+        reject: (error: Error) => void;
+    }> = [];
     private pushHandlers = new Map<string, Set<(data: any) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private state: ConnectionState = 'disconnected';
@@ -242,6 +249,11 @@ export class ApiClient {
     private setState(state: ConnectionState): void {
         if (this.state === state) return;
         this.state = state;
+        if (state === 'connected') {
+            this.flushBuffer();
+        } else if (state === 'disconnected') {
+            this.rejectBuffer(new Error('Not connected'));
+        }
         for (const listener of this.stateListeners) {
             listener(state);
         }
@@ -336,21 +348,70 @@ export class ApiClient {
 
     private request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
-            if (!this.transport.isConnected()) {
-                reject(new Error('Not connected'));
+            if (this.transport.isConnected()) {
+                this.sendRequest(method, params, options, resolve, reject);
                 return;
             }
-            const id = String(++this.requestId);
-            this.pending.set(id, { resolve, reject, onProgress: options?.onProgress });
-            if (options?.signal) {
-                options.signal.addEventListener('abort', () => {
-                    this.transport.send({ type: 'cancel', id });
-                    this.pending.delete(id);
-                    reject(new Error('Request aborted'));
-                });
+            if (this.state === 'connecting' || this.state === 'reconnecting') {
+                const entry = { method, params, options, resolve, reject };
+                this.buffer.push(entry);
+                if (options?.signal) {
+                    if (options.signal.aborted) {
+                        this.buffer.pop();
+                        reject(new Error('Request aborted'));
+                        return;
+                    }
+                    options.signal.addEventListener('abort', () => {
+                        const idx = this.buffer.indexOf(entry);
+                        if (idx !== -1) {
+                            this.buffer.splice(idx, 1);
+                            reject(new Error('Request aborted'));
+                        }
+                    }, { once: true });
+                }
+                return;
             }
-            this.transport.send({ type: 'request', id, method, params });
+            reject(new Error('Not connected'));
         });
+    }
+
+    private sendRequest(method: string, params: any, options: RequestOptions | undefined,
+        resolve: (value: any) => void, reject: (error: Error) => void): void {
+        const id = String(++this.requestId);
+        this.pending.set(id, { resolve, reject, onProgress: options?.onProgress });
+        if (options?.signal) {
+            if (options.signal.aborted) {
+                this.pending.delete(id);
+                reject(new Error('Request aborted'));
+                return;
+            }
+            options.signal.addEventListener('abort', () => {
+                this.transport.send({ type: 'cancel', id });
+                this.pending.delete(id);
+                reject(new Error('Request aborted'));
+            }, { once: true });
+        }
+        this.transport.send({ type: 'request', id, method, params });
+    }
+
+    private flushBuffer(): void {
+        const buffered = this.buffer;
+        this.buffer = [];
+        for (const entry of buffered) {
+            if (entry.options?.signal?.aborted) {
+                entry.reject(new Error('Request aborted'));
+                continue;
+            }
+            this.sendRequest(entry.method, entry.params, entry.options, entry.resolve, entry.reject);
+        }
+    }
+
+    private rejectBuffer(error: Error): void {
+        const buffered = this.buffer;
+        this.buffer = [];
+        for (const entry of buffered) {
+            entry.reject(error);
+        }
     }
 {{range .Methods}}
     {{.MethodName}}(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}> {


### PR DESCRIPTION
## Summary

- Requests made while the client is `connecting` or `reconnecting` are now queued in a buffer and automatically sent when the connection succeeds
- If the connection transitions to `disconnected`, all buffered requests are rejected with "Not connected"
- Buffered requests support `AbortSignal` cancellation (aborting removes the request from the buffer)
- No configuration needed — this is fully transparent to callers

Closes #5

## Test plan

- [ ] Verify `go test ./...` passes
- [ ] Verify generated TypeScript compiles (`npx tsc --noEmit` in react example)
- [ ] Test calling API methods before `connect()` promise resolves — requests should queue and complete after connection
- [ ] Test calling API methods during reconnection — requests should queue and complete after reconnect
- [ ] Test that requests made while fully `disconnected` (no reconnect in progress) still reject immediately
- [ ] Test `AbortSignal` cancellation of buffered requests
- [ ] Test that buffered requests are rejected when connection fails and transitions to `disconnected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)