### PR TITLE
Eliminate explicit any from generated TypeScript templates

### DIFF
--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -187,6 +187,11 @@ class WebSocketTransport implements ClientTransport {
     }
 }
 
+type ClientMessage =
+    | { type: 'request'; id: string; method: string; params: unknown[] }
+    | { type: 'cancel'; id: string }
+    | { type: 'ping' };
+
 class SSETransport implements ClientTransport {
     private eventSource: EventSource | null = null;
     private connectionId: string | null = null;
@@ -238,7 +243,7 @@ class SSETransport implements ClientTransport {
 
     send(message: object): void {
         if (!this.connectionId) return;
-        const msg = message as any;
+        const msg = message as ClientMessage;
 
         if (msg.type === 'request') {
             fetch(this.baseUrl + '/rpc', {
@@ -294,7 +299,7 @@ export class ApiClient {
     private options: ResolvedOptions;
     private requestId = 0;
     private pending = new Map<string, {
-        resolve: (value: any) => void;
+        resolve: (value: unknown) => void;
         reject: (error: Error) => void;
         onProgress?: (current: number, total: number, message: string) => void;
         onTaskProgress?: (tasks: TaskNode[]) => void;
@@ -302,12 +307,12 @@ export class ApiClient {
     }>();
     private buffer: Array<{
         method: string;
-        params: any;
+        params: unknown[];
         options?: RequestOptions;
-        resolve: (value: any) => void;
+        resolve: (value: unknown) => void;
         reject: (error: Error) => void;
     }> = [];
-    private pushHandlers = new Map<string, Set<(data: any) => void>>();
+    private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
@@ -554,14 +559,15 @@ export class ApiClient {
         }
     }
 
-    request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
+    request<T>(method: string, params: unknown[], options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
+            const res = resolve as (value: unknown) => void;
             if (this.transport.isConnected()) {
-                this.sendRequest(method, params, options, resolve, reject);
+                this.sendRequest(method, params, options, res, reject);
                 return;
             }
             if (this.state === 'connecting' || this.state === 'reconnecting') {
-                const entry = { method, params, options, resolve, reject };
+                const entry = { method, params, options, resolve: res, reject };
                 this.buffer.push(entry);
                 if (options?.signal) {
                     if (options.signal.aborted) {
@@ -583,8 +589,8 @@ export class ApiClient {
         });
     }
 
-    private sendRequest(method: string, params: any, options: RequestOptions | undefined,
-        resolve: (value: any) => void, reject: (error: Error) => void): void {
+    private sendRequest(method: string, params: unknown[], options: RequestOptions | undefined,
+        resolve: (value: unknown) => void, reject: (error: Error) => void): void {
         const id = String(++this.requestId);
         this.pending.set(id, {
             resolve, reject,
@@ -631,9 +637,10 @@ export class ApiClient {
         if (!this.pushHandlers.has(event)) {
             this.pushHandlers.set(event, new Set());
         }
-        this.pushHandlers.get(event)!.add(handler);
+        const cb = handler as (data: unknown) => void;
+        this.pushHandlers.get(event)!.add(cb);
         return () => {
-            this.pushHandlers.get(event)?.delete(handler);
+            this.pushHandlers.get(event)?.delete(cb);
         };
     }
 }
@@ -709,7 +716,7 @@ export interface UseQueryResult<TRes> {
     error: Error | null;
     isLoading: boolean;
     refetch: () => void;
-    mutate: (action: Promise<any> | (() => Promise<any>)) => Promise<void>;
+    mutate: (action: Promise<unknown> | (() => Promise<unknown>)) => Promise<void>;
 }
 
 // Mutation hook options
@@ -718,7 +725,7 @@ export interface UseMutationOptions {
 }
 
 // Mutation hook result
-export interface UseMutationResult<TParams extends any[], TRes> {
+export interface UseMutationResult<TParams extends unknown[], TRes> {
     mutate: (...params: TParams) => Promise<TRes>;
     data: TRes | null;
     error: Error | null;

--- a/templates/client-handler-react.ts.tmpl
+++ b/templates/client-handler-react.ts.tmpl
@@ -97,7 +97,7 @@ export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: n
         fetch();
     }, [fetch]);
 
-    const mutate = useCallback(async (action: Promise<any> | (() => Promise<any>)) => {
+    const mutate = useCallback(async (action: Promise<unknown> | (() => Promise<unknown>)) => {
         setIsLoading(true);
         setError(null);
         try {
@@ -168,6 +168,7 @@ export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>)
         } finally {
             setIsLoading(false);
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, options.enabled, paramsKey]);
 
     useEffect(() => {
@@ -185,7 +186,7 @@ export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>)
         fetch();
     }, [fetch]);
 
-    const mutate = useCallback(async (action: Promise<any> | (() => Promise<any>)) => {
+    const mutate = useCallback(async (action: Promise<unknown> | (() => Promise<unknown>)) => {
         setIsLoading(true);
         setError(null);
         try {

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -50,6 +50,11 @@ class WebSocketTransport implements ClientTransport {
     }
 }
 
+type ClientMessage =
+    | { type: 'request'; id: string; method: string; params: unknown[] }
+    | { type: 'cancel'; id: string }
+    | { type: 'ping' };
+
 class SSETransport implements ClientTransport {
     private eventSource: EventSource | null = null;
     private connectionId: string | null = null;
@@ -98,7 +103,7 @@ class SSETransport implements ClientTransport {
 
     send(message: object): void {
         if (!this.connectionId) return;
-        const msg = message as any;
+        const msg = message as ClientMessage;
 
         if (msg.type === 'request') {
             fetch(this.baseUrl + '/rpc', {
@@ -140,7 +145,7 @@ export class ApiClient {
     private options: Required<ApiClientOptions>;
     private requestId = 0;
     private pending = new Map<string, {
-        resolve: (value: any) => void;
+        resolve: (value: unknown) => void;
         reject: (error: Error) => void;
         onProgress?: (current: number, total: number, message: string) => void;
         onTaskProgress?: (tasks: TaskNode[]) => void;
@@ -148,12 +153,12 @@ export class ApiClient {
     }>();
     private buffer: Array<{
         method: string;
-        params: any;
+        params: unknown[];
         options?: RequestOptions;
-        resolve: (value: any) => void;
+        resolve: (value: unknown) => void;
         reject: (error: Error) => void;
     }> = [];
-    private pushHandlers = new Map<string, Set<(data: any) => void>>();
+    private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
@@ -358,14 +363,15 @@ export class ApiClient {
         }
     }
 
-    request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
+    request<T>(method: string, params: unknown[], options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
+            const res = resolve as (value: unknown) => void;
             if (this.transport.isConnected()) {
-                this.sendRequest(method, params, options, resolve, reject);
+                this.sendRequest(method, params, options, res, reject);
                 return;
             }
             if (this.state === 'connecting' || this.state === 'reconnecting') {
-                const entry = { method, params, options, resolve, reject };
+                const entry = { method, params, options, resolve: res, reject };
                 this.buffer.push(entry);
                 if (options?.signal) {
                     if (options.signal.aborted) {
@@ -387,8 +393,8 @@ export class ApiClient {
         });
     }
 
-    private sendRequest(method: string, params: any, options: RequestOptions | undefined,
-        resolve: (value: any) => void, reject: (error: Error) => void): void {
+    private sendRequest(method: string, params: unknown[], options: RequestOptions | undefined,
+        resolve: (value: unknown) => void, reject: (error: Error) => void): void {
         const id = String(++this.requestId);
         this.pending.set(id, {
             resolve, reject,
@@ -435,9 +441,10 @@ export class ApiClient {
         if (!this.pushHandlers.has(event)) {
             this.pushHandlers.set(event, new Set());
         }
-        this.pushHandlers.get(event)!.add(handler);
+        const cb = handler as (data: unknown) => void;
+        this.pushHandlers.get(event)!.add(cb);
         return () => {
-            this.pushHandlers.get(event)?.delete(handler);
+            this.pushHandlers.get(event)?.delete(cb);
         };
     }
 }
@@ -493,7 +500,7 @@ export function {{.HookName}}(options?: { enabled?: boolean; refetchInterval?: n
         fetch();
     }, [fetch]);
 
-    const mutate = useCallback(async (action: Promise<any> | (() => Promise<any>)) => {
+    const mutate = useCallback(async (action: Promise<unknown> | (() => Promise<unknown>)) => {
         setIsLoading(true);
         setError(null);
         try {
@@ -564,6 +571,7 @@ export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>)
         } finally {
             setIsLoading(false);
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, options.enabled, paramsKey]);
 
     useEffect(() => {
@@ -581,7 +589,7 @@ export function {{.HookName}}(options: UseQueryOptions<[{{paramDecl .Params}}]>)
         fetch();
     }, [fetch]);
 
-    const mutate = useCallback(async (action: Promise<any> | (() => Promise<any>)) => {
+    const mutate = useCallback(async (action: Promise<unknown> | (() => Promise<unknown>)) => {
         setIsLoading(true);
         setError(null);
         try {

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -48,6 +48,11 @@ class WebSocketTransport implements ClientTransport {
     }
 }
 
+type ClientMessage =
+    | { type: 'request'; id: string; method: string; params: unknown[] }
+    | { type: 'cancel'; id: string }
+    | { type: 'ping' };
+
 class SSETransport implements ClientTransport {
     private eventSource: EventSource | null = null;
     private connectionId: string | null = null;
@@ -96,7 +101,7 @@ class SSETransport implements ClientTransport {
 
     send(message: object): void {
         if (!this.connectionId) return;
-        const msg = message as any;
+        const msg = message as ClientMessage;
 
         if (msg.type === 'request') {
             fetch(this.baseUrl + '/rpc', {
@@ -138,7 +143,7 @@ export class ApiClient {
     private options: Required<ApiClientOptions>;
     private requestId = 0;
     private pending = new Map<string, {
-        resolve: (value: any) => void;
+        resolve: (value: unknown) => void;
         reject: (error: Error) => void;
         onProgress?: (current: number, total: number, message: string) => void;
         onTaskProgress?: (tasks: TaskNode[]) => void;
@@ -146,12 +151,12 @@ export class ApiClient {
     }>();
     private buffer: Array<{
         method: string;
-        params: any;
+        params: unknown[];
         options?: RequestOptions;
-        resolve: (value: any) => void;
+        resolve: (value: unknown) => void;
         reject: (error: Error) => void;
     }> = [];
-    private pushHandlers = new Map<string, Set<(data: any) => void>>();
+    private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
@@ -356,14 +361,15 @@ export class ApiClient {
         }
     }
 
-    request<T>(method: string, params: any, options?: RequestOptions): Promise<T> {
+    request<T>(method: string, params: unknown[], options?: RequestOptions): Promise<T> {
         return new Promise((resolve, reject) => {
+            const res = resolve as (value: unknown) => void;
             if (this.transport.isConnected()) {
-                this.sendRequest(method, params, options, resolve, reject);
+                this.sendRequest(method, params, options, res, reject);
                 return;
             }
             if (this.state === 'connecting' || this.state === 'reconnecting') {
-                const entry = { method, params, options, resolve, reject };
+                const entry = { method, params, options, resolve: res, reject };
                 this.buffer.push(entry);
                 if (options?.signal) {
                     if (options.signal.aborted) {
@@ -385,8 +391,8 @@ export class ApiClient {
         });
     }
 
-    private sendRequest(method: string, params: any, options: RequestOptions | undefined,
-        resolve: (value: any) => void, reject: (error: Error) => void): void {
+    private sendRequest(method: string, params: unknown[], options: RequestOptions | undefined,
+        resolve: (value: unknown) => void, reject: (error: Error) => void): void {
         const id = String(++this.requestId);
         this.pending.set(id, {
             resolve, reject,
@@ -432,9 +438,10 @@ export class ApiClient {
         if (!this.pushHandlers.has(event)) {
             this.pushHandlers.set(event, new Set());
         }
-        this.pushHandlers.get(event)!.add(handler);
+        const cb = handler as (data: unknown) => void;
+        this.pushHandlers.get(event)!.add(cb);
         return () => {
-            this.pushHandlers.get(event)?.delete(handler);
+            this.pushHandlers.get(event)?.delete(cb);
         };
     }
 }


### PR DESCRIPTION
## Summary

- Replace all 13 unique `any` patterns across template files with proper types, eliminating `@typescript-eslint/no-explicit-any` lint errors in generated output
- Add `ClientMessage` discriminated union for SSE transport message narrowing (replaces `message as any`)
- Use `unknown` / `unknown[]` for type-erased generic storage (`pending`, `buffer`, `pushHandlers`, `request()`, `sendRequest()`)
- Fix `UseQueryResult.mutate` and `UseMutationResult` generic constraint to use `unknown`
- Add `eslint-disable-next-line react-hooks/exhaustive-deps` for parameterized query hooks where `paramsKey` covers `options.params`

Changes applied consistently across all 4 template files:
- `_client-common.ts.tmpl` (shared blocks)
- `client.ts.tmpl` (standalone vanilla)
- `client-react.ts.tmpl` (standalone react)
- `client-handler-react.ts.tmpl` (per-handler react)

## Test plan

- [x] `go test ./...` passes
- [x] Vanilla example regenerated and output contains zero `any`
- [x] React example regenerated and output contains zero `any`
- [x] `npx tsc --noEmit` passes on react example

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)