### PR TITLE
Register and RegisterEnum now panic instead of returning errors

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -115,10 +115,7 @@ func (h *TaskHandlers) CreateTask(ctx context.Context, req *CreateTaskRequest) (
 
 func TestRegistry(t *testing.T) {
 	registry := NewRegistry()
-	err := registry.Register(&TestHandlers{})
-	if err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(&TestHandlers{})
 
 	methods := registry.Methods()
 	if len(methods) != 2 {
@@ -364,16 +361,10 @@ func TestRegisterEnum(t *testing.T) {
 	registry := NewRegistry()
 
 	// Test string-based enum
-	err := registry.RegisterEnum(TaskStatusValues())
-	if err != nil {
-		t.Fatalf("RegisterEnum (string) failed: %v", err)
-	}
+	registry.RegisterEnum(TaskStatusValues())
 
 	// Test int-based enum with Stringer
-	err = registry.RegisterEnum(PriorityValues())
-	if err != nil {
-		t.Fatalf("RegisterEnum (int) failed: %v", err)
-	}
+	registry.RegisterEnum(PriorityValues())
 
 	enums := registry.Enums()
 	if len(enums) != 2 {
@@ -421,17 +412,25 @@ func TestRegisterEnum(t *testing.T) {
 func TestRegisterEnumErrors(t *testing.T) {
 	registry := NewRegistry()
 
-	// Test non-slice
-	err := registry.RegisterEnum("not a slice")
-	if err == nil {
-		t.Error("Expected error for non-slice")
-	}
+	// Test non-slice panics
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for non-slice")
+			}
+		}()
+		registry.RegisterEnum("not a slice")
+	}()
 
-	// Test empty slice
-	err = registry.RegisterEnum([]TaskStatus{})
-	if err == nil {
-		t.Error("Expected error for empty slice")
-	}
+	// Test empty slice panics
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for empty slice")
+			}
+		}()
+		registry.RegisterEnum([]TaskStatus{})
+	}()
 }
 
 func TestGenerateWithEnums(t *testing.T) {
@@ -504,10 +503,7 @@ func (h *MixedHandlers) DeleteItem(ctx context.Context, req *DeleteItemRequest) 
 
 func TestVoidHandlerRegistration(t *testing.T) {
 	registry := NewRegistry()
-	err := registry.Register(&VoidHandlers{})
-	if err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(&VoidHandlers{})
 
 	info, ok := registry.Get("DeleteItem")
 	if !ok {

--- a/handler.go
+++ b/handler.go
@@ -109,12 +109,12 @@ func NewRegistry() *Registry {
 //	registry.Register(&PublicHandlers{})                    // No middleware
 //	registry.Register(&UserHandlers{}, authMiddleware)      // With auth
 //	registry.Register(&AdminHandlers{}, authMiddleware, adminMiddleware)
-func (r *Registry) Register(handler any, middleware ...Middleware) error {
+func (r *Registry) Register(handler any, middleware ...Middleware) {
 	v := reflect.ValueOf(handler)
 	t := v.Type()
 
 	if t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
-		return fmt.Errorf("handler must be a pointer to a struct")
+		panic("aprot: Register requires a pointer to a struct")
 	}
 
 	structName := t.Elem().Name()
@@ -133,7 +133,6 @@ func (r *Registry) Register(handler any, middleware ...Middleware) error {
 	}
 
 	r.groups[structName] = group
-	return nil
 }
 
 // RegisterPushEvent registers a push event type for code generation.
@@ -257,13 +256,13 @@ func (r *Registry) ErrorCodes() []ErrorCodeInfo {
 //
 //	registry.RegisterEnum(StrStateValues())   // string-based
 //	registry.RegisterEnum(IntStatusValues())  // int-based with Stringer
-func (r *Registry) RegisterEnum(values any) error {
+func (r *Registry) RegisterEnum(values any) {
 	v := reflect.ValueOf(values)
 	if v.Kind() != reflect.Slice {
-		return fmt.Errorf("RegisterEnum: expected slice, got %v", v.Kind())
+		panic(fmt.Sprintf("aprot: RegisterEnum requires a slice, got %v", v.Kind()))
 	}
 	if v.Len() == 0 {
-		return fmt.Errorf("RegisterEnum: empty slice")
+		panic("aprot: RegisterEnum requires a non-empty slice")
 	}
 
 	elemType := v.Type().Elem()
@@ -315,8 +314,6 @@ func (r *Registry) RegisterEnum(values any) error {
 
 	r.enums = append(r.enums, enumInfo)
 	r.enumTypes[elemType] = &r.enums[len(r.enums)-1]
-
-	return nil
 }
 
 // GetEnum returns the EnumInfo for a registered enum type, or nil if not registered.

--- a/server_test.go
+++ b/server_test.go
@@ -82,9 +82,7 @@ func (h *IntegrationHandlers) TriggerPush(ctx context.Context, req *BroadcastReq
 func setupTestServer(t *testing.T) (*httptest.Server, *Server, *IntegrationHandlers) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -363,9 +361,7 @@ func TestServerBroadcast(t *testing.T) {
 func TestOnConnectHookCalled(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -392,9 +388,7 @@ func TestOnConnectHookCalled(t *testing.T) {
 func TestOnConnectHookRejectsConnection(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -444,9 +438,7 @@ func TestOnConnectHookRejectsConnection(t *testing.T) {
 func TestOnConnectMultipleHooks(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -504,9 +496,7 @@ func TestOnConnectMultipleHooks(t *testing.T) {
 func TestOnDisconnectHookCalled(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -538,9 +528,7 @@ func TestOnDisconnectHookCalled(t *testing.T) {
 func TestOnDisconnectHookHasUserID(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -584,9 +572,7 @@ func TestOnDisconnectHookHasUserID(t *testing.T) {
 func TestHookContextContainsConnection(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -618,9 +604,7 @@ func TestHookContextContainsConnection(t *testing.T) {
 func TestConfigSentOnConnect(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry, ServerOptions{
 		ReconnectInterval:    2000,
@@ -682,9 +666,7 @@ func (h *VoidTestHandlers) DeleteItem(ctx context.Context, req *VoidRequest) err
 
 func TestServerVoidResponse(t *testing.T) {
 	registry := NewRegistry()
-	if err := registry.Register(&VoidTestHandlers{}); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(&VoidTestHandlers{})
 
 	server := NewServer(registry)
 	ts := httptest.NewServer(server)
@@ -723,9 +705,7 @@ func TestServerVoidResponse(t *testing.T) {
 func TestServerOptionsDefaults(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server

--- a/sse_handler_test.go
+++ b/sse_handler_test.go
@@ -60,9 +60,7 @@ func (r *sseReader) readEvent() (*sseEvent, error) {
 func setupSSETestServer(t *testing.T) (*httptest.Server, *Server, *sseHandler) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
-	if err := registry.Register(handlers); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
+	registry.Register(handlers)
 
 	server := NewServer(registry)
 	handlers.server = server


### PR DESCRIPTION
## Summary

- `Registry.Register()` and `Registry.RegisterEnum()` no longer return `error` — they panic on invalid input instead
- Follows Go conventions for setup-time functions (like `regexp.MustCompile`, `template.Must`) where errors indicate programmer mistakes, not recoverable conditions
- Updated all test call sites to remove error checks
- `TestRegisterEnumErrors` now asserts panics via `defer/recover`

Closes #18

## Test plan

- [x] `go test ./...` passes
- [ ] Verify CI passes (Go tests, TypeScript compile, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)