### PR TITLE
Add TaskNodeStatusCreated status

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ func (h *Handlers) Deploy(ctx context.Context, req *DeployRequest) (*DeployRespo
 
 The client receives a `TaskNode` tree in progress messages. Each node has `id`, `title`, `status` (a `TaskNodeStatusType`), optional `error` message (populated on failure), and optional `current`/`total` progress.
 
-`TaskNodeStatus` is exported as a TypeScript const enum, so you can use `TaskNodeStatus.Running`, `TaskNodeStatus.Completed`, and `TaskNodeStatus.Failed` instead of raw string literals:
+`TaskNodeStatus` is exported as a TypeScript const enum, so you can use `TaskNodeStatus.Created`, `TaskNodeStatus.Running`, `TaskNodeStatus.Completed`, and `TaskNodeStatus.Failed` instead of raw string literals. A task starts with `Created` status, transitions to `Running` before its function executes, and ends with `Completed` or `Failed`:
 
 ```typescript
 import { TaskNodeStatus } from './api/client';

--- a/generate_test.go
+++ b/generate_test.go
@@ -1627,8 +1627,8 @@ func TestEnableTasksRegistersEnum(t *testing.T) {
 	if enumInfo.Name != "TaskNodeStatus" {
 		t.Errorf("Expected enum name TaskNodeStatus, got %s", enumInfo.Name)
 	}
-	if len(enumInfo.Values) != 3 {
-		t.Errorf("Expected 3 enum values, got %d", len(enumInfo.Values))
+	if len(enumInfo.Values) != 4 {
+		t.Errorf("Expected 4 enum values, got %d", len(enumInfo.Values))
 	}
 }
 

--- a/shared_task_test.go
+++ b/shared_task_test.go
@@ -32,7 +32,7 @@ func TestSharedTaskBasic(t *testing.T) {
 		t.Fatal("expected non-empty task ID")
 	}
 
-	// Check snapshot
+	// Check snapshot — tm.create() leaves the task in "created" status
 	states := tm.snapshotAll()
 	if len(states) != 1 {
 		t.Fatalf("expected 1 task, got %d", len(states))
@@ -40,8 +40,8 @@ func TestSharedTaskBasic(t *testing.T) {
 	if states[0].Title != "Build project" {
 		t.Errorf("expected 'Build project', got %s", states[0].Title)
 	}
-	if states[0].Status != TaskNodeStatusRunning {
-		t.Errorf("expected running status, got %s", states[0].Status)
+	if states[0].Status != TaskNodeStatusCreated {
+		t.Errorf("expected created status, got %s", states[0].Status)
 	}
 
 	// Close the task

--- a/task_test.go
+++ b/task_test.go
@@ -47,17 +47,17 @@ func TestSubTaskWithTree(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should have received 2 progress messages: one for "running", one for "completed".
+	// Should have received 2 progress messages: one for "created", one for "completed".
 	if len(captured) < 2 {
 		t.Fatalf("expected at least 2 progress messages, got %d", len(captured))
 	}
 
-	// First message should have a task in "running" state
+	// First message should have a task in "created" state
 	if len(captured[0].Tasks) != 1 {
 		t.Fatalf("expected 1 task in first message, got %d", len(captured[0].Tasks))
 	}
-	if captured[0].Tasks[0].Status != TaskNodeStatusRunning {
-		t.Errorf("expected running status, got %s", captured[0].Tasks[0].Status)
+	if captured[0].Tasks[0].Status != TaskNodeStatusCreated {
+		t.Errorf("expected created status, got %s", captured[0].Tasks[0].Status)
 	}
 	if captured[0].Tasks[0].Title != "Step 1" {
 		t.Errorf("expected title 'Step 1', got %s", captured[0].Tasks[0].Title)


### PR DESCRIPTION
## Summary

- Add `TaskNodeStatusCreated` (`"created"`) status constant and include it in `TaskNodeStatusValues()`
- All task creation sites now broadcast `"created"` once before transitioning to `"running"` before executing user code
- Updated `closeTask()`/`fail()` guards to accept both `created` and `running` states
- Generated TypeScript automatically includes `TaskNodeStatus.Created`

Closes #74

## Test plan

- [x] `go test ./...` passes
- [x] Regenerated TypeScript clients (`vanilla` and `react`)
- [x] `npx tsc --noEmit` passes for react client
- [x] `TestSubTaskWithTree` verifies first broadcast shows `created` status
- [x] `TestSharedTaskBasic` verifies `tm.create()` returns `created` status
- [x] `TestEnableTasksRegistersEnum` updated for 4 enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)