### PR TITLE
Namespace wire protocol and export standalone functions

### DIFF
--- a/e2e/tests/auth.test.ts
+++ b/e2e/tests/auth.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { wsUrl } from './helpers';
 import { ApiClient, ApiError } from '../api/client';
-import '../api/public-handlers';
-import '../api/protected-handlers';
+import { login } from '../api/public-handlers';
+import { getProfile, sendMessage, onDirectMessageEvent } from '../api/protected-handlers';
 
 describe('Auth Flow (WebSocket)', () => {
     let client: ApiClient;
@@ -17,7 +17,7 @@ describe('Auth Flow (WebSocket)', () => {
     });
 
     test('login returns token and username', async () => {
-        const res = await client.login({ username: 'testuser', password: 'pass' });
+        const res = await login(client, { username: 'testuser', password: 'pass' });
         expect(res.token).toBeDefined();
         expect(res.token.length).toBeGreaterThan(0);
         expect(res.username).toBe('testuser');
@@ -25,17 +25,17 @@ describe('Auth Flow (WebSocket)', () => {
     });
 
     test('getProfile after login returns profile', async () => {
-        const loginRes = await client.login({ username: 'profileuser', password: 'pass' });
+        const loginRes = await login(client, { username: 'profileuser', password: 'pass' });
 
         // After login, the connection is authenticated — no token needed in params
-        const profile = await client.getProfile();
+        const profile = await getProfile(client);
         expect(profile.username).toBe('profileuser');
         expect(profile.user_id).toBe(loginRes.user_id);
     });
 
     test('getProfile without login throws Unauthorized', async () => {
         try {
-            await client.getProfile();
+            await getProfile(client);
             expect.fail('Should have thrown');
         } catch (err) {
             expect(err).toBeInstanceOf(ApiError);
@@ -45,23 +45,23 @@ describe('Auth Flow (WebSocket)', () => {
 
     test('sendMessage delivers DirectMessage push to recipient', async () => {
         // Client 1: sender
-        const senderLogin = await client.login({ username: 'sender', password: 'pass' });
+        const senderLogin = await login(client, { username: 'sender', password: 'pass' });
 
         // Client 2: recipient
         const client2 = new ApiClient(wsUrl(), { reconnect: false, heartbeatInterval: 0 });
         await client2.connect();
 
         try {
-            const recipientLogin = await client2.login({ username: 'recipient', password: 'pass' });
+            const recipientLogin = await login(client2, { username: 'recipient', password: 'pass' });
 
             const received = new Promise<{ from_user_id: string; from_user: string; message: string }>((resolve) => {
-                client2.onDirectMessageEvent((data) => {
+                onDirectMessageEvent(client2, (data) => {
                     resolve(data);
                 });
             });
 
             // After login, connection is authenticated — send message directly
-            await client.sendMessage({
+            await sendMessage(client, {
                 to_user_id: recipientLogin.user_id,
                 message: 'Hello from sender',
             });

--- a/e2e/tests/ws.test.ts
+++ b/e2e/tests/ws.test.ts
@@ -1,8 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { wsUrl } from './helpers';
 import { ApiClient, ApiError } from '../api/client';
-import { TaskStatus } from '../api/public-handlers';
-import '../api/protected-handlers';
+import { TaskStatus, createUser, getUser, listUsers, getTask, processBatch, sendNotification, onUserCreatedEvent, onSystemNotificationEvent } from '../api/public-handlers';
 
 describe('WebSocket Transport', () => {
     let client: ApiClient;
@@ -17,29 +16,29 @@ describe('WebSocket Transport', () => {
     });
 
     test('createUser returns id, name, email', async () => {
-        const res = await client.createUser({ name: 'Alice', email: 'alice@test.com' });
+        const res = await createUser(client, { name: 'Alice', email: 'alice@test.com' });
         expect(res.id).toBeDefined();
         expect(res.name).toBe('Alice');
         expect(res.email).toBe('alice@test.com');
     });
 
     test('getUser returns created user', async () => {
-        const created = await client.createUser({ name: 'Bob', email: 'bob@test.com' });
-        const user = await client.getUser({ id: created.id });
+        const created = await createUser(client, { name: 'Bob', email: 'bob@test.com' });
+        const user = await getUser(client, { id: created.id });
         expect(user.id).toBe(created.id);
         expect(user.name).toBe('Bob');
         expect(user.email).toBe('bob@test.com');
     });
 
     test('listUsers returns array', async () => {
-        await client.createUser({ name: 'Carol', email: 'carol@test.com' });
-        const res = await client.listUsers();
+        await createUser(client, { name: 'Carol', email: 'carol@test.com' });
+        const res = await listUsers(client);
         expect(Array.isArray(res.users)).toBe(true);
         expect(res.users.length).toBeGreaterThanOrEqual(1);
     });
 
     test('getTask returns enum status field', async () => {
-        const task = await client.getTask({ id: 'task-1' });
+        const task = await getTask(client, { id: 'task-1' });
         expect(task.id).toBe('task-1');
         expect(task.name).toBe('Example Task');
         expect(task.status).toBe(TaskStatus.Running);
@@ -47,7 +46,8 @@ describe('WebSocket Transport', () => {
 
     test('processBatch reports progress callbacks', async () => {
         const progressUpdates: { current: number; total: number; message: string }[] = [];
-        const res = await client.processBatch(
+        const res = await processBatch(
+            client,
             { items: ['a', 'b', 'c'], delay: 50 },
             {
                 onProgress: (current, total, message) => {
@@ -64,7 +64,8 @@ describe('WebSocket Transport', () => {
 
     test('processBatch abort cancels request', async () => {
         const controller = new AbortController();
-        const promise = client.processBatch(
+        const promise = processBatch(
+            client,
             { items: ['a', 'b', 'c', 'd', 'e'], delay: 200 },
             { signal: controller.signal },
         );
@@ -76,12 +77,12 @@ describe('WebSocket Transport', () => {
 
     test('sendNotification triggers push event to same client', async () => {
         const received = new Promise<{ message: string; level: string }>((resolve) => {
-            client.onSystemNotificationEvent((data) => {
+            onSystemNotificationEvent(client, (data) => {
                 resolve(data);
             });
         });
 
-        await client.sendNotification({ message: 'hello', level: 'info' });
+        await sendNotification(client, { message: 'hello', level: 'info' });
 
         const event = await received;
         expect(event.message).toBe('hello');
@@ -94,12 +95,12 @@ describe('WebSocket Transport', () => {
 
         try {
             const received = new Promise<{ id: string; name: string; email: string }>((resolve) => {
-                client2.onUserCreatedEvent((data) => {
+                onUserCreatedEvent(client2, (data) => {
                     resolve(data);
                 });
             });
 
-            const created = await client.createUser({ name: 'Dave', email: 'dave@test.com' });
+            const created = await createUser(client, { name: 'Dave', email: 'dave@test.com' });
 
             const event = await received;
             expect(event.id).toBe(created.id);
@@ -112,7 +113,7 @@ describe('WebSocket Transport', () => {
 
     test('createUser with empty name throws ApiError with isInvalidParams', async () => {
         try {
-            await client.createUser({ name: '', email: 'bad@test.com' });
+            await createUser(client, { name: '', email: 'bad@test.com' });
             expect.fail('Should have thrown');
         } catch (err) {
             expect(err).toBeInstanceOf(ApiError);

--- a/generate.go
+++ b/generate.go
@@ -142,9 +142,10 @@ type paramData struct {
 }
 
 type methodData struct {
-	Name         string
-	MethodName   string
-	HookName     string
+	Name         string // short method name (e.g., "CreateUser")
+	WireMethod   string // qualified wire name (e.g., "PublicHandlers.CreateUser")
+	MethodName   string // camelCase function name (e.g., "createUser")
+	HookName     string // React hook name (e.g., "useCreateUser")
 	ResponseType string
 	IsVoid       bool
 	Params       []paramData
@@ -303,17 +304,19 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 	}
 	sort.Strings(names)
 
-	for _, name := range names {
-		info := handlers[name]
+	for _, qualifiedName := range names {
+		info := handlers[qualifiedName]
+		shortName := info.Name
 		isVoid := info.ResponseType == voidResponseType
 		respType := info.ResponseType.Name()
 		if isVoid {
 			respType = "void"
 		}
 		data.Methods = append(data.Methods, methodData{
-			Name:         name,
-			MethodName:   toLowerCamel(name),
-			HookName:     "use" + name,
+			Name:         shortName,
+			WireMethod:   qualifiedName,
+			MethodName:   toLowerCamel(shortName),
+			HookName:     "use" + shortName,
 			ResponseType: respType,
 			IsVoid:       isVoid,
 			Params:       g.buildParamData(info, paramNames),
@@ -415,6 +418,7 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, paramNames map[string
 		}
 		data.Methods = append(data.Methods, methodData{
 			Name:         name,
+			WireMethod:   group.Name + "." + name,
 			MethodName:   toLowerCamel(name),
 			HookName:     "use" + name,
 			ResponseType: respType,

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -106,7 +106,7 @@ func TestMiddlewareChainExecutionOrder(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hello"}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {
@@ -163,7 +163,7 @@ func TestMiddlewareContextModification(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hello"}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {
@@ -206,7 +206,7 @@ func TestMiddlewareRequestRejection(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hello"}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {
@@ -272,7 +272,7 @@ func TestPerHandlerMiddleware(t *testing.T) {
 	echoReq := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "Echo",
+		"method": "PublicTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hello"}},
 	}
 	if err := ws.WriteJSON(echoReq); err != nil {
@@ -292,7 +292,7 @@ func TestPerHandlerMiddleware(t *testing.T) {
 	secretReq := map[string]any{
 		"type":   "request",
 		"id":     "2",
-		"method": "GetSecret",
+		"method": "ProtectedTestHandler.GetSecret",
 		"params": []any{map[string]any{}},
 	}
 	if err := ws.WriteJSON(secretReq); err != nil {
@@ -324,14 +324,14 @@ func TestGetMiddleware(t *testing.T) {
 	registry.Register(&ProtectedTestHandler{}, testMiddleware) // With middleware
 
 	// Check middleware retrieval
-	publicMW := registry.GetMiddleware("Echo")
+	publicMW := registry.GetMiddleware("PublicTestHandler.Echo")
 	if len(publicMW) != 0 {
-		t.Errorf("expected no middleware for Echo, got %d", len(publicMW))
+		t.Errorf("expected no middleware for PublicTestHandler.Echo, got %d", len(publicMW))
 	}
 
-	protectedMW := registry.GetMiddleware("GetSecret")
+	protectedMW := registry.GetMiddleware("ProtectedTestHandler.GetSecret")
 	if len(protectedMW) != 1 {
-		t.Errorf("expected 1 middleware for GetSecret, got %d", len(protectedMW))
+		t.Errorf("expected 1 middleware for ProtectedTestHandler.GetSecret, got %d", len(protectedMW))
 	}
 }
 
@@ -380,7 +380,7 @@ func TestServerAndHandlerMiddlewareCombined(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "GetSecret",
+		"method": "ProtectedTestHandler.GetSecret",
 		"params": []any{map[string]any{}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {
@@ -459,7 +459,7 @@ func TestUserTargetedPush(t *testing.T) {
 		msg := map[string]any{
 			"type":   "request",
 			"id":     reqID,
-			"method": "Echo",
+			"method": "MiddlewareTestHandler.Echo",
 			"params": []any{map[string]string{"message": "identify", "user_id": userID}},
 		}
 		ws.WriteJSON(msg)
@@ -525,7 +525,7 @@ func TestRequestFromContext(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "test-123",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hello"}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {
@@ -543,8 +543,8 @@ func TestRequestFromContext(t *testing.T) {
 	if capturedReq.ID != "test-123" {
 		t.Errorf("expected ID=test-123, got %s", capturedReq.ID)
 	}
-	if capturedReq.Method != "Echo" {
-		t.Errorf("expected Method=Echo, got %s", capturedReq.Method)
+	if capturedReq.Method != "MiddlewareTestHandler.Echo" {
+		t.Errorf("expected Method=MiddlewareTestHandler.Echo, got %s", capturedReq.Method)
 	}
 }
 
@@ -582,7 +582,7 @@ func TestSetUserIDDisassociatesOldUser(t *testing.T) {
 	msg1 := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hi", "user_id": "user1"}},
 	}
 	ws.WriteJSON(msg1)
@@ -601,7 +601,7 @@ func TestSetUserIDDisassociatesOldUser(t *testing.T) {
 	msg2 := map[string]any{
 		"type":   "request",
 		"id":     "2",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hi", "user_id": "user2"}},
 	}
 	ws.WriteJSON(msg2)
@@ -755,7 +755,7 @@ func TestRegisteredErrorSentToClient(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "TriggerNotFound",
+		"method": "ErrorTestHandler.TriggerNotFound",
 		"params": []any{map[string]any{}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {
@@ -778,7 +778,7 @@ func TestRegisteredErrorSentToClient(t *testing.T) {
 	reqMsg2 := map[string]any{
 		"type":   "request",
 		"id":     "2",
-		"method": "TriggerWrapped",
+		"method": "ErrorTestHandler.TriggerWrapped",
 		"params": []any{map[string]any{}},
 	}
 	if err := ws.WriteJSON(reqMsg2); err != nil {
@@ -814,7 +814,7 @@ func TestMiddlewareWithNoMiddleware(t *testing.T) {
 	reqMsg := map[string]any{
 		"type":   "request",
 		"id":     "1",
-		"method": "Echo",
+		"method": "MiddlewareTestHandler.Echo",
 		"params": []any{map[string]string{"message": "hello"}},
 	}
 	if err := ws.WriteJSON(reqMsg); err != nil {

--- a/protocol.go
+++ b/protocol.go
@@ -25,6 +25,7 @@ type ConnectedMessage struct {
 }
 
 // IncomingMessage represents a message from client to server.
+// Method uses qualified "Group.Method" format (e.g., "PublicHandlers.CreateUser").
 type IncomingMessage struct {
 	Type   MessageType    `json:"type"`
 	ID     string         `json:"id,omitempty"`

--- a/server.go
+++ b/server.go
@@ -164,7 +164,7 @@ func (s *Server) buildHandler(info *HandlerInfo) Handler {
 	handler := final
 
 	// Apply handler-specific middleware (inner layer)
-	handlerMW := s.registry.GetMiddleware(info.Name)
+	handlerMW := s.registry.GetMiddleware(info.StructName + "." + info.Name)
 	for i := len(handlerMW) - 1; i >= 0; i-- {
 		handler = handlerMW[i](handler)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -118,7 +118,7 @@ func TestServerEcho(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "Echo",
+		Method: "IntegrationHandlers.Echo",
 		Params: jsontext.Value(`[{"message":"hello"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -183,7 +183,7 @@ func TestServerProgress(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "Slow",
+		Method: "IntegrationHandlers.Slow",
 		Params: jsontext.Value(`[{"steps":3}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -225,7 +225,7 @@ func TestServerCancel(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "Slow",
+		Method: "IntegrationHandlers.Slow",
 		Params: jsontext.Value(`[{"steps":100}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -277,7 +277,7 @@ func TestServerPush(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "TriggerPush",
+		Method: "IntegrationHandlers.TriggerPush",
 		Params: jsontext.Value(`[{"message":"pushed"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -680,7 +680,7 @@ func TestServerVoidResponse(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "DeleteItem",
+		Method: "VoidTestHandlers.DeleteItem",
 		Params: jsontext.Value(`[{"id":"item_1"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -735,7 +735,7 @@ func TestServerNoRequestHandler(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "GetStatus",
+		Method: "NoRequestTestHandlers.GetStatus",
 	}
 	if err := ws.WriteJSON(req); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -762,7 +762,7 @@ func TestServerNoRequestHandler(t *testing.T) {
 	req2 := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "2",
-		Method: "Ping",
+		Method: "NoRequestTestHandlers.Ping",
 	}
 	if err := ws.WriteJSON(req2); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -796,7 +796,7 @@ func TestServerNoRequestHandlerWithParams(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "GetStatus",
+		Method: "NoRequestTestHandlers.GetStatus",
 		Params: jsontext.Value(`["bar"]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -873,7 +873,7 @@ func TestStopGraceful(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "Block",
+		Method: "BlockingHandlers.Block",
 		Params: jsontext.Value(`[{"token":"test"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {
@@ -933,7 +933,7 @@ func TestStopTimeout(t *testing.T) {
 	req := IncomingMessage{
 		Type:   TypeRequest,
 		ID:     "1",
-		Method: "Stubborn",
+		Method: "StubbornHandlers.Stubborn",
 		Params: jsontext.Value(`[{"token":"test"}]`),
 	}
 	if err := ws.WriteJSON(req); err != nil {

--- a/sse_handler_test.go
+++ b/sse_handler_test.go
@@ -144,7 +144,7 @@ func TestSSEEcho(t *testing.T) {
 	// Wait for registration
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "Echo", `[{"message":"hello"}]`)
+	rpcResp := postRPC(t, ts, connID, "1", "IntegrationHandlers.Echo", `[{"message":"hello"}]`)
 	if rpcResp.StatusCode != http.StatusAccepted {
 		t.Fatalf("Expected 202, got %d", rpcResp.StatusCode)
 	}
@@ -209,7 +209,7 @@ func TestSSEProgress(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "Slow", `[{"steps":3}]`)
+	rpcResp := postRPC(t, ts, connID, "1", "IntegrationHandlers.Slow", `[{"steps":3}]`)
 	rpcResp.Body.Close()
 
 	progressCount := 0
@@ -242,7 +242,7 @@ func TestSSECancel(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "Slow", `[{"steps":100}]`)
+	rpcResp := postRPC(t, ts, connID, "1", "IntegrationHandlers.Slow", `[{"steps":100}]`)
 	rpcResp.Body.Close()
 
 	time.Sleep(50 * time.Millisecond)
@@ -282,7 +282,7 @@ func TestSSEPush(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	rpcResp := postRPC(t, ts, connID, "1", "TriggerPush", `[{"message":"pushed"}]`)
+	rpcResp := postRPC(t, ts, connID, "1", "IntegrationHandlers.TriggerPush", `[{"message":"pushed"}]`)
 	rpcResp.Body.Close()
 
 	gotPush := false
@@ -521,7 +521,7 @@ func TestSSEInvalidConnectionID(t *testing.T) {
 	defer ts.Close()
 
 	// POST /rpc with invalid connection ID
-	body := `{"connectionId":"invalid","id":"1","method":"Echo","params":[{"message":"hello"}]}`
+	body := `{"connectionId":"invalid","id":"1","method":"IntegrationHandlers.Echo","params":[{"message":"hello"}]}`
 	resp, err := http.Post(ts.URL+"/sse/rpc", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST failed: %v", err)

--- a/templates/client-handler-react.ts.tmpl
+++ b/templates/client-handler-react.ts.tmpl
@@ -30,28 +30,16 @@ export interface {{.Name}} {
 }
 
 {{end -}}
-// Extend ApiClient with {{.StructName}} methods
-declare module './client' {
-    interface ApiClient {
-{{- range .Methods}}
-        {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}>;
-{{- end}}
-{{- range .PushEvents}}
-        {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void;
-{{- end}}
-    }
-}
-
 {{range .Methods -}}
-ApiClient.prototype.{{.MethodName}} = function({{paramNames .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
-    return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
-};
+export function {{.MethodName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
+    return client.request<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], options);
+}
 
 {{end -}}
 {{range .PushEvents -}}
-ApiClient.prototype.{{.HandlerName}} = function(handler: PushHandler<{{.DataType}}>): () => void {
-    return this.onPush<{{.DataType}}>('{{.Name}}', handler);
-};
+export function {{.HandlerName}}(client: ApiClient, handler: PushHandler<{{.DataType}}>): () => void {
+    return client.onPush<{{.DataType}}>('{{.Name}}', handler);
+}
 
 {{end -}}
 // React Hooks for {{.StructName}}
@@ -69,7 +57,7 @@ export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: n
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}();
+            const result = await {{.MethodName}}(client);
             setData(result);
         } catch (err) {
             setError(err as Error);
@@ -120,7 +108,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}({
+            const result = await {{.MethodName}}(client, {
                 onProgress: options?.onProgress,
             });
             setData(result);
@@ -157,7 +145,7 @@ export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>)
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}(...options.params);
+            const result = await {{.MethodName}}(client, ...options.params);
             setData(result);
         } catch (err) {
             setError(err as Error);
@@ -208,7 +196,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}({{paramNames .Params}}, {
+            const result = await {{.MethodName}}(client, {{paramNames .Params}}, {
                 onProgress: options?.onProgress,
             });
             setData(result);
@@ -240,7 +228,7 @@ export function {{.HookName}}(options?: { maxEvents?: number }): UsePushResult<{
     const maxEvents = options?.maxEvents ?? 100;
 
     useEffect(() => {
-        return client.{{.HandlerName}}((data) => {
+        return {{.HandlerName}}(client, (data) => {
             setLastEvent(data);
             setEvents((prev) => {
                 const next = [...prev, data];

--- a/templates/client-handler.ts.tmpl
+++ b/templates/client-handler.ts.tmpl
@@ -21,27 +21,15 @@ export interface {{.Name}} {
 }
 
 {{end -}}
-// Extend ApiClient with {{.StructName}} methods
-declare module './client' {
-    interface ApiClient {
-{{- range .Methods}}
-        {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}>;
-{{- end}}
-{{- range .PushEvents}}
-        {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void;
-{{- end}}
-    }
-}
-
 {{range .Methods -}}
-ApiClient.prototype.{{.MethodName}} = function({{paramNames .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
-    return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
-};
+export function {{.MethodName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
+    return client.request<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], options);
+}
 
 {{end -}}
 {{range .PushEvents -}}
-ApiClient.prototype.{{.HandlerName}} = function(handler: PushHandler<{{.DataType}}>): () => void {
-    return this.onPush<{{.DataType}}>('{{.Name}}', handler);
-};
+export function {{.HandlerName}}(client: ApiClient, handler: PushHandler<{{.DataType}}>): () => void {
+    return client.onPush<{{.DataType}}>('{{.Name}}', handler);
+}
 
 {{end -}}

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -348,7 +348,7 @@ export class ApiClient {
         }
     }
 
-    private request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
+    request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
             if (this.transport.isConnected()) {
                 this.sendRequest(method, params, options, resolve, reject);
@@ -425,21 +425,21 @@ export class ApiClient {
             this.pushHandlers.get(event)?.delete(handler);
         };
     }
-{{range .Methods}}
-    {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
-        return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
-    }
-{{end}}
-{{- range .PushEvents}}
-    {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void {
-        return this.onPush<{{.DataType}}>('{{.Name}}', handler);
-    }
-{{end -}}
 }
 
 {{template "react-context" .}}
 
 {{template "react-hook-types" .}}
+{{range .Methods}}
+export function {{.MethodName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
+    return client.request<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], options);
+}
+{{end}}
+{{- range .PushEvents}}
+export function {{.HandlerName}}(client: ApiClient, handler: PushHandler<{{.DataType}}>): () => void {
+    return client.onPush<{{.DataType}}>('{{.Name}}', handler);
+}
+{{end}}
 {{range .Methods}}
 {{- if not (hasParams .Params)}}
 // Query hook for {{.Name}}
@@ -454,7 +454,7 @@ export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: n
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}();
+            const result = await {{.MethodName}}(client);
             setData(result);
         } catch (err) {
             setError(err as Error);
@@ -505,7 +505,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}({
+            const result = await {{.MethodName}}(client, {
                 onProgress: options?.onProgress,
             });
             setData(result);
@@ -542,7 +542,7 @@ export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>)
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}(...options.params);
+            const result = await {{.MethodName}}(client, ...options.params);
             setData(result);
         } catch (err) {
             setError(err as Error);
@@ -593,7 +593,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         setIsLoading(true);
         setError(null);
         try {
-            const result = await client.{{.MethodName}}({{paramNames .Params}}, {
+            const result = await {{.MethodName}}(client, {{paramNames .Params}}, {
                 onProgress: options?.onProgress,
             });
             setData(result);
@@ -625,7 +625,7 @@ export function {{.HookName}}(options?: { maxEvents?: number }): UsePushResult<{
     const maxEvents = options?.maxEvents ?? 100;
 
     useEffect(() => {
-        return client.{{.HandlerName}}((data) => {
+        return {{.HandlerName}}(client, (data) => {
             setLastEvent(data);
             setEvents((prev) => {
                 const next = [...prev, data];

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -346,7 +346,7 @@ export class ApiClient {
         }
     }
 
-    private request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
+    request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
             if (this.transport.isConnected()) {
                 this.sendRequest(method, params, options, resolve, reject);
@@ -413,20 +413,23 @@ export class ApiClient {
             entry.reject(error);
         }
     }
-{{range .Methods}}
-    {{.MethodName}}({{paramDecl .Params}}{{if hasParams .Params}}, {{end}}options?: RequestOptions): Promise<{{.ResponseType}}> {
-        return this.request<{{.ResponseType}}>('{{.Name}}', [{{paramArray .Params}}], options);
-    }
-{{end}}
-{{- range .PushEvents}}
-    {{.HandlerName}}(handler: PushHandler<{{.DataType}}>): () => void {
-        if (!this.pushHandlers.has('{{.Name}}')) {
-            this.pushHandlers.set('{{.Name}}', new Set());
+    onPush<T>(event: string, handler: PushHandler<T>): () => void {
+        if (!this.pushHandlers.has(event)) {
+            this.pushHandlers.set(event, new Set());
         }
-        this.pushHandlers.get('{{.Name}}')!.add(handler);
+        this.pushHandlers.get(event)!.add(handler);
         return () => {
-            this.pushHandlers.get('{{.Name}}')?.delete(handler);
+            this.pushHandlers.get(event)?.delete(handler);
         };
     }
-{{end -}}
 }
+{{range .Methods}}
+export function {{.MethodName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, options?: RequestOptions): Promise<{{.ResponseType}}> {
+    return client.request<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], options);
+}
+{{end}}
+{{- range .PushEvents}}
+export function {{.HandlerName}}(client: ApiClient, handler: PushHandler<{{.DataType}}>): () => void {
+    return client.onPush<{{.DataType}}>('{{.Name}}', handler);
+}
+{{end -}}


### PR DESCRIPTION
## Summary

- **Namespaced wire protocol**: Method names are now qualified as `"HandlerStruct.MethodName"` (e.g., `"PublicHandlers.CreateUser"`) on the wire, allowing multiple handler groups to have methods with the same name
- **Standalone exported functions**: Generated TypeScript files export standalone functions with `client: ApiClient` as the first argument, replacing module augmentation. This enables tree-shaking and idiomatic namespace imports (`import * as users from './api/user-handlers'`)
- **Duplicate detection**: `Register()` now panics if a handler struct is registered twice or if two handlers produce the same qualified wire method name

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] React example TypeScript compiles (`npx tsc --noEmit`)
- [x] E2E test files updated to use standalone function imports
- [x] Example app code updated (vanilla `app.ts`)
- [x] README updated with new API patterns
- [ ] CI: Go tests, TypeScript compilation, E2E tests

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)