### PR TITLE
Support arbitrary handler return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ myapp/
 
 ### 1. Define handlers (api/handlers.go)
 
-Handler methods must accept `context.Context` as the first parameter (after receiver), followed by any number of additional parameters. They must return either `error` or `(*T, error)`:
+Handler methods must accept `context.Context` as the first parameter (after receiver), followed by any number of additional parameters. They must return either `error` (void) or `(T, error)` where `T` is any JSON-serializable type:
 
 ```go
-func(ctx context.Context) (*U, error)                           // No parameters
+func(ctx context.Context) (*U, error)                           // No parameters, struct response
 func(ctx context.Context) error                                 // No parameters, void
 func(ctx context.Context, req *T) (*U, error)                   // Single struct parameter
 func(ctx context.Context, name string, age int) (*U, error)     // Multiple primitives
 func(ctx context.Context, items ...string) error                // Variadic
+func(ctx context.Context) ([]User, error)                       // Slice response → User[]
+func(ctx context.Context) (map[string]int, error)               // Map response → Record<string, number>
+func(ctx context.Context) (string, error)                       // Primitive response → string
 ```
 
 Parameters are positional — each Go parameter becomes a separate argument in the TypeScript client:

--- a/generate.go
+++ b/generate.go
@@ -227,7 +227,11 @@ func (g *Generator) Generate() (map[string]string, error) {
 			for _, param := range info.Params {
 				g.collectNestedType(param.Type)
 			}
-			g.collectType(info.ResponseType)
+			if info.ResponseType.Kind() == reflect.Struct && info.ResponseType != voidResponseType {
+				g.collectType(info.ResponseType)
+			} else {
+				g.collectNestedType(info.ResponseType)
+			}
 		}
 		for _, event := range group.PushEvents {
 			g.collectType(event.DataType)
@@ -268,7 +272,11 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 			for _, param := range info.Params {
 				g.collectNestedType(param.Type)
 			}
-			g.collectType(info.ResponseType)
+			if info.ResponseType.Kind() == reflect.Struct && info.ResponseType != voidResponseType {
+				g.collectType(info.ResponseType)
+			} else {
+				g.collectNestedType(info.ResponseType)
+			}
 		}
 		for _, event := range group.PushEvents {
 			g.collectType(event.DataType)
@@ -313,9 +321,9 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 		info := handlers[qualifiedName]
 		shortName := info.Name
 		isVoid := info.ResponseType == voidResponseType
-		respType := info.ResponseType.Name()
-		if isVoid {
-			respType = "void"
+		respType := "void"
+		if !isVoid {
+			respType = g.goTypeToTS(info.ResponseType)
 		}
 		data.Methods = append(data.Methods, methodData{
 			Name:         shortName,
@@ -416,9 +424,9 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, paramNames map[string
 	for _, name := range names {
 		info := group.Handlers[name]
 		isVoid := info.ResponseType == voidResponseType
-		respType := info.ResponseType.Name()
-		if isVoid {
-			respType = "void"
+		respType := "void"
+		if !isVoid {
+			respType = g.goTypeToTS(info.ResponseType)
 		}
 		data.Methods = append(data.Methods, methodData{
 			Name:         name,

--- a/handler.go
+++ b/handler.go
@@ -511,18 +511,20 @@ func validateOutputs(method reflect.Method, handlerValue reflect.Value, structNa
 			handler:      handlerValue,
 		}
 	case 2:
-		// func(...) (*Resp, error)
+		// func(...) (T, error) where T is any JSON-serializable type
 		respType := mt.Out(0)
-		if respType.Kind() != reflect.Ptr || respType.Elem().Kind() != reflect.Struct {
-			return nil
-		}
 		if !mt.Out(1).Implements(errorType) {
 			return nil
+		}
+		// Unwrap pointer to store the element type
+		rt := respType
+		if rt.Kind() == reflect.Ptr {
+			rt = rt.Elem()
 		}
 		return &HandlerInfo{
 			Name:         method.Name,
 			Params:       params,
-			ResponseType: respType.Elem(),
+			ResponseType: rt,
 			StructName:   structName,
 			method:       handlerValue.Method(method.Index),
 			handler:      handlerValue,


### PR DESCRIPTION
## Summary

- Handlers can now return `(T, error)` where `T` is any JSON-serializable type — slices, maps, primitives, or pointer-to-struct
- The code generator produces correct TypeScript types: `[]User` → `User[]`, `map[string]int` → `Record<string, number>`, `string` → `string`, etc.
- No wrapper structs needed for simple returns

## Test plan

- [x] Registration tests for all new return types (slice, map, string, int, bool, pointer-to-struct)
- [x] `Call()` tests verifying runtime behavior for each type
- [x] Code generation test verifying correct TypeScript output
- [x] E2E server tests for slice and primitive returns over WebSocket
- [x] All existing tests pass
- [x] Example TypeScript clients regenerated and compile cleanly

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)