### PR TITLE
Add graceful server shutdown via Server.Stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,20 @@ server.OnDisconnect(func(ctx context.Context, conn *aprot.Conn) {
 
 Multiple hooks can be registered and are called in order. If an `OnConnect` hook returns an error, the connection is rejected and subsequent hooks are not called.
 
+### Graceful Shutdown
+
+Stop the server gracefully with `Server.Stop()`. It rejects new connections (503), sends WebSocket close frames, waits for in-flight requests to complete, and runs all disconnect hooks before returning.
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+if err := server.Stop(ctx); err != nil {
+    log.Printf("shutdown timed out: %v", err)
+}
+```
+
+`Stop` is safe to call multiple times. If the context deadline is exceeded, it returns `ctx.Err()` and in-flight requests that haven't finished may still be running.
+
 ### Server Options
 
 Configure client reconnection and heartbeat behavior:

--- a/transport.go
+++ b/transport.go
@@ -7,4 +7,6 @@ type transport interface {
 	Send(data []byte) error
 	// Close closes the transport.
 	Close() error
+	// CloseGracefully sends a close frame (if supported) before closing.
+	CloseGracefully() error
 }

--- a/transport_sse.go
+++ b/transport_sse.go
@@ -53,6 +53,10 @@ func (t *sseTransport) Close() error {
 	return nil
 }
 
+func (t *sseTransport) CloseGracefully() error {
+	return t.Close()
+}
+
 // sendEvent sends a named SSE event with JSON data directly (not through the transport interface).
 func (t *sseTransport) sendEvent(event string, data []byte) {
 	t.mu.Lock()

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -1,6 +1,8 @@
 package aprot
 
 import (
+	"time"
+
 	"github.com/gorilla/websocket"
 )
 
@@ -27,6 +29,17 @@ func (t *wsTransport) Send(data []byte) error {
 }
 
 func (t *wsTransport) Close() error {
+	close(t.send)
+	return nil
+}
+
+func (t *wsTransport) CloseGracefully() error {
+	// Send a WebSocket close frame to notify the client
+	t.ws.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down"),
+		time.Now().Add(5*time.Second),
+	)
 	close(t.send)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `Server.Stop(ctx context.Context) error` for clean shutdown: rejects new connections (503), sends WebSocket close frames, drains in-flight requests, and fires all disconnect hooks before returning
- Adds `CloseGracefully()` to the transport interface for protocol-appropriate close signaling (WebSocket close frame / SSE no-op)
- Tracks in-flight requests via `sync.WaitGroup` at dispatch sites (both WS and SSE paths)
- Fixes bug where SSE disconnect hooks didn't fire when transport was closed server-side
- Safe to call `Stop()` multiple times (idempotent via `sync.Once`)

Closes #24

## Test plan

- [x] `TestStopGraceful` — verifies requests complete, connections close, disconnect hooks fire
- [x] `TestStopTimeout` — verifies `context.DeadlineExceeded` returned when requests ignore cancellation
- [x] `TestStopRejectsNewConnections` — verifies 503 after Stop for both WS and SSE
- [x] `TestStopNoConnections` — verifies immediate return with no connections
- [x] `TestStopIdempotent` — verifies second Stop call doesn't panic
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)