### PR TITLE
Support arbitrary handler parameters

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -119,7 +119,7 @@ func TestServerEcho(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "Echo",
-		Params: jsontext.Value(`{"message":"hello"}`),
+		Params: jsontext.Value(`[{"message":"hello"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -184,7 +184,7 @@ func TestServerProgress(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "Slow",
-		Params: jsontext.Value(`{"steps":3}`),
+		Params: jsontext.Value(`[{"steps":3}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -226,7 +226,7 @@ func TestServerCancel(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "Slow",
-		Params: jsontext.Value(`{"steps":100}`),
+		Params: jsontext.Value(`[{"steps":100}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -278,7 +278,7 @@ func TestServerPush(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "TriggerPush",
-		Params: jsontext.Value(`{"message":"pushed"}`),
+		Params: jsontext.Value(`[{"message":"pushed"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -681,7 +681,7 @@ func TestServerVoidResponse(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "DeleteItem",
-		Params: jsontext.Value(`{"id":"item_1"}`),
+		Params: jsontext.Value(`[{"id":"item_1"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -792,12 +792,12 @@ func TestServerNoRequestHandlerWithParams(t *testing.T) {
 	ws := connectWS(t, ts)
 	defer ws.Close()
 
-	// Sending params to a no-request handler should still work (params are ignored)
+	// Sending params to a no-params handler should still work (params are ignored)
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "GetStatus",
-		Params: jsontext.Value(`{"foo":"bar"}`),
+		Params: jsontext.Value(`["bar"]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -874,7 +874,7 @@ func TestStopGraceful(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "Block",
-		Params: jsontext.Value(`{"token":"test"}`),
+		Params: jsontext.Value(`[{"token":"test"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -934,7 +934,7 @@ func TestStopTimeout(t *testing.T) {
 		Type:   TypeRequest,
 		ID:     "1",
 		Method: "Stubborn",
-		Params: jsontext.Value(`{"token":"test"}`),
+		Params: jsontext.Value(`[{"token":"test"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)

--- a/sse_handler_test.go
+++ b/sse_handler_test.go
@@ -144,7 +144,7 @@ func TestSSEEcho(t *testing.T) {
 	// Wait for registration
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "Echo", `{"message":"hello"}`)
+	rpcResp := postRPC(t, ts, connID, "1", "Echo", `[{"message":"hello"}]`)
 	if rpcResp.StatusCode != http.StatusAccepted {
 		t.Fatalf("Expected 202, got %d", rpcResp.StatusCode)
 	}
@@ -181,7 +181,7 @@ func TestSSEMethodNotFound(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "NonExistent", `{}`)
+	rpcResp := postRPC(t, ts, connID, "1", "NonExistent", `[]`)
 	rpcResp.Body.Close()
 
 	ev, err := reader.readEvent()
@@ -209,7 +209,7 @@ func TestSSEProgress(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "Slow", `{"steps":3}`)
+	rpcResp := postRPC(t, ts, connID, "1", "Slow", `[{"steps":3}]`)
 	rpcResp.Body.Close()
 
 	progressCount := 0
@@ -242,7 +242,7 @@ func TestSSECancel(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "Slow", `{"steps":100}`)
+	rpcResp := postRPC(t, ts, connID, "1", "Slow", `[{"steps":100}]`)
 	rpcResp.Body.Close()
 
 	time.Sleep(50 * time.Millisecond)
@@ -282,7 +282,7 @@ func TestSSEPush(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "TriggerPush", `{"message":"pushed"}`)
+	rpcResp := postRPC(t, ts, connID, "1", "TriggerPush", `[{"message":"pushed"}]`)
 	rpcResp.Body.Close()
 
 	gotPush := false
@@ -521,7 +521,7 @@ func TestSSEInvalidConnectionID(t *testing.T) {
 	defer ts.Close()
 
 	// POST /rpc with invalid connection ID
-	body := `{"connectionId":"invalid","id":"1","method":"Echo","params":{"message":"hello"}}`
+	body := `{"connectionId":"invalid","id":"1","method":"Echo","params":[{"message":"hello"}]}`
 	resp, err := http.Post(ts.URL+"/sse/rpc", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST failed: %v", err)

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -651,8 +651,8 @@ export interface UseMutationOptions {
 }
 
 // Mutation hook result
-export interface UseMutationResult<TReq, TRes> {
-    mutate: (params: TReq) => Promise<TRes>;
+export interface UseMutationResult<TParams extends any[], TRes> {
+    mutate: (...params: TParams) => Promise<TRes>;
     data: TRes | null;
     error: Error | null;
     isLoading: boolean;

--- a/templates/client-handler-react.ts.tmpl
+++ b/templates/client-handler-react.ts.tmpl
@@ -34,11 +34,7 @@ export interface {{.Name}} {
 declare module './client' {
     interface ApiClient {
 {{- range .Methods}}
-{{- if .NoRequest}}
-        {{.MethodName}}(options?: RequestOptions): Promise<{{.ResponseType}}>;
-{{- else}}
-        {{.MethodName}}(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}>;
-{{- end}}
+        {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}>;
 {{- end}}
 {{- range .PushEvents}}
         {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void;
@@ -47,15 +43,9 @@ declare module './client' {
 }
 
 {{range .Methods -}}
-{{- if .NoRequest}}
-ApiClient.prototype.{{.MethodName}} = function(options?: RequestOptions): Promise<{{.ResponseType}}> {
-    return this.request<{{.ResponseType}}>('{{.Name}}', {}, options);
+ApiClient.prototype.{{.MethodName}} = function({{paramNames .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
+    return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
 };
-{{- else}}
-ApiClient.prototype.{{.MethodName}} = function(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
-    return this.request<{{.ResponseType}}>('{{.Name}}', req, options);
-};
-{{- end}}
 
 {{end -}}
 {{range .PushEvents -}}
@@ -66,7 +56,7 @@ ApiClient.prototype.{{.HandlerName}} = function(handler: PushHandler<{{.DataType
 {{end -}}
 // React Hooks for {{.StructName}}
 {{range .Methods}}
-{{- if .NoRequest}}
+{{- if not (hasParams .Params)}}
 // Query hook for {{.Name}}
 export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: number }): UseQueryResult<{{.ResponseType}}> {
     const client = useApiClient();
@@ -120,7 +110,7 @@ export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: n
 }
 
 // Mutation hook for {{.Name}}
-export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<void, {{.ResponseType}}> {
+export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[], {{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
     const [error, setError] = useState<Error | null>(null);
@@ -153,7 +143,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
 }
 {{- else}}
 // Query hook for {{.Name}}
-export function {{.HookName}}(options: UseQueryOptions<{{.RequestType}}>): UseQueryResult<{{.ResponseType}}> {
+export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>): UseQueryResult<{{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
     const [error, setError] = useState<Error | null>(null);
@@ -167,7 +157,7 @@ export function {{.HookName}}(options: UseQueryOptions<{{.RequestType}}>): UseQu
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}(options.params);
+            const result = await client.{{.MethodName}}(...options.params);
             setData(result);
         } catch (err) {
             setError(err as Error);
@@ -208,17 +198,17 @@ export function {{.HookName}}(options: UseQueryOptions<{{.RequestType}}>): UseQu
 }
 
 // Mutation hook for {{.Name}}
-export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<{{.RequestType}}, {{.ResponseType}}> {
+export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[{{paramDecl .Params}}], {{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
     const [error, setError] = useState<Error | null>(null);
     const [isLoading, setIsLoading] = useState(false);
 
-    const mutate = useCallback(async (params: {{.RequestType}}): Promise<{{.ResponseType}}> => {
+    const mutate = useCallback(async ({{paramDecl .Params}}): Promise<{{.ResponseType}}> => {
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}(params, {
+            const result = await client.{{.MethodName}}({{paramNames .Params}}, {
                 onProgress: options?.onProgress,
             });
             setData(result);

--- a/templates/client-handler.ts.tmpl
+++ b/templates/client-handler.ts.tmpl
@@ -25,11 +25,7 @@ export interface {{.Name}} {
 declare module './client' {
     interface ApiClient {
 {{- range .Methods}}
-{{- if .NoRequest}}
-        {{.MethodName}}(options?: RequestOptions): Promise<{{.ResponseType}}>;
-{{- else}}
-        {{.MethodName}}(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}>;
-{{- end}}
+        {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}>;
 {{- end}}
 {{- range .PushEvents}}
         {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void;
@@ -38,15 +34,9 @@ declare module './client' {
 }
 
 {{range .Methods -}}
-{{- if .NoRequest}}
-ApiClient.prototype.{{.MethodName}} = function(options?: RequestOptions): Promise<{{.ResponseType}}> {
-    return this.request<{{.ResponseType}}>('{{.Name}}', {}, options);
+ApiClient.prototype.{{.MethodName}} = function({{paramNames .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
+    return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
 };
-{{- else}}
-ApiClient.prototype.{{.MethodName}} = function(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
-    return this.request<{{.ResponseType}}>('{{.Name}}', req, options);
-};
-{{- end}}
 
 {{end -}}
 {{range .PushEvents -}}

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -426,15 +426,9 @@ export class ApiClient {
         };
     }
 {{range .Methods}}
-{{- if .NoRequest}}
-    {{.MethodName}}(options?: RequestOptions): Promise<{{.ResponseType}}> {
-        return this.request<{{.ResponseType}}>('{{.Name}}', {}, options);
+    {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
+        return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
     }
-{{- else}}
-    {{.MethodName}}(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
-        return this.request<{{.ResponseType}}>('{{.Name}}', req, options);
-    }
-{{- end}}
 {{end}}
 {{- range .PushEvents}}
     {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void {
@@ -447,8 +441,8 @@ export class ApiClient {
 
 {{template "react-hook-types" .}}
 {{range .Methods}}
-{{- if .NoRequest}}
-// Hook for {{.Name}}
+{{- if not (hasParams .Params)}}
+// Query hook for {{.Name}}
 export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: number }): UseQueryResult<{{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
@@ -501,7 +495,7 @@ export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: n
 }
 
 // Mutation hook for {{.Name}}
-export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<void, {{.ResponseType}}> {
+export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[], {{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
     const [error, setError] = useState<Error | null>(null);
@@ -533,28 +527,29 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
     return { mutate, data, error, isLoading, reset };
 }
 {{- else}}
-// Hook for {{.Name}}
-export function {{.HookName}}(options: UseQueryOptions<{{.RequestType}}>): UseQueryResult<{{.ResponseType}}> {
+// Query hook for {{.Name}}
+export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>): UseQueryResult<{{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
     const [error, setError] = useState<Error | null>(null);
     const [isLoading, setIsLoading] = useState(false);
-    const paramsRef = useRef(options.params);
-    paramsRef.current = options.params;
+
+    // Serialize params to detect changes
+    const paramsKey = JSON.stringify(options.params);
 
     const fetch = useCallback(async () => {
         if (options.enabled === false) return;
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}(paramsRef.current);
+            const result = await client.{{.MethodName}}(...options.params);
             setData(result);
         } catch (err) {
             setError(err as Error);
         } finally {
             setIsLoading(false);
         }
-    }, [client, options.enabled]);
+    }, [client, options.enabled, paramsKey]);
 
     useEffect(() => {
         fetch();
@@ -588,17 +583,17 @@ export function {{.HookName}}(options: UseQueryOptions<{{.RequestType}}>): UseQu
 }
 
 // Mutation hook for {{.Name}}
-export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<{{.RequestType}}, {{.ResponseType}}> {
+export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[{{paramDecl .Params}}], {{.ResponseType}}> {
     const client = useApiClient();
     const [data, setData] = useState<{{.ResponseType}} | null>(null);
     const [error, setError] = useState<Error | null>(null);
     const [isLoading, setIsLoading] = useState(false);
 
-    const mutate = useCallback(async (params: {{.RequestType}}): Promise<{{.ResponseType}}> => {
+    const mutate = useCallback(async ({{paramDecl .Params}}): Promise<{{.ResponseType}}> => {
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}(params, {
+            const result = await client.{{.MethodName}}({{paramNames .Params}}, {
                 onProgress: options?.onProgress,
             });
             setData(result);

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -414,15 +414,9 @@ export class ApiClient {
         }
     }
 {{range .Methods}}
-{{- if .NoRequest}}
-    {{.MethodName}}(options?: RequestOptions): Promise<{{.ResponseType}}> {
-        return this.request<{{.ResponseType}}>('{{.Name}}', {}, options);
+    {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
+        return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
     }
-{{- else}}
-    {{.MethodName}}(req: {{.RequestType}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
-        return this.request<{{.ResponseType}}>('{{.Name}}', req, options);
-    }
-{{- end}}
 {{end}}
 {{- range .PushEvents}}
     {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void {


### PR DESCRIPTION
## Summary

- Handlers can now accept any number of parameters of any type (primitives, structs, slices, maps, variadic), not just a single `*RequestStruct`
- Wire format changed from JSON object `"params": {...}` to positional JSON array `"params": [...]`
- Parameter names are auto-extracted from Go source via AST parsing (using `runtime.FuncForPC` to locate source files), falling back to `arg0`, `arg1`, etc.
- Updated all 4 TypeScript templates (vanilla, react, split handler variants) and the `UseMutationResult` interface to use spread params

## Test plan

- [x] All 79 Go tests pass (`go test ./...`)
- [x] TypeScript clients regenerated for vanilla and react examples
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] README updated with new handler signatures and wire format

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>