### PR TITLE
Fix E2E tests for flattened handler args

### DIFF
--- a/e2e/tests/auth.test.ts
+++ b/e2e/tests/auth.test.ts
@@ -17,7 +17,7 @@ describe('Auth Flow (WebSocket)', () => {
     });
 
     test('login returns token and username', async () => {
-        const res = await login(client, { username: 'testuser', password: 'pass' });
+        const res = await login(client, 'testuser', 'pass');
         expect(res.token).toBeDefined();
         expect(res.token.length).toBeGreaterThan(0);
         expect(res.username).toBe('testuser');
@@ -25,7 +25,7 @@ describe('Auth Flow (WebSocket)', () => {
     });
 
     test('getProfile after login returns profile', async () => {
-        const loginRes = await login(client, { username: 'profileuser', password: 'pass' });
+        const loginRes = await login(client, 'profileuser', 'pass');
 
         // After login, the connection is authenticated — no token needed in params
         const profile = await getProfile(client);
@@ -45,14 +45,14 @@ describe('Auth Flow (WebSocket)', () => {
 
     test('sendMessage delivers DirectMessage push to recipient', async () => {
         // Client 1: sender
-        const senderLogin = await login(client, { username: 'sender', password: 'pass' });
+        const senderLogin = await login(client, 'sender', 'pass');
 
         // Client 2: recipient
         const client2 = new ApiClient(wsUrl(), { reconnect: false, heartbeatInterval: 0 });
         await client2.connect();
 
         try {
-            const recipientLogin = await login(client2, { username: 'recipient', password: 'pass' });
+            const recipientLogin = await login(client2, 'recipient', 'pass');
 
             const received = new Promise<{ from_user_id: string; from_user: string; message: string }>((resolve) => {
                 onDirectMessageEvent(client2, (data) => {
@@ -61,10 +61,7 @@ describe('Auth Flow (WebSocket)', () => {
             });
 
             // After login, connection is authenticated — send message directly
-            await sendMessage(client, {
-                to_user_id: recipientLogin.user_id,
-                message: 'Hello from sender',
-            });
+            await sendMessage(client, recipientLogin.user_id, 'Hello from sender');
 
             const event = await received;
             expect(event.from_user).toBe('sender');

--- a/e2e/tests/sse.test.ts
+++ b/e2e/tests/sse.test.ts
@@ -16,29 +16,29 @@ describe('SSE Transport', () => {
     });
 
     test('createUser returns id, name, email', async () => {
-        const res = await createUser(client, { name: 'Alice', email: 'alice@test.com' });
+        const res = await createUser(client, 'Alice', 'alice@test.com');
         expect(res.id).toBeDefined();
         expect(res.name).toBe('Alice');
         expect(res.email).toBe('alice@test.com');
     });
 
     test('getUser returns created user', async () => {
-        const created = await createUser(client, { name: 'Bob', email: 'bob@test.com' });
-        const user = await getUser(client, { id: created.id });
+        const created = await createUser(client, 'Bob', 'bob@test.com');
+        const user = await getUser(client, created.id);
         expect(user.id).toBe(created.id);
         expect(user.name).toBe('Bob');
         expect(user.email).toBe('bob@test.com');
     });
 
     test('listUsers returns array', async () => {
-        await createUser(client, { name: 'Carol', email: 'carol@test.com' });
+        await createUser(client, 'Carol', 'carol@test.com');
         const res = await listUsers(client);
         expect(Array.isArray(res.users)).toBe(true);
         expect(res.users.length).toBeGreaterThanOrEqual(1);
     });
 
     test('getTask returns enum status field', async () => {
-        const task = await getTask(client, { id: 'task-1' });
+        const task = await getTask(client, 'task-1');
         expect(task.id).toBe('task-1');
         expect(task.name).toBe('Example Task');
         expect(task.status).toBe(TaskStatus.Running);
@@ -48,7 +48,8 @@ describe('SSE Transport', () => {
         const progressUpdates: { current: number; total: number; message: string }[] = [];
         const res = await processBatch(
             client,
-            { items: ['a', 'b', 'c'], delay: 50 },
+            ['a', 'b', 'c'],
+            50,
             {
                 onProgress: (current, total, message) => {
                     progressUpdates.push({ current, total, message });
@@ -66,7 +67,8 @@ describe('SSE Transport', () => {
         const controller = new AbortController();
         const promise = processBatch(
             client,
-            { items: ['a', 'b', 'c', 'd', 'e'], delay: 200 },
+            ['a', 'b', 'c', 'd', 'e'],
+            200,
             { signal: controller.signal },
         );
 
@@ -82,7 +84,7 @@ describe('SSE Transport', () => {
             });
         });
 
-        await sendNotification(client, { message: 'hello', level: 'info' });
+        await sendNotification(client, 'hello', 'info');
 
         const event = await received;
         expect(event.message).toBe('hello');
@@ -100,7 +102,7 @@ describe('SSE Transport', () => {
                 });
             });
 
-            const created = await createUser(client, { name: 'Dave', email: 'dave@test.com' });
+            const created = await createUser(client, 'Dave', 'dave@test.com');
 
             const event = await received;
             expect(event.id).toBe(created.id);
@@ -113,7 +115,7 @@ describe('SSE Transport', () => {
 
     test('createUser with empty name throws ApiError with isInvalidParams', async () => {
         try {
-            await createUser(client, { name: '', email: 'bad@test.com' });
+            await createUser(client, '', 'bad@test.com');
             expect.fail('Should have thrown');
         } catch (err) {
             expect(err).toBeInstanceOf(ApiError);
@@ -123,7 +125,7 @@ describe('SSE Transport', () => {
 
     test('unknown method throws ApiError with isNotFound', async () => {
         try {
-            await client.request('NonExistent', {});
+            await client.request('NonExistent', []);
             expect.fail('Should have thrown');
         } catch (err) {
             expect(err).toBeInstanceOf(ApiError);

--- a/e2e/tests/tasks.test.ts
+++ b/e2e/tests/tasks.test.ts
@@ -24,7 +24,8 @@ describe('SubTask (WebSocket)', () => {
 
         const res = await processWithSubTasks(
             client,
-            { steps: ['Build', 'Test', 'Deploy'], delay: 50 },
+            ['Build', 'Test', 'Deploy'],
+            50,
             taskOptions({
                 onTaskProgress: (tasks) => {
                     taskUpdates.push(tasks);
@@ -59,7 +60,8 @@ describe('SubTask (WebSocket)', () => {
 
         const res = await processWithSubTasks(
             client,
-            { steps: ['Alpha', 'Beta'], delay: 50 },
+            ['Alpha', 'Beta'],
+            50,
             taskOptions({
                 onOutput: (output, taskId) => {
                     outputs.push({ output, taskId });
@@ -114,11 +116,7 @@ describe('SharedTask (WebSocket)', () => {
 
         try {
             // startSharedWork is now void — it blocks until work completes
-            await startSharedWork(client, {
-                title: 'E2E Shared Work',
-                steps: ['Step1', 'Step2'],
-                delay: 50,
-            });
+            await startSharedWork(client, 'E2E Shared Work', ['Step1', 'Step2'], 50);
 
             // Wait for final broadcasts to arrive
             await new Promise(resolve => setTimeout(resolve, 500));
@@ -152,11 +150,7 @@ describe('SharedTask (WebSocket)', () => {
             });
 
             // Start shared work from the FIRST client (blocks until done)
-            await startSharedWork(client, {
-                title: 'Broadcast Test',
-                steps: ['A', 'B'],
-                delay: 50,
-            });
+            await startSharedWork(client, 'Broadcast Test', ['A', 'B'], 50);
 
             // Second client should have received the task state during execution
             const tasks = await received;
@@ -190,11 +184,7 @@ describe('SharedTask (WebSocket)', () => {
 
         try {
             // startSharedWork blocks until work completes
-            await startSharedWork(client, {
-                title: 'Output Test',
-                steps: ['X', 'Y'],
-                delay: 50,
-            });
+            await startSharedWork(client, 'Output Test', ['X', 'Y'], 50);
 
             // Wait for any remaining events
             await new Promise(resolve => setTimeout(resolve, 200));
@@ -222,11 +212,7 @@ describe('SharedTask (WebSocket)', () => {
     test('cancelSharedTask cancels a running task', async () => {
         // We need to discover the taskId from the broadcast since startSharedWork is void.
         // Start a long-running task WITHOUT awaiting (it blocks until done).
-        const workDone = startSharedWork(client, {
-            title: 'Cancel Test',
-            steps: ['Slow1', 'Slow2', 'Slow3', 'Slow4', 'Slow5'],
-            delay: 500,
-        });
+        const workDone = startSharedWork(client, 'Cancel Test', ['Slow1', 'Slow2', 'Slow3', 'Slow4', 'Slow5'], 500);
 
         // Wait for the task to appear in a TaskStateEvent broadcast
         const taskId = await new Promise<string>((resolve, reject) => {
@@ -270,11 +256,7 @@ describe('SharedTask (WebSocket)', () => {
 
     test('late joiner receives active shared tasks', async () => {
         // Start a long-running shared task from client 1 WITHOUT awaiting
-        const workDone = startSharedWork(client, {
-            title: 'Late Join Test',
-            steps: ['Long1', 'Long2', 'Long3'],
-            delay: 300,
-        });
+        const workDone = startSharedWork(client, 'Late Join Test', ['Long1', 'Long2', 'Long3'], 300);
 
         // Wait for the task to appear in broadcasts
         const taskId = await new Promise<string>((resolve, reject) => {

--- a/e2e/tests/ws.test.ts
+++ b/e2e/tests/ws.test.ts
@@ -16,29 +16,29 @@ describe('WebSocket Transport', () => {
     });
 
     test('createUser returns id, name, email', async () => {
-        const res = await createUser(client, { name: 'Alice', email: 'alice@test.com' });
+        const res = await createUser(client, 'Alice', 'alice@test.com');
         expect(res.id).toBeDefined();
         expect(res.name).toBe('Alice');
         expect(res.email).toBe('alice@test.com');
     });
 
     test('getUser returns created user', async () => {
-        const created = await createUser(client, { name: 'Bob', email: 'bob@test.com' });
-        const user = await getUser(client, { id: created.id });
+        const created = await createUser(client, 'Bob', 'bob@test.com');
+        const user = await getUser(client, created.id);
         expect(user.id).toBe(created.id);
         expect(user.name).toBe('Bob');
         expect(user.email).toBe('bob@test.com');
     });
 
     test('listUsers returns array', async () => {
-        await createUser(client, { name: 'Carol', email: 'carol@test.com' });
+        await createUser(client, 'Carol', 'carol@test.com');
         const res = await listUsers(client);
         expect(Array.isArray(res.users)).toBe(true);
         expect(res.users.length).toBeGreaterThanOrEqual(1);
     });
 
     test('getTask returns enum status field', async () => {
-        const task = await getTask(client, { id: 'task-1' });
+        const task = await getTask(client, 'task-1');
         expect(task.id).toBe('task-1');
         expect(task.name).toBe('Example Task');
         expect(task.status).toBe(TaskStatus.Running);
@@ -48,7 +48,8 @@ describe('WebSocket Transport', () => {
         const progressUpdates: { current: number; total: number; message: string }[] = [];
         const res = await processBatch(
             client,
-            { items: ['a', 'b', 'c'], delay: 50 },
+            ['a', 'b', 'c'],
+            50,
             {
                 onProgress: (current, total, message) => {
                     progressUpdates.push({ current, total, message });
@@ -66,7 +67,8 @@ describe('WebSocket Transport', () => {
         const controller = new AbortController();
         const promise = processBatch(
             client,
-            { items: ['a', 'b', 'c', 'd', 'e'], delay: 200 },
+            ['a', 'b', 'c', 'd', 'e'],
+            200,
             { signal: controller.signal },
         );
 
@@ -82,7 +84,7 @@ describe('WebSocket Transport', () => {
             });
         });
 
-        await sendNotification(client, { message: 'hello', level: 'info' });
+        await sendNotification(client, 'hello', 'info');
 
         const event = await received;
         expect(event.message).toBe('hello');
@@ -100,7 +102,7 @@ describe('WebSocket Transport', () => {
                 });
             });
 
-            const created = await createUser(client, { name: 'Dave', email: 'dave@test.com' });
+            const created = await createUser(client, 'Dave', 'dave@test.com');
 
             const event = await received;
             expect(event.id).toBe(created.id);
@@ -113,7 +115,7 @@ describe('WebSocket Transport', () => {
 
     test('createUser with empty name throws ApiError with isInvalidParams', async () => {
         try {
-            await createUser(client, { name: '', email: 'bad@test.com' });
+            await createUser(client, '', 'bad@test.com');
             expect.fail('Should have thrown');
         } catch (err) {
             expect(err).toBeInstanceOf(ApiError);
@@ -123,7 +125,7 @@ describe('WebSocket Transport', () => {
 
     test('unknown method throws ApiError with isNotFound', async () => {
         try {
-            await client.request('NonExistent', {});
+            await client.request('NonExistent', []);
             expect.fail('Should have thrown');
         } catch (err) {
             expect(err).toBeInstanceOf(ApiError);


### PR DESCRIPTION
## Summary
- Update all E2E test call sites (`ws.test.ts`, `sse.test.ts`, `auth.test.ts`, `tasks.test.ts`) to use positional args instead of request objects, matching the flattened handler signatures from #91
- Fix `client.request('NonExistent', {})` → `client.request('NonExistent', [])` to match updated params type
- Regenerated E2E TypeScript client (gitignored, not committed)

## Test plan
- [x] `go test ./...` passes
- [x] `npm test` in `e2e/` — all 33 tests pass across 5 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)