### PR TITLE
Add context-based TaskProgress/StepTaskProgress for SubTask nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,26 @@ func (h *Handlers) Deploy(ctx context.Context, req *DeployRequest) (*DeployRespo
 
 The client receives a `TaskNode` tree in progress messages. Each node has `id`, `title`, `status` (`running`/`completed`/`failed`), and optional `current`/`total` progress.
 
+**Task progress** — report numeric progress (current/total) on a sub-task from inside the callback:
+
+```go
+aprot.SubTask(ctx, "Parsing files", func(ctx context.Context) error {
+    aprot.TaskProgress(ctx, 0, len(files))
+    for _, file := range files {
+        if err := parseFile(ctx, file); err != nil {
+            return err
+        }
+        aprot.StepTaskProgress(ctx, 1)
+    }
+    return nil
+})
+```
+
+- `TaskProgress(ctx, current, total)` — sets both current and total on the task node
+- `StepTaskProgress(ctx, step)` — increments current by step (e.g. call with 1 after each item)
+
+Both update the request-scoped task tree and the shared task system (if present). No-op if called outside a `SubTask` context.
+
 **Output streaming** sends text output during execution:
 
 ```go


### PR DESCRIPTION
## Summary
- Adds `TaskProgress(ctx, current, total)` and `StepTaskProgress(ctx, step)` public functions that set progress on the current `SubTask` node via context lookup
- Both follow the existing dual-send pattern: update request-scoped task tree + shared task system (if present), no-op outside `SubTask`
- Adds `taskNode.stepProgress()` helper for atomic increment

Closes #48

## Test plan
- [x] `TestTaskProgressBasic` — verifies `TaskProgress` sets current/total on snapshot
- [x] `TestStepTaskProgressBasic` — verifies `StepTaskProgress` accumulates correctly
- [x] `TestTaskProgressNoContext` — verifies no panic on `context.Background()`
- [x] `TestTaskProgressDualSend` — verifies both request-scoped and shared snapshots reflect progress
- [x] `TestStepTaskProgressDualSend` — same for step increments
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)