### PR TITLE
Add extensible metadata to SharedTask

### DIFF
--- a/example/vanilla/api/handlers.go
+++ b/example/vanilla/api/handlers.go
@@ -273,6 +273,12 @@ func (h *PublicHandlers) StartSharedWork(ctx context.Context, req *StartSharedWo
 		return nil, aprot.ErrInternal(nil)
 	}
 
+	// Attach metadata visible to all clients
+	conn := aprot.Connection(ctx)
+	if conn != nil {
+		task.SetMeta(TaskMeta{UserName: conn.UserID()})
+	}
+
 	task.Go(func(ctx context.Context) {
 		for i, step := range req.Steps {
 			select {

--- a/example/vanilla/api/registry.go
+++ b/example/vanilla/api/registry.go
@@ -25,8 +25,9 @@ func NewRegistry(state *SharedState, authMiddleware aprot.Middleware) *aprot.Reg
 	registry.RegisterPushEventFor(publicHandlers, SystemNotificationEvent{})
 	registry.RegisterPushEventFor(protectedHandlers, DirectMessageEvent{})
 
-	// Enable shared tasks (registers TaskStateEvent, TaskOutputEvent, CancelTask handler)
-	registry.EnableTasks()
+	// Enable shared tasks with typed metadata
+	// (registers TaskStateEvent, TaskOutputEvent, CancelTask handler)
+	registry.EnableTasksWithMeta(TaskMeta{})
 
 	return registry
 }

--- a/example/vanilla/api/types.go
+++ b/example/vanilla/api/types.go
@@ -119,6 +119,11 @@ type ProcessWithSubTasksResponse struct {
 
 // SharedTask demo types
 
+type TaskMeta struct {
+	UserName string `json:"userName,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
 type StartSharedWorkRequest struct {
 	Title string   `json:"title"`
 	Steps []string `json:"steps"`

--- a/task.go
+++ b/task.go
@@ -19,12 +19,13 @@ const (
 
 // TaskNode is the JSON-serializable snapshot of a task sent to the client.
 type TaskNode struct {
-	ID       string      `json:"id"`
-	Title    string      `json:"title"`
-	Status   TaskNodeStatus  `json:"status"`
-	Current  int         `json:"current,omitempty"`
-	Total    int         `json:"total,omitempty"`
-	Children []*TaskNode `json:"children,omitempty"`
+	ID       string         `json:"id"`
+	Title    string         `json:"title"`
+	Status   TaskNodeStatus `json:"status"`
+	Current  int            `json:"current,omitempty"`
+	Total    int            `json:"total,omitempty"`
+	Meta     any            `json:"meta,omitempty"`
+	Children []*TaskNode    `json:"children,omitempty"`
 }
 
 // taskTree is the mutable state for a request's task hierarchy.

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -43,12 +43,23 @@ export class ApiError extends Error {
 {{end}}
 
 {{define "types"}}
+{{- range .TaskMetaInterfaces}}
+export interface {{.Name}} {
+{{- range .Fields}}
+    {{.Name}}{{if .Optional}}?{{end}}: {{.Type}};
+{{- end}}
+}
+
+{{end -}}
 export interface TaskNode {
     id: string;
     title: string;
     status: 'running' | 'completed' | 'failed';
     current?: number;
     total?: number;
+{{- if .TaskMetaType}}
+    meta?: {{.TaskMetaType}};
+{{- end}}
     children?: TaskNode[];
 }
 
@@ -67,6 +78,9 @@ export interface SharedTaskState {
     status: 'running' | 'completed' | 'failed';
     current?: number;
     total?: number;
+{{- if .TaskMetaType}}
+    meta?: {{.TaskMetaType}};
+{{- end}}
     children?: TaskNode[];
 }
 


### PR DESCRIPTION
## Summary

- Add `EnableTasksWithMeta(meta)` to register a typed metadata struct for shared tasks
- Add `SetMeta(v)` on `SharedTask` and `SharedTaskSub` to attach metadata broadcast to all clients
- Add `SubTask(title)` on `SharedTaskSub` for creating nested children
- Generate typed TypeScript `meta?:` field on `SharedTaskState` and `TaskNode` when meta is registered
- Backward compatible: `EnableTasks()` without meta continues to work (no `meta` field in generated TS)

## Test plan

- [x] `go test ./...` passes (7 new tests)
- [x] Vanilla example regenerated with `EnableTasksWithMeta(TaskMeta{})`
- [x] React example regenerated (uses `EnableTasks()` without meta — backward compat)
- [x] React TypeScript compiles: `cd example/react/client && npx tsc --noEmit`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)