### PR TITLE
Change task.Go to accept func(ctx) error and auto-fail

### DIFF
--- a/example/vanilla/api/handlers.go
+++ b/example/vanilla/api/handlers.go
@@ -279,11 +279,11 @@ func (h *PublicHandlers) StartSharedWork(ctx context.Context, req *StartSharedWo
 		task.SetMeta(TaskMeta{UserName: conn.UserID()})
 	}
 
-	task.Go(func(ctx context.Context) {
+	task.Go(func(ctx context.Context) error {
 		for i, step := range req.Steps {
 			select {
 			case <-ctx.Done():
-				return
+				return ctx.Err()
 			default:
 			}
 			sub := task.SubTask(step)
@@ -292,6 +292,7 @@ func (h *PublicHandlers) StartSharedWork(ctx context.Context, req *StartSharedWo
 			sub.Complete()
 			task.Progress(i+1, len(req.Steps))
 		}
+		return nil
 	})
 
 	return task.Ref(), nil


### PR DESCRIPTION
## Summary

- Changes `SharedTask[M].Go()` to accept `func(ctx context.Context) error` instead of `func(ctx context.Context)`
- If the function returns nil, the task is marked completed (existing behavior)
- If the function returns a non-nil error, the task is automatically marked failed (new behavior)
- Aligns with the existing `SubTask()` and `SharedSubTask()` patterns

Closes #52

## Test plan

- [x] Existing `TestSharedTaskGo` updated and passing (nil return path)
- [x] New `TestSharedTaskGoError` added and passing (error return path)
- [x] All existing tests pass (`go test ./...`)
- [x] TypeScript clients regenerated successfully
- [x] Example handler updated with proper error returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)