### PR TITLE
Fix first shared task message to show CREATED status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ Register Go enum types to generate TypeScript const objects with full type safet
 type TaskStatus string
 
 const (
-    TaskStatusPending   TaskStatus = "pending"
+    TaskStatusCreated   TaskStatus = "created"
     TaskStatusRunning   TaskStatus = "running"
     TaskStatusCompleted TaskStatus = "completed"
     TaskStatusFailed    TaskStatus = "failed"
@@ -1019,7 +1019,7 @@ const (
 // Required: Values() function returning all enum values
 func TaskStatusValues() []TaskStatus {
     return []TaskStatus{
-        TaskStatusPending,
+        TaskStatusCreated,
         TaskStatusRunning,
         TaskStatusCompleted,
         TaskStatusFailed,
@@ -1119,8 +1119,8 @@ if (task.status === TaskStatus.Running) {
 // Type-safe switch with exhaustive checking
 function getStatusLabel(status: TaskStatusType): string {
     switch (status) {
-        case TaskStatus.Pending:
-            return 'Pending';
+        case TaskStatus.Created:
+            return 'Created';
         case TaskStatus.Running:
             return 'Running';
         case TaskStatus.Completed:

--- a/example/react/api/types.go
+++ b/example/react/api/types.go
@@ -6,7 +6,7 @@ package api
 type TaskStatus string
 
 const (
-	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusCreated   TaskStatus = "created"
 	TaskStatusRunning   TaskStatus = "running"
 	TaskStatusCompleted TaskStatus = "completed"
 	TaskStatusFailed    TaskStatus = "failed"
@@ -15,7 +15,7 @@ const (
 // TaskStatusValues returns all possible TaskStatus values.
 func TaskStatusValues() []TaskStatus {
 	return []TaskStatus{
-		TaskStatusPending,
+		TaskStatusCreated,
 		TaskStatusRunning,
 		TaskStatusCompleted,
 		TaskStatusFailed,

--- a/example/react/client/src/App.tsx
+++ b/example/react/client/src/App.tsx
@@ -107,8 +107,8 @@ function UsersList() {
 // Helper to get status label using enum - demonstrates type-safe enum usage
 function getStatusLabel(status: TaskStatusType): string {
   switch (status) {
-    case TaskStatus.Pending:
-      return '⏳ Pending'
+    case TaskStatus.Created:
+      return '⏳ Created'
     case TaskStatus.Running:
       return '🔄 Running'
     case TaskStatus.Completed:
@@ -123,8 +123,8 @@ function getStatusLabel(status: TaskStatusType): string {
 // Helper to get status badge class using enum
 function getStatusClass(status: TaskStatusType): string {
   switch (status) {
-    case TaskStatus.Pending:
-      return 'status-pending'
+    case TaskStatus.Created:
+      return 'status-created'
     case TaskStatus.Running:
       return 'status-running'
     case TaskStatus.Completed:

--- a/example/react/client/src/index.css
+++ b/example/react/client/src/index.css
@@ -95,7 +95,7 @@ button.danger:hover { background: #c82333; }
 
 /* Status badge styles for enum demo */
 .status-badge { padding: 4px 8px; border-radius: 4px; font-size: 13px; font-weight: 500; }
-.status-pending { background: #fff3cd; color: #856404; }
+.status-created { background: #fff3cd; color: #856404; }
 .status-running { background: #cce5ff; color: #004085; }
 .status-completed { background: #d4edda; color: #155724; }
 .status-failed { background: #f8d7da; color: #721c24; }

--- a/example/vanilla/api/types.go
+++ b/example/vanilla/api/types.go
@@ -6,7 +6,7 @@ package api
 type TaskStatus string
 
 const (
-	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusCreated   TaskStatus = "created"
 	TaskStatusRunning   TaskStatus = "running"
 	TaskStatusCompleted TaskStatus = "completed"
 	TaskStatusFailed    TaskStatus = "failed"
@@ -15,7 +15,7 @@ const (
 // TaskStatusValues returns all possible TaskStatus values.
 func TaskStatusValues() []TaskStatus {
 	return []TaskStatus{
-		TaskStatusPending,
+		TaskStatusCreated,
 		TaskStatusRunning,
 		TaskStatusCompleted,
 		TaskStatusFailed,

--- a/example/vanilla/client/static/app.ts
+++ b/example/vanilla/client/static/app.ts
@@ -66,8 +66,8 @@ async function doListUsers(): Promise<void> {
 // Helper to get a human-readable label for task status using the enum
 function getStatusLabel(status: TaskStatusType): string {
     switch (status) {
-        case TaskStatus.Pending:
-            return '⏳ Pending';
+        case TaskStatus.Created:
+            return '⏳ Created';
         case TaskStatus.Running:
             return '🔄 Running';
         case TaskStatus.Completed:
@@ -82,8 +82,8 @@ function getStatusLabel(status: TaskStatusType): string {
 // Helper to get CSS class for status badge
 function getStatusClass(status: TaskStatusType): string {
     switch (status) {
-        case TaskStatus.Pending:
-            return 'status-pending';
+        case TaskStatus.Created:
+            return 'status-created';
         case TaskStatus.Running:
             return 'status-running';
         case TaskStatus.Completed:

--- a/example/vanilla/client/static/index.html
+++ b/example/vanilla/client/static/index.html
@@ -55,7 +55,7 @@
         .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
         @media (max-width: 768px) { .grid { grid-template-columns: 1fr; } }
         .status-badge { padding: 4px 8px; border-radius: 4px; font-size: 13px; font-weight: 500; }
-        .status-pending { background: #fff3cd; color: #856404; }
+        .status-created { background: #fff3cd; color: #856404; }
         .status-running { background: #cce5ff; color: #004085; }
         .status-completed { background: #d4edda; color: #155724; }
         .status-failed { background: #f8d7da; color: #721c24; }

--- a/generate_test.go
+++ b/generate_test.go
@@ -41,13 +41,13 @@ type UserUpdatedEvent struct {
 type TaskStatus string
 
 const (
-	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusCreated   TaskStatus = "created"
 	TaskStatusRunning   TaskStatus = "running"
 	TaskStatusCompleted TaskStatus = "completed"
 )
 
 func TaskStatusValues() []TaskStatus {
-	return []TaskStatus{TaskStatusPending, TaskStatusRunning, TaskStatusCompleted}
+	return []TaskStatus{TaskStatusCreated, TaskStatusRunning, TaskStatusCompleted}
 }
 
 // Int-based enum for testing (with Stringer interface)
@@ -471,8 +471,8 @@ func TestGenerateWithEnums(t *testing.T) {
 	if !strings.Contains(output, "export const TaskStatus = {") {
 		t.Error("Missing TaskStatus enum const")
 	}
-	if !strings.Contains(output, `Pending: "pending"`) {
-		t.Error("Missing Pending enum value")
+	if !strings.Contains(output, `Created: "created"`) {
+		t.Error("Missing Created enum value")
 	}
 	if !strings.Contains(output, "export type TaskStatusType = typeof TaskStatus[keyof typeof TaskStatus]") {
 		t.Error("Missing TaskStatusType type alias")

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -349,10 +349,10 @@ func StartSharedTask[M any](ctx context.Context, title string) (context.Context,
 		return ctx, nil
 	}
 	core := tm.create(title, conn.ID(), true, ctx)
+	tm.broadcastNow() // first message shows CREATED
 	core.mu.Lock()
 	core.status = TaskNodeStatusRunning
 	core.mu.Unlock()
-	tm.broadcastNow()
 
 	if slot := taskSlotFromContext(ctx); slot != nil {
 		slot.sharedCore = core
@@ -380,10 +380,10 @@ func SharedSubTask(ctx context.Context, title string, fn func(ctx context.Contex
 	}
 
 	core := tm.create(title, conn.ID(), false, ctx)
+	tm.broadcastNow() // first message shows CREATED
 	core.mu.Lock()
 	core.status = TaskNodeStatusRunning
 	core.mu.Unlock()
-	tm.broadcastNow()
 	sc := &sharedContext{core: core}
 	childCtx := withSharedContext(ctx, sc)
 

--- a/tasks/event_order_test.go
+++ b/tasks/event_order_test.go
@@ -1,0 +1,199 @@
+package tasks
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/gorilla/websocket"
+	"github.com/marrasen/aprot"
+)
+
+// eventOrderHandler is a handler used in event-order integration tests.
+type eventOrderHandler struct {
+	server *aprot.Server
+}
+
+func (h *eventOrderHandler) StartShared(ctx context.Context, title string) error {
+	_, task := StartSharedTask[struct{}](ctx, title)
+	if task == nil {
+		return aprot.NewError(aprot.CodeInternalError, "task not created")
+	}
+	Output(ctx, "hello")
+	TaskProgress(ctx, 1, 2)
+	task.Close()
+	return nil
+}
+
+// setupEventOrderServer creates a real HTTP server with tasks enabled and
+// returns the httptest.Server and a cleanup function.
+func setupEventOrderServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	registry := aprot.NewRegistry()
+	handler := &eventOrderHandler{}
+	registry.Register(handler)
+	Enable(registry)
+
+	server := aprot.NewServer(registry)
+	handler.server = server
+
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() {
+		ts.Close()
+		server.Stop(context.Background()) //nolint:errcheck
+	})
+	return ts
+}
+
+// connectEventOrderWS opens a WS connection and discards the initial config message.
+func connectEventOrderWS(t *testing.T, ts *httptest.Server) *websocket.Conn {
+	t.Helper()
+	url := "ws" + strings.TrimPrefix(ts.URL, "http")
+	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	// Discard the config message sent on connect.
+	ws.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err = ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("Failed to read config message: %v", err)
+	}
+	return ws
+}
+
+// rawPush is a minimal struct to parse just the type and event fields of any
+// message off the wire.
+type rawPush struct {
+	Type  string `json:"type"`
+	Event string `json:"event"`
+}
+
+// taskStatePush is the expected shape of a TaskStateEvent push message's data.
+type taskStatePush struct {
+	Tasks []SharedTaskState `json:"tasks"`
+}
+
+// readAllPushMessages sends a request and reads all messages until a response
+// or error comes back for that request ID, collecting push messages.
+func readAllPushMessages(t *testing.T, ws *websocket.Conn, reqID string) (pushes []rawPushWithData) {
+	t.Helper()
+	ws.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		_, data, err := ws.ReadMessage()
+		if err != nil {
+			t.Fatalf("ReadMessage failed: %v", err)
+		}
+
+		var base struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		}
+		if err := json.Unmarshal(data, &base); err != nil {
+			t.Fatalf("Unmarshal base message failed: %v", err)
+		}
+
+		switch base.Type {
+		case "push":
+			var p rawPushWithData
+			if err := json.Unmarshal(data, &p); err != nil {
+				t.Fatalf("Unmarshal push failed: %v", err)
+			}
+			pushes = append(pushes, p)
+		case "response", "error":
+			if base.ID == reqID {
+				return pushes
+			}
+		case "progress":
+			// request-scoped progress — ignore
+		}
+	}
+}
+
+// rawPushWithData captures the full push message including raw data.
+type rawPushWithData struct {
+	Type  string          `json:"type"`
+	Event string          `json:"event"`
+	Data  jsontext.Value `json:"data"`
+}
+
+// TestSharedTaskFirstMessageIsCreated verifies that the first TaskStateEvent
+// push for a newly created shared task has status "created".
+func TestSharedTaskFirstMessageIsCreated(t *testing.T) {
+	ts := setupEventOrderServer(t)
+	ws := connectEventOrderWS(t, ts)
+	defer ws.Close()
+
+	// Send StartShared request.
+	req := map[string]any{
+		"type":   "request",
+		"id":     "1",
+		"method": "eventOrderHandler.StartShared",
+		"params": []any{"test-task"},
+	}
+	if err := ws.WriteJSON(req); err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+
+	pushes := readAllPushMessages(t, ws, "1")
+
+	// Find the first TaskStateEvent push.
+	var firstState *taskStatePush
+	for _, p := range pushes {
+		if p.Event == "TaskStateEvent" {
+			var ts taskStatePush
+			if err := json.Unmarshal(p.Data, &ts); err != nil {
+				t.Fatalf("Unmarshal TaskStateEvent data failed: %v", err)
+			}
+			firstState = &ts
+			break
+		}
+	}
+	if firstState == nil {
+		t.Fatal("no TaskStateEvent push received")
+	}
+	if len(firstState.Tasks) == 0 {
+		t.Fatal("first TaskStateEvent has no tasks")
+	}
+	if firstState.Tasks[0].Status != TaskNodeStatusCreated {
+		t.Errorf("first TaskStateEvent task status: got %q, want %q",
+			firstState.Tasks[0].Status, TaskNodeStatusCreated)
+	}
+}
+
+// TestSharedTaskNoUpdateBeforeCreated verifies that no TaskUpdateEvent appears
+// before the first TaskStateEvent (which should show "created").
+func TestSharedTaskNoUpdateBeforeCreated(t *testing.T) {
+	ts := setupEventOrderServer(t)
+	ws := connectEventOrderWS(t, ts)
+	defer ws.Close()
+
+	// Send StartShared request — the handler calls Output and Progress immediately.
+	req := map[string]any{
+		"type":   "request",
+		"id":     "1",
+		"method": "eventOrderHandler.StartShared",
+		"params": []any{"task-with-output"},
+	}
+	if err := ws.WriteJSON(req); err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+
+	pushes := readAllPushMessages(t, ws, "1")
+
+	// Walk pushes and assert no TaskUpdateEvent before the first TaskStateEvent.
+	for _, p := range pushes {
+		if p.Event == "TaskStateEvent" {
+			// Good — the state event came first.
+			break
+		}
+		if p.Event == "TaskUpdateEvent" {
+			t.Fatal("TaskUpdateEvent appeared before the first TaskStateEvent")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #84

- **Fix broadcast order** in `StartSharedTask` and `SharedSubTask`: call `broadcastNow()` before setting status to `RUNNING`, so the first message clients receive shows `"created"`
- **Rename `TaskStatusPending` → `TaskStatusCreated`** (value `"created"`) in example apps to align with core `TaskNodeStatusCreated`
- **Update client-side files** (vanilla TS/JS/HTML, React TSX/CSS) to use `TaskStatus.Created` and `.status-created`
- **Add integration tests** (`tasks/event_order_test.go`) verifying the first push is `CREATED` and no `TaskUpdateEvent` precedes it

## Test plan

- [x] `go test ./...` passes
- [x] New tests `TestSharedTaskFirstMessageIsCreated` and `TestSharedTaskNoUpdateBeforeCreated` pass
- [x] Regenerated TS clients reflect `Created: "created"`
- [x] `npx tsc --noEmit` passes for React client

🤖 Generated with [Claude Code](https://claude.com/claude-code)