### PR TITLE
Make push broadcasting type-safe by deriving event names from Go types

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ type Handlers struct {
 
 func (h *Handlers) CreateUser(ctx context.Context, req *CreateUserRequest) (*CreateUserResponse, error) {
     resp := &CreateUserResponse{ID: "1", Name: req.Name, Email: req.Email}
-    h.Broadcaster.Broadcast("UserCreated", &UserCreatedEvent{ID: resp.ID, Name: resp.Name})
+    h.Broadcaster.Broadcast(&UserCreatedEvent{ID: resp.ID, Name: resp.Name})
     return resp, nil
 }
 ```
@@ -245,7 +245,7 @@ if conn != nil {
 }
 
 // Later, send push to specific user (e.g., from a background job):
-server.PushToUser("user_123", "Notification", &NotificationEvent{
+server.PushToUser("user_123", &NotificationEvent{
     Message: "You have a new message",
 })
 ```
@@ -722,7 +722,7 @@ await client.connect();
 
 const user = await client.createUser({ name: 'Alice', email: 'alice@example.com' });
 
-client.onUserCreated((event) => {
+client.onUserCreatedEvent((event) => {
     console.log('User created:', event);
 });
 ```
@@ -777,7 +777,7 @@ Messages are JSON with a `type` field:
 | server→client | error | `{"type":"error","id":"1","code":404,"message":"Not found"}` |
 | server→client | progress | `{"type":"progress","id":"1","current":5,"total":10,"message":"..."}` |
 | client→server | cancel | `{"type":"cancel","id":"1"}` |
-| server→client | push | `{"type":"push","event":"UserCreated","data":{...}}` |
+| server→client | push | `{"type":"push","event":"UserCreatedEvent","data":{...}}` |
 | server→client | config | `{"type":"config","reconnectInterval":1000,"heartbeatInterval":30000,...}` |
 | server→client | connected | `{"type":"connected","connectionId":"abc123"}` (SSE only) |
 

--- a/connection.go
+++ b/connection.go
@@ -103,7 +103,15 @@ func newConn(t transport, server *Server, id uint64, r *http.Request, ctx contex
 }
 
 // Push sends a push message to this connection.
-func (c *Conn) Push(event string, data any) error {
+// The event name is derived from the Go type of data, which must have been
+// registered via RegisterPushEvent or RegisterPushEventFor.
+func (c *Conn) Push(data any) error {
+	event := c.server.registry.eventName(data)
+	return c.push(event, data)
+}
+
+// push sends a push message with an explicit event name (internal use).
+func (c *Conn) push(event string, data any) error {
 	msg := PushMessage{
 		Type:  TypePush,
 		Event: event,

--- a/e2e/tests/auth.test.ts
+++ b/e2e/tests/auth.test.ts
@@ -65,7 +65,7 @@ describe('Auth Flow (WebSocket)', () => {
             const recipientLogin = await client2.login({ username: 'recipient', password: 'pass' });
 
             const received = new Promise<{ from_user_id: string; from_user: string; message: string }>((resolve) => {
-                client2.onDirectMessage((data) => {
+                client2.onDirectMessageEvent((data) => {
                     resolve(data);
                 });
             });

--- a/e2e/tests/sse.test.ts
+++ b/e2e/tests/sse.test.ts
@@ -76,7 +76,7 @@ describe('SSE Transport', () => {
 
     test('sendNotification triggers push event to same client', async () => {
         const received = new Promise<{ message: string; level: string }>((resolve) => {
-            client.onSystemNotification((data) => {
+            client.onSystemNotificationEvent((data) => {
                 resolve(data);
             });
         });
@@ -94,7 +94,7 @@ describe('SSE Transport', () => {
 
         try {
             const received = new Promise<{ id: string; name: string; email: string }>((resolve) => {
-                client2.onUserCreated((data) => {
+                client2.onUserCreatedEvent((data) => {
                     resolve(data);
                 });
             });

--- a/e2e/tests/ws.test.ts
+++ b/e2e/tests/ws.test.ts
@@ -76,7 +76,7 @@ describe('WebSocket Transport', () => {
 
     test('sendNotification triggers push event to same client', async () => {
         const received = new Promise<{ message: string; level: string }>((resolve) => {
-            client.onSystemNotification((data) => {
+            client.onSystemNotificationEvent((data) => {
                 resolve(data);
             });
         });
@@ -94,7 +94,7 @@ describe('WebSocket Transport', () => {
 
         try {
             const received = new Promise<{ id: string; name: string; email: string }>((resolve) => {
-                client2.onUserCreated((data) => {
+                client2.onUserCreatedEvent((data) => {
                     resolve(data);
                 });
             });

--- a/example/react/api/handlers.go
+++ b/example/react/api/handlers.go
@@ -52,7 +52,7 @@ func (h *Handlers) CreateUser(ctx context.Context, req *CreateUserRequest) (*Cre
 
 	// Broadcast to all clients that a user was created
 	if h.broadcaster != nil {
-		h.broadcaster.Broadcast("UserCreated", &UserCreatedEvent{
+		h.broadcaster.Broadcast(&UserCreatedEvent{
 			ID:    user.ID,
 			Name:  user.Name,
 			Email: user.Email,
@@ -136,7 +136,7 @@ func (h *Handlers) ProcessBatch(ctx context.Context, req *ProcessBatchRequest) (
 func (h *Handlers) SendNotification(ctx context.Context, req *SystemNotificationEvent) (*SystemNotificationEvent, error) {
 	conn := aprot.Connection(ctx)
 	if conn != nil {
-		conn.Push("SystemNotification", req)
+		conn.Push(req)
 	}
 	return req, nil
 }

--- a/example/react/client/src/App.tsx
+++ b/example/react/client/src/App.tsx
@@ -4,8 +4,8 @@ import {
   useListUsers,
   useCreateUserMutation,
   useProcessBatchMutation,
-  useUserCreated,
-  useSystemNotification,
+  useUserCreatedEvent,
+  useSystemNotificationEvent,
   useGetTaskMutation,
   TaskStatus,
 } from './api/handlers'
@@ -77,7 +77,7 @@ function CreateUserForm({ onLog }: { onLog: (msg: string, type?: string) => void
 
 function UsersList() {
   const { data, isLoading, refetch } = useListUsers({ params: {} })
-  const { lastEvent } = useUserCreated()
+  const { lastEvent } = useUserCreatedEvent()
 
   useEffect(() => {
     if (lastEvent) refetch()
@@ -264,7 +264,7 @@ function BatchProcessor({ onLog }: { onLog: (msg: string, type?: string) => void
 }
 
 function EventLog({ logs, onClear }: { logs: { message: string; type: string; time: string }[]; onClear: () => void }) {
-  const { lastEvent: notification } = useSystemNotification()
+  const { lastEvent: notification } = useSystemNotificationEvent()
   const logRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -294,7 +294,7 @@ function EventLog({ logs, onClear }: { logs: { message: string; type: string; ti
 function AppContent() {
   const [logs, setLogs] = useState<{ message: string; type: string; time: string }[]>([])
   const { isConnected } = useConnection()
-  const { lastEvent: userCreated } = useUserCreated()
+  const { lastEvent: userCreated } = useUserCreatedEvent()
 
   useEffect(() => {
     if (isConnected) addLog('Connected to server', 'response')

--- a/example/vanilla/api/handlers.go
+++ b/example/vanilla/api/handlers.go
@@ -13,7 +13,7 @@ import (
 
 // UserPusher interface for sending push messages to specific users.
 type UserPusher interface {
-	PushToUser(userID string, event string, data any)
+	PushToUser(userID string, data any)
 }
 
 // SharedState holds state shared between handler groups.
@@ -79,7 +79,7 @@ func (h *PublicHandlers) CreateUser(ctx context.Context, req *CreateUserRequest)
 
 	// Broadcast to all clients that a user was created
 	if h.state.Broadcaster != nil {
-		h.state.Broadcaster.Broadcast("UserCreated", &UserCreatedEvent{
+		h.state.Broadcaster.Broadcast(&UserCreatedEvent{
 			ID:    user.ID,
 			Name:  user.Name,
 			Email: user.Email,
@@ -163,7 +163,7 @@ func (h *PublicHandlers) ProcessBatch(ctx context.Context, req *ProcessBatchRequ
 func (h *PublicHandlers) SendNotification(ctx context.Context, req *SystemNotificationEvent) (*SystemNotificationEvent, error) {
 	conn := aprot.Connection(ctx)
 	if conn != nil {
-		conn.Push("SystemNotification", req)
+		conn.Push(req)
 	}
 	return req, nil
 }
@@ -257,7 +257,7 @@ func (h *ProtectedHandlers) SendMessage(ctx context.Context, req *SendMessageReq
 
 	// Send push to the recipient
 	if h.state.UserPusher != nil {
-		h.state.UserPusher.PushToUser(req.ToUserID, "DirectMessage", &DirectMessageEvent{
+		h.state.UserPusher.PushToUser(req.ToUserID, &DirectMessageEvent{
 			FromUserID: sender.ID,
 			FromUser:   sender.Username,
 			Message:    req.Message,

--- a/example/vanilla/client/static/app.ts
+++ b/example/vanilla/client/static/app.ts
@@ -190,17 +190,17 @@ function createClient(transport: 'websocket' | 'sse'): ApiClient {
         updateStatus(state === 'connected');
     });
 
-    c.onUserCreated((data) => {
+    c.onUserCreatedEvent((data) => {
         log(`User created: ${data.name} (${data.id})`, 'push');
         listUsers();
     });
 
-    c.onUserUpdated((data) => {
+    c.onUserUpdatedEvent((data) => {
         log(`User updated: ${data.name} (${data.id})`, 'push');
         listUsers();
     });
 
-    c.onSystemNotification((data) => {
+    c.onSystemNotificationEvent((data) => {
         log(`Notification [${data.level}]: ${data.message}`, 'push');
     });
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -225,8 +225,8 @@ func TestGenerate(t *testing.T) {
 	}
 
 	// Check for push handler
-	if !strings.Contains(output, "onUserUpdated(handler: PushHandler<UserUpdatedEvent>)") {
-		t.Error("Missing onUserUpdated handler")
+	if !strings.Contains(output, "onUserUpdatedEvent(handler: PushHandler<UserUpdatedEvent>)") {
+		t.Error("Missing onUserUpdatedEvent handler")
 	}
 
 	// Check for optional fields
@@ -330,8 +330,8 @@ func TestGenerateReact(t *testing.T) {
 	}
 
 	// Check for push event hooks
-	if !strings.Contains(output, "export function useUserUpdated") {
-		t.Error("Missing useUserUpdated hook")
+	if !strings.Contains(output, "export function useUserUpdatedEvent") {
+		t.Error("Missing useUserUpdatedEvent hook")
 	}
 
 	// Check for context

--- a/sse_handler_test.go
+++ b/sse_handler_test.go
@@ -61,6 +61,7 @@ func setupSSETestServer(t *testing.T) (*httptest.Server, *Server, *sseHandler) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
+	registry.RegisterPushEvent(NotificationEvent{})
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -297,8 +298,8 @@ func TestSSEPush(t *testing.T) {
 			gotPush = true
 			var pushMsg PushMessage
 			json.Unmarshal([]byte(ev.Data), &pushMsg)
-			if pushMsg.Event != "Notification" {
-				t.Errorf("Expected Notification event, got %s", pushMsg.Event)
+			if pushMsg.Event != "NotificationEvent" {
+				t.Errorf("Expected NotificationEvent event, got %s", pushMsg.Event)
 			}
 		} else if ev.Event == "response" {
 			gotResponse = true
@@ -322,7 +323,7 @@ func TestSSEBroadcast(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	server.Broadcast("Notification", &NotificationEvent{Message: "broadcast"})
+	server.Broadcast(&NotificationEvent{Message: "broadcast"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -577,7 +578,7 @@ func TestMixedBroadcast(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Broadcast
-	server.Broadcast("Notification", &NotificationEvent{Message: "both"})
+	server.Broadcast(&NotificationEvent{Message: "both"})
 
 	// Check WS receives
 	var wg sync.WaitGroup
@@ -592,8 +593,8 @@ func TestMixedBroadcast(t *testing.T) {
 		}
 		var msg PushMessage
 		json.Unmarshal(data, &msg)
-		if msg.Event != "Notification" {
-			t.Errorf("WS: Expected Notification, got %s", msg.Event)
+		if msg.Event != "NotificationEvent" {
+			t.Errorf("WS: Expected NotificationEvent, got %s", msg.Event)
 		}
 	}()
 
@@ -633,6 +634,7 @@ func TestMixedPushToUser(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
+	registry.RegisterPushEvent(NotificationEvent{})
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -661,7 +663,7 @@ func TestMixedPushToUser(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Push to user
-	server.PushToUser("user1", "DirectMessage", &NotificationEvent{Message: "dm"})
+	server.PushToUser("user1", &NotificationEvent{Message: "dm"})
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -675,8 +677,8 @@ func TestMixedPushToUser(t *testing.T) {
 		}
 		var msg PushMessage
 		json.Unmarshal(data, &msg)
-		if msg.Event != "DirectMessage" {
-			t.Errorf("WS: Expected DirectMessage, got %s", msg.Event)
+		if msg.Event != "NotificationEvent" {
+			t.Errorf("WS: Expected NotificationEvent, got %s", msg.Event)
 		}
 	}()
 


### PR DESCRIPTION
Closes #19

## Summary

- **Type-safe push API**: `Broadcast(data)`, `PushToUser(userID, data)`, and `Conn.Push(data)` now derive the event name from the Go type via reflection, eliminating fragile string parameters that could silently drift out of sync with registrations
- **Stop suffix stripping**: Event names now use the full Go type name (`UserCreatedEvent` → `"UserCreatedEvent"`, not `"UserCreated"`), giving users full control over naming
- **Panic on unregistered types**: Broadcasting an unregistered push type panics immediately instead of silently sending, catching bugs at development time

### Breaking changes

| Before | After |
|--------|-------|
| `server.Broadcast("UserCreated", &UserCreatedEvent{...})` | `server.Broadcast(&UserCreatedEvent{...})` |
| `server.PushToUser(id, "Notif", &NotifEvent{...})` | `server.PushToUser(id, &NotifEvent{...})` |
| `conn.Push("Foo", &FooEvent{...})` | `conn.Push(&FooEvent{...})` |
| `client.onUserCreated(handler)` | `client.onUserCreatedEvent(handler)` |
| `useUserCreated()` | `useUserCreatedEvent()` |

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] TypeScript compiles for vanilla and React examples (`npx tsc --noEmit`)
- [x] All three TypeScript generators produce correct output
- [x] Handwritten TypeScript (app.ts, App.tsx, e2e tests) updated to new method names
- [x] README updated with new API signatures and event naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)