### PR TITLE
Make SharedTask/SetMeta type-safe with Go generics

### DIFF
--- a/example/vanilla/api/handlers.go
+++ b/example/vanilla/api/handlers.go
@@ -268,7 +268,7 @@ func (h *PublicHandlers) StartSharedWork(ctx context.Context, req *StartSharedWo
 		delay = 50
 	}
 
-	task := aprot.ShareTask(ctx, req.Title)
+	task := aprot.ShareTask[TaskMeta](ctx, req.Title)
 	if task == nil {
 		return nil, aprot.ErrInternal(nil)
 	}

--- a/example/vanilla/api/registry.go
+++ b/example/vanilla/api/registry.go
@@ -27,7 +27,7 @@ func NewRegistry(state *SharedState, authMiddleware aprot.Middleware) *aprot.Reg
 
 	// Enable shared tasks with typed metadata
 	// (registers TaskStateEvent, TaskOutputEvent, CancelTask handler)
-	registry.EnableTasksWithMeta(TaskMeta{})
+	aprot.EnableTasksWithMeta[TaskMeta](registry)
 
 	return registry
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -1241,7 +1241,7 @@ func TestGenerateWithTaskMeta(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&TestHandlers{})
 	registry.RegisterPushEventFor(&TestHandlers{}, UserUpdatedEvent{})
-	registry.EnableTasksWithMeta(TaskMeta{})
+	EnableTasksWithMeta[TaskMeta](registry)
 
 	gen := NewGenerator(registry)
 
@@ -1282,7 +1282,7 @@ func TestGenerateWithTaskMetaMultiFile(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&TestHandlers{})
 	registry.RegisterPushEventFor(&TestHandlers{}, UserUpdatedEvent{})
-	registry.EnableTasksWithMeta(TaskMeta{})
+	EnableTasksWithMeta[TaskMeta](registry)
 
 	gen := NewGenerator(registry)
 	files, err := gen.Generate()

--- a/handler.go
+++ b/handler.go
@@ -369,19 +369,18 @@ func (r *Registry) EnableTasks() {
 // The meta type will be used in the generated TypeScript client for type-safe
 // metadata on SharedTaskState and TaskNode.
 //
+// This is a free function (not a method) because Go does not allow generic
+// methods on non-generic types.
+//
 // Example:
 //
 //	type TaskMeta struct {
 //	    UserName string `json:"userName,omitempty"`
 //	    Error    string `json:"error,omitempty"`
 //	}
-//	registry.EnableTasksWithMeta(TaskMeta{})
-func (r *Registry) EnableTasksWithMeta(meta any) {
-	t := reflect.TypeOf(meta)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	r.taskMetaType = t
+//	aprot.EnableTasksWithMeta[TaskMeta](registry)
+func EnableTasksWithMeta[M any](r *Registry) {
+	r.taskMetaType = reflect.TypeFor[M]()
 	r.EnableTasks()
 }
 


### PR DESCRIPTION
## Summary

- Introduce generic `SharedTask[M]` and `SharedTaskSub[M]` wrappers so `SetMeta(v M)` is compile-time enforced
- Rename internal `SharedTask` → `sharedTaskCore` (unexported), keeping `taskManager` non-generic
- `EnableTasksWithMeta` becomes a free function `EnableTasksWithMeta[M any](r *Registry)` using `reflect.TypeFor[M]()`
- `ShareTask` becomes `ShareTask[M any](ctx, title) *SharedTask[M]`
- Wire types (`SharedTaskState`, `TaskNode`, `TaskRef`) unchanged — no protocol breaking changes

Closes #42

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Vanilla and React examples compile
- [ ] Regenerate TypeScript clients and verify output is identical
- [ ] Verify TypeScript compiles (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)