### PR TITLE
Add SharedSubTask to bridge request-scoped and shared task systems

### DIFF
--- a/context.go
+++ b/context.go
@@ -11,6 +11,7 @@ const (
 	requestKey
 	taskTreeKey
 	taskNodeKey
+	sharedContextKey
 )
 
 // Progress returns the ProgressReporter from the context.
@@ -95,4 +96,18 @@ func withTaskTree(ctx context.Context, t *taskTree) context.Context {
 // withTaskNode returns a context with the given task node.
 func withTaskNode(ctx context.Context, n *taskNode) context.Context {
 	return context.WithValue(ctx, taskNodeKey, n)
+}
+
+// sharedCtxFromContext returns the sharedContext from the context.
+// Returns nil if not present.
+func sharedCtxFromContext(ctx context.Context) *sharedContext {
+	if sc, ok := ctx.Value(sharedContextKey).(*sharedContext); ok {
+		return sc
+	}
+	return nil
+}
+
+// withSharedContext returns a context with the given shared context.
+func withSharedContext(ctx context.Context, sc *sharedContext) context.Context {
+	return context.WithValue(ctx, sharedContextKey, sc)
 }


### PR DESCRIPTION
## Summary

- **`SharedSubTask(ctx, title, fn)`** — creates a node in both the request-scoped task tree (progress to requester) and a top-level shared task (broadcast to all clients). Nested `SubTask` calls inside it automatically mirror to the shared tree.
- **`SharedTask[M].WithContext(ctx)`** — returns a context carrying the shared task's context, for use with `Go()` goroutines that should dual-send via `SubTask`.
- **`SubTask` dual-send** — when a `sharedContext` is present, `SubTask` creates mirrored nodes in the shared task system.
- **`Output` dual-send** — `Output(ctx, msg)` now also broadcasts to all clients when inside a shared context.

| Scenario | Request-scoped | Shared |
|---|---|---|
| Has task tree + no shared context yet | Creates core + request node | Creates sharedTaskCore (top-level) |
| Has task tree + already in shared context | Creates request node | Creates child sharedTaskNode |
| No task tree + shared context | — | Creates child sharedTaskNode |
| No connection / tasks not enabled | Falls back to SubTask | — |

## Test plan

- [x] `TestSubTaskWithSharedContext` — dual-send basic
- [x] `TestSubTaskWithSharedContextNested` — hierarchy mirroring
- [x] `TestSubTaskWithSharedContextError` — error propagation to shared nodes
- [x] `TestSharedSubTaskStandalone` — creates core, dual-sends, closes core
- [x] `TestSharedSubTaskNested` — creates child node, not new core
- [x] `TestSharedSubTaskErrorPropagation` — both nodes marked failed
- [x] `TestSharedSubTaskWithoutTaskTree` — shared only
- [x] `TestSharedSubTaskWithoutConnection` — fallback to SubTask
- [x] `TestSharedTaskWithContextAndSubTask` — WithContext + SubTask inside Go()
- [x] `TestOutputDualSend` — output sent to both systems
- [x] `TestSharedTaskNodeSubTaskRefactor` — refactoring correctness
- [x] All existing tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)