### PR TITLE
Remove RegisterPushEvent due to nondeterministic map iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ func main() {
 
     registry := aprot.NewRegistry()
     registry.Register(handlers)
-    registry.RegisterPushEvent(api.UserCreatedEvent{})
+    registry.RegisterPushEventFor(handlers, api.UserCreatedEvent{})
 
     server := aprot.NewServer(registry)
     handlers.Broadcaster = server
@@ -163,9 +163,10 @@ import (
 )
 
 func main() {
+    handlers := &api.Handlers{}
     registry := aprot.NewRegistry()
-    registry.Register(&api.Handlers{})
-    registry.RegisterPushEvent(api.UserCreatedEvent{})
+    registry.Register(handlers)
+    registry.RegisterPushEventFor(handlers, api.UserCreatedEvent{})
 
     gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
         OutputDir: "../../client/src/api",

--- a/connection.go
+++ b/connection.go
@@ -104,7 +104,7 @@ func newConn(t transport, server *Server, id uint64, r *http.Request, ctx contex
 
 // Push sends a push message to this connection.
 // The event name is derived from the Go type of data, which must have been
-// registered via RegisterPushEvent or RegisterPushEventFor.
+// registered via RegisterPushEventFor.
 func (c *Conn) Push(data any) error {
 	event := c.server.registry.eventName(data)
 	return c.push(event, data)

--- a/example/react/api/registry.go
+++ b/example/react/api/registry.go
@@ -10,12 +10,13 @@ func NewRegistry() *aprot.Registry {
 	registry.RegisterEnum(TaskStatusValues())
 
 	// Register handlers
-	registry.Register(&Handlers{})
+	handlers := &Handlers{}
+	registry.Register(handlers)
 
 	// Register push events
-	registry.RegisterPushEvent(UserCreatedEvent{})
-	registry.RegisterPushEvent(UserUpdatedEvent{})
-	registry.RegisterPushEvent(SystemNotificationEvent{})
+	registry.RegisterPushEventFor(handlers, UserCreatedEvent{})
+	registry.RegisterPushEventFor(handlers, UserUpdatedEvent{})
+	registry.RegisterPushEventFor(handlers, SystemNotificationEvent{})
 
 	return registry
 }

--- a/example_test.go
+++ b/example_test.go
@@ -93,8 +93,8 @@ func Example() {
 	registry := aprot.NewRegistry()
 	handlers := &MyHandlers{}
 	registry.Register(handlers)
-	registry.RegisterPushEvent(UserUpdatedEvent{})
-	registry.RegisterPushEvent(ProcessingCompleteEvent{})
+	registry.RegisterPushEventFor(handlers, UserUpdatedEvent{})
+	registry.RegisterPushEventFor(handlers, ProcessingCompleteEvent{})
 
 	// Create server
 	server := aprot.NewServer(registry)
@@ -111,10 +111,11 @@ func Example() {
 func Example_generate() {
 	// Create registry with handlers
 	registry := aprot.NewRegistry()
-	registry.Register(&MyHandlers{})
+	myHandlers := &MyHandlers{}
+	registry.Register(myHandlers)
 
 	// Register push events on the registry
-	registry.RegisterPushEvent(UserUpdatedEvent{})
+	registry.RegisterPushEventFor(myHandlers, UserUpdatedEvent{})
 
 	// Create generator and generate TypeScript to stdout (or file)
 	gen := aprot.NewGenerator(registry)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -415,7 +415,7 @@ type NotificationData struct {
 func TestUserTargetedPush(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&MiddlewareTestHandler{})
-	registry.RegisterPushEvent(NotificationData{})
+	registry.RegisterPushEventFor(&MiddlewareTestHandler{}, NotificationData{})
 
 	server := NewServer(registry)
 

--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ import (
 
 // Broadcaster is an interface for broadcasting push events to all clients.
 // The event name is derived from the Go type of data, which must have been
-// registered via RegisterPushEvent or RegisterPushEventFor.
+// registered via RegisterPushEventFor.
 type Broadcaster interface {
 	Broadcast(data any)
 }
@@ -192,7 +192,7 @@ func (s *Server) buildHandler(info *HandlerInfo) Handler {
 
 // PushToUser sends a push message to all connections for a specific user.
 // The event name is derived from the Go type of data, which must have been
-// registered via RegisterPushEvent or RegisterPushEventFor.
+// registered via RegisterPushEventFor.
 func (s *Server) PushToUser(userID string, data any) {
 	event := s.registry.eventName(data)
 	s.mu.RLock()
@@ -286,7 +286,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Broadcast sends a push message to all connected clients.
 // The event name is derived from the Go type of data, which must have been
-// registered via RegisterPushEvent or RegisterPushEventFor.
+// registered via RegisterPushEventFor.
 func (s *Server) Broadcast(data any) {
 	event := s.registry.eventName(data)
 	s.mu.RLock()

--- a/server_test.go
+++ b/server_test.go
@@ -84,7 +84,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Server, *IntegrationHandl
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(handlers, NotificationEvent{})
 
 	server := NewServer(registry)
 	handlers.server = server

--- a/shared_task_test.go
+++ b/shared_task_test.go
@@ -14,7 +14,7 @@ import (
 func TestSharedTaskBasic(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -60,7 +60,7 @@ func TestSharedTaskBasic(t *testing.T) {
 func TestSharedTaskProgress(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -82,7 +82,7 @@ func TestSharedTaskProgress(t *testing.T) {
 func TestSharedTaskSubTask(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -119,7 +119,7 @@ func TestSharedTaskSubTask(t *testing.T) {
 func TestSharedTaskCancel(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -153,7 +153,7 @@ func TestSharedTaskCancel(t *testing.T) {
 func TestSharedTaskCancelNonExistent(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -168,7 +168,7 @@ func TestSharedTaskCancelNonExistent(t *testing.T) {
 func TestSharedTaskGo(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -211,7 +211,7 @@ func TestSharedTaskGo(t *testing.T) {
 func TestSharedTaskBatchBroadcast(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -243,7 +243,7 @@ func TestSharedTaskBatchBroadcast(t *testing.T) {
 func TestSharedTaskFail(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -267,7 +267,7 @@ func TestSharedTaskFail(t *testing.T) {
 func TestEnableTasksRegistersHandler(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	_, ok := registry.Get("taskCancelHandler.CancelTask")
@@ -294,7 +294,7 @@ func TestSharedTaskBroadcastOverWebSocket(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -342,7 +342,7 @@ func TestSharedTaskPushOnConnect(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -387,7 +387,7 @@ func TestSharedTaskPushOnConnect(t *testing.T) {
 func TestSharedTaskSetMeta(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -420,7 +420,7 @@ func TestSharedTaskSetMeta(t *testing.T) {
 func TestSharedTaskSubSetMeta(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -448,7 +448,7 @@ func TestSharedTaskSubSetMeta(t *testing.T) {
 func TestSharedTaskSubSubTask(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasks()
 
 	server := NewServer(registry)
@@ -495,7 +495,7 @@ func TestEnableTasksWithMeta(t *testing.T) {
 
 	registry := NewRegistry()
 	registry.Register(&IntegrationHandlers{})
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(&IntegrationHandlers{}, NotificationEvent{})
 	registry.EnableTasksWithMeta(TaskMeta{})
 
 	if !registry.TasksEnabled() {

--- a/sse_handler_test.go
+++ b/sse_handler_test.go
@@ -61,7 +61,7 @@ func setupSSETestServer(t *testing.T) (*httptest.Server, *Server, *sseHandler) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(handlers, NotificationEvent{})
 
 	server := NewServer(registry)
 	handlers.server = server
@@ -634,7 +634,7 @@ func TestMixedPushToUser(t *testing.T) {
 	registry := NewRegistry()
 	handlers := &IntegrationHandlers{}
 	registry.Register(handlers)
-	registry.RegisterPushEvent(NotificationEvent{})
+	registry.RegisterPushEventFor(handlers, NotificationEvent{})
 
 	server := NewServer(registry)
 	handlers.server = server


### PR DESCRIPTION
## Summary

- Remove `RegisterPushEvent()` which assigned push events to a random handler group due to Go's nondeterministic map iteration, causing events to land in different `.ts` files across codegen runs
- Make `RegisterPushEventFor()` the only API for registering push events
- `RegisterPushEventFor()` now panics when called with an unregistered handler (previously silently skipped)
- Migrate all call sites in tests, examples, and README

## Test plan

- [x] Existing tests pass (`go test ./...`)
- [x] New test: `TestPushEventDeterministicAssignment` — registers 4 handler groups, targets push event at one, generates 10 times, verifies deterministic output
- [x] New test: `TestRegisterPushEventForPanicsOnUnregisteredHandler` — verifies panic on unregistered handler
- [x] TypeScript codegen verified (`vanilla` + `react` examples regenerated, `npx tsc --noEmit` passes)

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)