### PR TITLE
Fix SSE error handling, add vanilla SSE support, simplify README

### DIFF
--- a/example/vanilla/client/static/index.html
+++ b/example/vanilla/client/static/index.html
@@ -65,7 +65,17 @@
 </head>
 <body>
     <h1>aprot Example</h1>
-    <div id="status" class="status disconnected">Disconnected</div>
+    <div style="display: flex; align-items: center; gap: 20px; margin-bottom: 20px;">
+        <div id="status" class="status disconnected" style="margin-bottom: 0;">Disconnected</div>
+        <div style="display: flex; align-items: center; gap: 10px;">
+            <label style="margin: 0; font-weight: 500; color: #555;">Transport:</label>
+            <select id="transportSelect" style="padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px; font-size: 14px;">
+                <option value="websocket">WebSocket</option>
+                <option value="sse">SSE</option>
+            </select>
+            <button id="reconnectBtn" onclick="reconnect()">Reconnect</button>
+        </div>
+    </div>
     <div class="grid">
         <div class="card">
             <h2>Create User</h2>

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -143,9 +143,11 @@ class SSETransport implements ClientTransport {
     private eventSource: EventSource | null = null;
     private connectionId: string | null = null;
     private baseUrl: string = '';
+    private onMessage: ((data: string) => void) | null = null;
 
     connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
         this.baseUrl = url;
+        this.onMessage = onMessage;
 
         return new Promise((resolve) => {
             this.eventSource = new EventSource(url);
@@ -200,7 +202,13 @@ class SSETransport implements ClientTransport {
                     method: msg.method,
                     params: msg.params,
                 }),
-            }).catch(() => {});
+            }).then((resp) => {
+                if (resp.status !== 202) {
+                    this.synthesizeError(msg.id, `Server returned unexpected response (status ${resp.status})`);
+                }
+            }).catch(() => {
+                this.synthesizeError(msg.id, 'Network error: failed to send request');
+            });
         } else if (msg.type === 'cancel') {
             fetch(this.baseUrl + '/cancel', {
                 method: 'POST',
@@ -214,10 +222,17 @@ class SSETransport implements ClientTransport {
         // ping is a no-op for SSE (server uses keep-alive comments)
     }
 
+    private synthesizeError(id: string, message: string): void {
+        if (this.onMessage) {
+            this.onMessage(JSON.stringify({ type: 'error', id, code: -32603, message }));
+        }
+    }
+
     disconnect(): void {
         this.eventSource?.close();
         this.eventSource = null;
         this.connectionId = null;
+        this.onMessage = null;
     }
 
     isConnected(): boolean {


### PR DESCRIPTION
Closes #14

## Summary

- **Fix SSE transport error handling**: `POST /rpc` errors (non-202 status, network failures) now synthesize protocol-compatible error messages via `onMessage`, causing pending promises to reject with `ApiError` instead of hanging forever.
- **Add transport switching to vanilla example**: New dropdown + reconnect button lets users switch between WebSocket and SSE transports at runtime.
- **Simplify README Quick Start**: Reduced from 6 steps with two handler structs to 3 steps with a single `Handlers` struct. Multi-handler pattern moved to Per-Handler Middleware section.

## Test plan

- [x] `go test ./...` passes
- [x] Regenerated vanilla and React TypeScript clients
- [x] `npx tsc --noEmit` passes for React client
- [x] `npm run build` passes for vanilla client
- [ ] Manually verify vanilla example works with both WebSocket and SSE transports
- [ ] Verify SSE error handling by testing against a server that returns non-202 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)