### PR TITLE
Fix case-sensitive JSON deserialization of request params

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -451,7 +451,7 @@ func (info *HandlerInfo) Call(ctx context.Context, params jsontext.Value) (any, 
 
 	// Unmarshal params if provided
 	if len(params) > 0 {
-		if err := json.Unmarshal(params, reqPtr.Interface()); err != nil {
+		if err := json.Unmarshal(params, reqPtr.Interface(), json.MatchCaseInsensitiveNames(true)); err != nil {
 			return nil, ErrInvalidParams(err.Error())
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix `HandlerInfo.Call()` silently dropping request fields when Go structs lack explicit `json` tags, by enabling case-insensitive JSON field matching

Closes #16

## Details

The TypeScript code generator converts Go field names to camelCase via `toLowerCamel()` (e.g., `Milliseconds` → `milliseconds`), but `go-json-experiment/json` defaults to case-sensitive matching. This caused all fields without explicit `json` tags to silently remain at zero values.

The fix adds `json.MatchCaseInsensitiveNames(true)` to the `Unmarshal` call in `handler.go`.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Verify with a handler struct that has no `json` tags (e.g., `SetStatisticsRefreshRequest{Milliseconds: 1000}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)