### PR TITLE
Unify shared and non-shared task types

### DIFF
--- a/example/vanilla/api/handlers.go
+++ b/example/vanilla/api/handlers.go
@@ -269,7 +269,7 @@ func (h *PublicHandlers) StartSharedWork(ctx context.Context, title string, step
 		delay = 50
 	}
 
-	ctx, task := tasks.StartSharedTask[TaskMeta](ctx, title)
+	ctx, task := tasks.StartTask[TaskMeta](ctx, title, tasks.Shared())
 	if task == nil {
 		return aprot.ErrInternal(nil)
 	}
@@ -289,7 +289,7 @@ func (h *PublicHandlers) StartSharedWork(ctx context.Context, title string, step
 		sub := task.SubTask(step)
 		task.Output(fmt.Sprintf("Working on: %s", step))
 		time.Sleep(time.Duration(delay) * time.Millisecond)
-		sub.Complete()
+		sub.Close()
 		task.Progress(i+1, len(steps))
 	}
 	return nil

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -3,260 +3,27 @@ package tasks
 import (
 	"context"
 	"io"
-	"time"
 
 	"github.com/marrasen/aprot"
 )
 
-// SubTask creates a child task under the current task node, runs fn, and marks
-// the sub-task as completed (or failed if fn returns an error).
-//
-// When a sharedContext is present on ctx, SubTask routes through the shared
-// task system only (broadcast to all clients). Otherwise it uses the
-// request-scoped task tree (visible only to the requesting client).
-func SubTask(ctx context.Context, title string, fn func(ctx context.Context) error) error {
-	sc := sharedCtxFromContext(ctx)
-	if sc != nil {
-		return sharedSubTaskInner(ctx, sc, title, fn)
-	}
+// TaskOption configures a task created by StartTask.
+type TaskOption func(*taskOptions)
 
-	tree := taskTreeFromContext(ctx)
-	if tree == nil {
-		return fn(ctx)
-	}
-
-	parent := taskNodeFromContext(ctx)
-
-	tree.mu.Lock()
-	root := tree.ensureRoot()
-	tree.mu.Unlock()
-
-	if parent == nil {
-		parent = root
-	}
-
-	child := &taskNode{
-		tree:   tree,
-		id:     tree.allocID(),
-		title:  title,
-		status: TaskNodeStatusCreated,
-	}
-	parent.addChild(child)
-	tree.send()
-
-	child.setStatus(TaskNodeStatusRunning)
-	childCtx := withTaskNode(ctx, child)
-	err := fn(childCtx)
-
-	if err != nil {
-		child.setFailed(err.Error())
-	} else {
-		child.setStatus(TaskNodeStatusCompleted)
-	}
-	tree.send()
-
-	return err
+type taskOptions struct {
+	shared bool
 }
 
-// sharedSubTaskInner handles SubTask when a shared context is present.
-func sharedSubTaskInner(ctx context.Context, sc *sharedContext, title string, fn func(ctx context.Context) error) error {
-	var sharedNode *sharedTaskNode
-	if sc.node != nil {
-		sharedNode = sc.node.subTask(sc.core, title)
-	} else {
-		sharedNode = sc.core.subTask(title)
-	}
-
-	childCtx := withSharedContext(ctx, &sharedContext{core: sc.core, node: sharedNode})
-	err := fn(childCtx)
-
-	sharedNode.mu.Lock()
-	if err != nil {
-		sharedNode.status = TaskNodeStatusFailed
-		sharedNode.error = err.Error()
-	} else {
-		sharedNode.status = TaskNodeStatusCompleted
-	}
-	sharedNode.mu.Unlock()
-	sc.core.manager.broadcastNow()
-
-	return err
-}
-
-// Output sends a text output message attached to the nearest task node.
-func Output(ctx context.Context, msg string) {
-	if sc := sharedCtxFromContext(ctx); sc != nil {
-		nodeID := sc.core.id
-		if sc.node != nil {
-			nodeID = sc.node.id
-		}
-		sc.core.manager.sendUpdate(nodeID, &msg, nil, nil)
-		return
-	}
-	tree := taskTreeFromContext(ctx)
-	if tree != nil {
-		taskID := ""
-		if node := taskNodeFromContext(ctx); node != nil {
-			taskID = node.id
-		}
-		tree.sender.SendJSON(taskNodeOutputMessage{
-			Type:   aprot.TypeProgress,
-			ID:     tree.sender.RequestID(),
-			TaskID: taskID,
-			Output: msg,
-		})
+// Shared makes the task visible to all connected clients (broadcast).
+// Without this option, the task is only visible to the requesting client.
+func Shared() TaskOption {
+	return func(o *taskOptions) {
+		o.shared = true
 	}
 }
 
-// TaskProgress sets the progress (current/total) on the current task node.
-func TaskProgress(ctx context.Context, current, total int) {
-	if sc := sharedCtxFromContext(ctx); sc != nil && sc.node != nil {
-		sc.node.mu.Lock()
-		sc.node.current = current
-		sc.node.total = total
-		sc.node.mu.Unlock()
-		sc.core.manager.sendUpdate(sc.node.id, nil, &current, &total)
-		return
-	}
-	node := taskNodeFromContext(ctx)
-	if node != nil {
-		node.setProgress(current, total)
-		tree := node.tree
-		tree.sender.SendJSON(taskNodeProgressMessage{
-			Type:    aprot.TypeProgress,
-			ID:      tree.sender.RequestID(),
-			TaskID:  node.id,
-			Current: current,
-			Total:   total,
-		})
-	}
-}
-
-// StepTaskProgress increments the current progress on the current task node by step.
-func StepTaskProgress(ctx context.Context, step int) {
-	if sc := sharedCtxFromContext(ctx); sc != nil && sc.node != nil {
-		sc.node.mu.Lock()
-		sc.node.current += step
-		current := sc.node.current
-		total := sc.node.total
-		sc.node.mu.Unlock()
-		sc.core.manager.sendUpdate(sc.node.id, nil, &current, &total)
-		return
-	}
-	node := taskNodeFromContext(ctx)
-	if node != nil {
-		current, total := node.stepProgress(step)
-		tree := node.tree
-		tree.sender.SendJSON(taskNodeProgressMessage{
-			Type:    aprot.TypeProgress,
-			ID:      tree.sender.RequestID(),
-			TaskID:  node.id,
-			Current: current,
-			Total:   total,
-		})
-	}
-}
-
-// OutputWriter returns an io.WriteCloser that creates a child task node
-// and sends each Write as output attached to that node.
-func OutputWriter(ctx context.Context, title string) io.WriteCloser {
-	if sc := sharedCtxFromContext(ctx); sc != nil {
-		var node *sharedTaskNode
-		if sc.node != nil {
-			node = sc.node.subTask(sc.core, title)
-		} else {
-			node = sc.core.subTask(title)
-		}
-		return &sharedOutputWriter{core: sc.core, node: node}
-	}
-
-	tree := taskTreeFromContext(ctx)
-	if tree == nil {
-		return discardWriteCloser{}
-	}
-
-	parent := taskNodeFromContext(ctx)
-
-	tree.mu.Lock()
-	root := tree.ensureRoot()
-	tree.mu.Unlock()
-
-	if parent == nil {
-		parent = root
-	}
-
-	child := &taskNode{
-		tree:   tree,
-		id:     tree.allocID(),
-		title:  title,
-		status: TaskNodeStatusCreated,
-	}
-	parent.addChild(child)
-	tree.send()
-
-	child.setStatus(TaskNodeStatusRunning)
-	return &taskOutputWriter{
-		tree: tree,
-		node: child,
-	}
-}
-
-// WriterProgress returns an io.WriteCloser that creates a child task node
-// tracking bytes written as progress (current/total).
-func WriterProgress(ctx context.Context, title string, size int) io.WriteCloser {
-	if sc := sharedCtxFromContext(ctx); sc != nil {
-		var node *sharedTaskNode
-		if sc.node != nil {
-			node = sc.node.subTask(sc.core, title)
-		} else {
-			node = sc.core.subTask(title)
-		}
-		node.mu.Lock()
-		node.total = size
-		node.mu.Unlock()
-		return &sharedProgressWriter{
-			core:     sc.core,
-			node:     node,
-			total:    size,
-			lastSend: time.Now(),
-		}
-	}
-
-	tree := taskTreeFromContext(ctx)
-	if tree == nil {
-		return discardWriteCloser{}
-	}
-
-	parent := taskNodeFromContext(ctx)
-
-	tree.mu.Lock()
-	root := tree.ensureRoot()
-	tree.mu.Unlock()
-
-	if parent == nil {
-		parent = root
-	}
-
-	child := &taskNode{
-		tree:   tree,
-		id:     tree.allocID(),
-		title:  title,
-		status: TaskNodeStatusCreated,
-		total:  size,
-	}
-	parent.addChild(child)
-	tree.send()
-
-	child.setStatus(TaskNodeStatusRunning)
-	return &taskProgressWriter{
-		tree:     tree,
-		node:     child,
-		total:    size,
-		lastSend: time.Now(),
-	}
-}
-
-// Task is a type-safe, generic wrapper around a request-scoped task node.
+// Task is a type-safe, generic wrapper around a task node.
+// It works for both request-scoped and shared tasks.
 type Task[M any] struct {
 	node *taskNode
 }
@@ -268,15 +35,7 @@ func (t *Task[M]) ID() string {
 
 // Progress updates the task's progress counters.
 func (t *Task[M]) Progress(current, total int) {
-	t.node.setProgress(current, total)
-	tree := t.node.tree
-	tree.sender.SendJSON(taskNodeProgressMessage{
-		Type:    aprot.TypeProgress,
-		ID:      tree.sender.RequestID(),
-		TaskID:  t.node.id,
-		Current: current,
-		Total:   total,
-	})
+	t.node.progress(current, total)
 }
 
 // SetMeta sets typed metadata on the task.
@@ -284,19 +43,32 @@ func (t *Task[M]) SetMeta(v M) {
 	t.node.mu.Lock()
 	t.node.meta = v
 	t.node.mu.Unlock()
-	t.node.tree.send()
+	t.node.delivery.sendSnapshot(nil)
+}
+
+// Output sends output text associated with this task.
+func (t *Task[M]) Output(msg string) {
+	t.node.output(msg)
 }
 
 // Close marks the task as completed.
 func (t *Task[M]) Close() {
-	t.node.setStatus(TaskNodeStatusCompleted)
-	t.node.tree.send()
+	if t.node.IsShared() {
+		t.node.completeTop()
+	} else {
+		t.node.setStatus(TaskNodeStatusCompleted)
+		t.node.delivery.sendSnapshot(nil)
+	}
 }
 
 // Fail marks the task as failed with the given error message.
 func (t *Task[M]) Fail(message string) {
-	t.node.setFailed(message)
-	t.node.tree.send()
+	if t.node.IsShared() {
+		t.node.failTop(message)
+	} else {
+		t.node.setFailed(message)
+		t.node.delivery.sendSnapshot(nil)
+	}
 }
 
 // Err fails the task with err.Error() if err is non-nil, or completes it if nil.
@@ -308,38 +80,237 @@ func (t *Task[M]) Err(err error) {
 	}
 }
 
-// StartTask creates a request-scoped task visible to the calling client.
-func StartTask[M any](ctx context.Context, title string) (context.Context, *Task[M]) {
-	tree := taskTreeFromContext(ctx)
-	if tree == nil {
+// SubTask creates a child node under this task.
+func (t *Task[M]) SubTask(title string) *TaskSub[M] {
+	child := t.node.createChild(title)
+	return &TaskSub[M]{node: child}
+}
+
+// Context returns the task's context (for shared tasks, the cancellable task context).
+func (t *Task[M]) Context() context.Context {
+	if t.node.ctx != nil {
+		return t.node.ctx
+	}
+	return context.Background()
+}
+
+// WithContext returns a new context that carries this task's delivery and node.
+func (t *Task[M]) WithContext(ctx context.Context) context.Context {
+	ctx = withDelivery(ctx, t.node.delivery)
+	return withTaskNode(ctx, t.node)
+}
+
+// IsShared returns true if this task broadcasts to all clients.
+func (t *Task[M]) IsShared() bool {
+	return t.node.IsShared()
+}
+
+// TaskSub is a type-safe, generic child node of a Task.
+type TaskSub[M any] struct {
+	node *taskNode
+}
+
+// Close marks this sub-task as completed.
+func (s *TaskSub[M]) Close() {
+	s.node.closeNode()
+}
+
+// Fail marks this sub-task as failed with the given error message.
+func (s *TaskSub[M]) Fail(message string) {
+	s.node.failNode(message)
+}
+
+// Err fails the sub-task with err.Error() if err is non-nil, or completes it if nil.
+func (s *TaskSub[M]) Err(err error) {
+	if err != nil {
+		s.Fail(err.Error())
+	} else {
+		s.Close()
+	}
+}
+
+// SetMeta sets typed metadata on this sub-task node.
+func (s *TaskSub[M]) SetMeta(v M) {
+	s.node.mu.Lock()
+	s.node.meta = v
+	s.node.mu.Unlock()
+	s.node.delivery.sendSnapshot(nil)
+}
+
+// SubTask creates a child node under this sub-task.
+func (s *TaskSub[M]) SubTask(title string) *TaskSub[M] {
+	child := s.node.createChild(title)
+	return &TaskSub[M]{node: child}
+}
+
+// Progress updates the sub-task's progress.
+func (s *TaskSub[M]) Progress(current, total int) {
+	s.node.progress(current, total)
+}
+
+// SubTask creates a child task under the current task node, runs fn, and marks
+// the sub-task as completed (or failed if fn returns an error).
+func SubTask(ctx context.Context, title string, fn func(ctx context.Context) error) error {
+	node := taskNodeFromContext(ctx)
+	d := deliveryFromContext(ctx)
+
+	if d == nil {
+		return fn(ctx)
+	}
+
+	var parent *taskNode
+	if node != nil {
+		parent = node
+	} else if rd, ok := d.(*requestDelivery); ok {
+		parent = ensureRoot(rd)
+	} else {
+		// Shared delivery without a node — shouldn't normally happen,
+		// but handle gracefully.
+		return fn(ctx)
+	}
+
+	child := parent.createChild(title)
+	childCtx := withTaskNode(ctx, child)
+	err := fn(childCtx)
+
+	if err != nil {
+		child.failNode(err.Error())
+	} else {
+		child.closeNode()
+	}
+
+	return err
+}
+
+// Output sends a text output message attached to the nearest task node.
+func Output(ctx context.Context, msg string) {
+	node := taskNodeFromContext(ctx)
+	if node != nil {
+		node.output(msg)
+		return
+	}
+	d := deliveryFromContext(ctx)
+	if d == nil {
+		return
+	}
+	// No node but have delivery — send with empty task ID for request-scoped.
+	if !d.isShared() {
+		d.sendOutput("", msg)
+	}
+}
+
+// TaskProgress sets the progress (current/total) on the current task node.
+func TaskProgress(ctx context.Context, current, total int) {
+	node := taskNodeFromContext(ctx)
+	if node != nil {
+		node.progress(current, total)
+	}
+}
+
+// StepTaskProgress increments the current progress on the current task node by step.
+func StepTaskProgress(ctx context.Context, step int) {
+	node := taskNodeFromContext(ctx)
+	if node != nil {
+		cur, tot := node.stepProgress(step)
+		node.delivery.sendProgress(node.id, cur, tot)
+	}
+}
+
+// OutputWriter returns an io.WriteCloser that creates a child task node
+// and sends each Write as output attached to that node.
+func OutputWriter(ctx context.Context, title string) io.WriteCloser {
+	node := taskNodeFromContext(ctx)
+	d := deliveryFromContext(ctx)
+
+	if d == nil {
+		return discardWriteCloser{}
+	}
+
+	var parent *taskNode
+	if node != nil {
+		parent = node
+	} else if rd, ok := d.(*requestDelivery); ok {
+		parent = ensureRoot(rd)
+	} else {
+		return discardWriteCloser{}
+	}
+
+	child := parent.createChild(title)
+	return &outputWriter{node: child}
+}
+
+// WriterProgress returns an io.WriteCloser that creates a child task node
+// tracking bytes written as progress (current/total).
+func WriterProgress(ctx context.Context, title string, size int) io.WriteCloser {
+	node := taskNodeFromContext(ctx)
+	d := deliveryFromContext(ctx)
+
+	if d == nil {
+		return discardWriteCloser{}
+	}
+
+	var parent *taskNode
+	if node != nil {
+		parent = node
+	} else if rd, ok := d.(*requestDelivery); ok {
+		parent = ensureRoot(rd)
+	} else {
+		return discardWriteCloser{}
+	}
+
+	child := parent.createChild(title)
+	child.mu.Lock()
+	child.total = size
+	child.mu.Unlock()
+	return &progressWriter{node: child, total: size}
+}
+
+// StartTask creates a task. By default it is request-scoped (visible only to
+// the calling client). Pass Shared() to make it visible to all clients.
+func StartTask[M any](ctx context.Context, title string, opts ...TaskOption) (context.Context, *Task[M]) {
+	var o taskOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	if o.shared {
+		return startSharedTask[M](ctx, title)
+	}
+	return startRequestTask[M](ctx, title)
+}
+
+func startRequestTask[M any](ctx context.Context, title string) (context.Context, *Task[M]) {
+	d := deliveryFromContext(ctx)
+	if d == nil {
+		return ctx, nil
+	}
+	rd, ok := d.(*requestDelivery)
+	if !ok {
 		return ctx, nil
 	}
 
-	tree.mu.Lock()
-	root := tree.ensureRoot()
-	tree.mu.Unlock()
+	root := ensureRoot(rd)
 
 	node := &taskNode{
-		tree:   tree,
-		id:     tree.allocID(),
-		title:  title,
-		status: TaskNodeStatusCreated,
+		delivery: d,
+		id:       d.allocID(),
+		title:    title,
+		status:   TaskNodeStatusCreated,
 	}
 	root.addChild(node)
 
 	if slot := taskSlotFromContext(ctx); slot != nil {
-		slot.taskNode = node
+		slot.node = node
 	}
 
 	ctx = withTaskNode(ctx, node)
-	tree.send()
+	d.sendSnapshot(nil)
 
 	node.setStatus(TaskNodeStatusRunning)
 	return ctx, &Task[M]{node: node}
 }
 
-// StartSharedTask creates a new shared task visible to all clients.
-func StartSharedTask[M any](ctx context.Context, title string) (context.Context, *SharedTask[M]) {
+func startSharedTask[M any](ctx context.Context, title string) (context.Context, *Task[M]) {
 	conn := aprot.Connection(ctx)
 	if conn == nil {
 		return ctx, nil
@@ -348,24 +319,27 @@ func StartSharedTask[M any](ctx context.Context, title string) (context.Context,
 	if tm == nil {
 		return ctx, nil
 	}
-	core := tm.create(title, conn.ID(), true, ctx)
+	node := tm.create(title, conn.ID(), true, ctx)
 	tm.broadcastNow() // first message shows CREATED
-	core.mu.Lock()
-	core.status = TaskNodeStatusRunning
-	core.mu.Unlock()
+	node.mu.Lock()
+	node.status = TaskNodeStatusRunning
+	node.mu.Unlock()
 
 	if slot := taskSlotFromContext(ctx); slot != nil {
-		slot.sharedCore = core
+		slot.node = node
 	}
 
-	ctx = withSharedContext(core.ctx, &sharedContext{core: core})
+	// Use the task's own cancellable context, with delivery and node set.
+	taskCtx := withDelivery(node.ctx, node.delivery)
+	taskCtx = withTaskNode(taskCtx, node)
 
-	return ctx, &SharedTask[M]{core: core}
+	return taskCtx, &Task[M]{node: node}
 }
 
 // SharedSubTask bridges the request-scoped and shared task systems.
 func SharedSubTask(ctx context.Context, title string, fn func(ctx context.Context) error) error {
-	if sc := sharedCtxFromContext(ctx); sc != nil {
+	// If already in a shared context (node is shared), route through SubTask.
+	if node := taskNodeFromContext(ctx); node != nil && node.IsShared() {
 		return SubTask(ctx, title, fn)
 	}
 
@@ -379,20 +353,21 @@ func SharedSubTask(ctx context.Context, title string, fn func(ctx context.Contex
 		return SubTask(ctx, title, fn)
 	}
 
-	core := tm.create(title, conn.ID(), false, ctx)
+	node := tm.create(title, conn.ID(), false, ctx)
 	tm.broadcastNow() // first message shows CREATED
-	core.mu.Lock()
-	core.status = TaskNodeStatusRunning
-	core.mu.Unlock()
-	sc := &sharedContext{core: core}
-	childCtx := withSharedContext(core.ctx, sc)
+	node.mu.Lock()
+	node.status = TaskNodeStatusRunning
+	node.mu.Unlock()
+
+	childCtx := withDelivery(node.ctx, node.delivery)
+	childCtx = withTaskNode(childCtx, node)
 
 	err := SubTask(childCtx, title, fn)
 
 	if err != nil {
-		core.fail(err.Error())
+		node.failTop(err.Error())
 	} else {
-		core.closeTask()
+		node.completeTop()
 	}
 
 	return err

--- a/tasks/context.go
+++ b/tasks/context.go
@@ -5,19 +5,23 @@ import "context"
 type contextKey int
 
 const (
-	taskTreeKey contextKey = iota
+	deliveryKey    contextKey = iota
 	taskNodeKey
-	sharedContextKey
 	taskSlotKey
 	taskManagerKey
 )
 
-// taskTreeFromContext returns the taskTree from the context.
-func taskTreeFromContext(ctx context.Context) *taskTree {
-	if t, ok := ctx.Value(taskTreeKey).(*taskTree); ok {
-		return t
+// deliveryFromContext returns the taskDelivery from the context.
+func deliveryFromContext(ctx context.Context) taskDelivery {
+	if d, ok := ctx.Value(deliveryKey).(taskDelivery); ok {
+		return d
 	}
 	return nil
+}
+
+// withDelivery returns a context with the given delivery.
+func withDelivery(ctx context.Context, d taskDelivery) context.Context {
+	return context.WithValue(ctx, deliveryKey, d)
 }
 
 // taskNodeFromContext returns the current taskNode from the context.
@@ -28,35 +32,16 @@ func taskNodeFromContext(ctx context.Context) *taskNode {
 	return nil
 }
 
-// withTaskTree returns a context with the given task tree.
-func withTaskTree(ctx context.Context, t *taskTree) context.Context {
-	return context.WithValue(ctx, taskTreeKey, t)
-}
-
 // withTaskNode returns a context with the given task node.
 func withTaskNode(ctx context.Context, n *taskNode) context.Context {
 	return context.WithValue(ctx, taskNodeKey, n)
 }
 
-// sharedCtxFromContext returns the sharedContext from the context.
-func sharedCtxFromContext(ctx context.Context) *sharedContext {
-	if sc, ok := ctx.Value(sharedContextKey).(*sharedContext); ok {
-		return sc
-	}
-	return nil
-}
-
-// withSharedContext returns a context with the given shared context.
-func withSharedContext(ctx context.Context, sc *sharedContext) context.Context {
-	return context.WithValue(ctx, sharedContextKey, sc)
-}
-
 // taskSlot is a mutable slot placed on the context by the task middleware.
-// StartTask and StartSharedTask populate it so the middleware can detect
-// inline tasks after the handler returns and auto-manage their lifecycle.
+// StartTask populates it so the middleware can detect inline tasks after the
+// handler returns and auto-manage their lifecycle.
 type taskSlot struct {
-	sharedCore *sharedTaskCore
-	taskNode   *taskNode
+	node *taskNode // inline task (shared or request-scoped)
 }
 
 // taskSlotFromContext returns the taskSlot from the context.

--- a/tasks/delivery.go
+++ b/tasks/delivery.go
@@ -1,0 +1,113 @@
+package tasks
+
+import (
+	"sync/atomic"
+
+	"github.com/marrasen/aprot"
+)
+
+// taskDelivery abstracts how task state updates are delivered to clients.
+// requestDelivery sends to a single client; sharedDelivery broadcasts to all.
+type taskDelivery interface {
+	sendSnapshot(root *taskNode)
+	sendOutput(taskID, msg string)
+	sendProgress(taskID string, current, total int)
+	onComplete(node *taskNode)
+	onFail(node *taskNode)
+	allocID() string
+	isShared() bool
+}
+
+// requestDelivery sends task updates to a single requesting client.
+type requestDelivery struct {
+	sender aprot.RequestSender
+	nextID atomic.Int64
+	root   *taskNode // lazily created implicit root
+}
+
+func newRequestDelivery(sender aprot.RequestSender) *requestDelivery {
+	return &requestDelivery{sender: sender}
+}
+
+func (d *requestDelivery) sendSnapshot(_ *taskNode) {
+	if d.root == nil {
+		return
+	}
+	nodes := d.root.snapshotChildren()
+	if nodes != nil {
+		d.sender.SendJSON(taskTreeMessage{
+			Type:  aprot.TypeProgress,
+			ID:    d.sender.RequestID(),
+			Tasks: nodes,
+		})
+	}
+}
+
+func (d *requestDelivery) sendOutput(taskID, msg string) {
+	d.sender.SendJSON(taskNodeOutputMessage{
+		Type:   aprot.TypeProgress,
+		ID:     d.sender.RequestID(),
+		TaskID: taskID,
+		Output: msg,
+	})
+}
+
+func (d *requestDelivery) sendProgress(taskID string, current, total int) {
+	d.sender.SendJSON(taskNodeProgressMessage{
+		Type:    aprot.TypeProgress,
+		ID:      d.sender.RequestID(),
+		TaskID:  taskID,
+		Current: current,
+		Total:   total,
+	})
+}
+
+func (d *requestDelivery) onComplete(node *taskNode) {
+	node.setStatus(TaskNodeStatusCompleted)
+}
+
+func (d *requestDelivery) onFail(node *taskNode) {
+	// status and error already set by caller
+}
+
+func (d *requestDelivery) allocID() string {
+	n := d.nextID.Add(1)
+	return "t" + itoa(n)
+}
+
+func (d *requestDelivery) isShared() bool { return false }
+
+// sharedDelivery broadcasts task updates to all connected clients.
+type sharedDelivery struct {
+	manager *taskManager
+}
+
+func newSharedDelivery(manager *taskManager) *sharedDelivery {
+	return &sharedDelivery{manager: manager}
+}
+
+func (d *sharedDelivery) sendSnapshot(_ *taskNode) {
+	d.manager.broadcastNow()
+}
+
+func (d *sharedDelivery) sendOutput(taskID, msg string) {
+	d.manager.sendUpdate(taskID, &msg, nil, nil)
+}
+
+func (d *sharedDelivery) sendProgress(taskID string, current, total int) {
+	d.manager.sendUpdate(taskID, nil, &current, &total)
+}
+
+func (d *sharedDelivery) onComplete(node *taskNode) {
+	node.setStatus(TaskNodeStatusCompleted)
+}
+
+func (d *sharedDelivery) onFail(node *taskNode) {
+	// status and error already set by caller
+}
+
+func (d *sharedDelivery) allocID() string {
+	return d.manager.allocID()
+}
+
+func (d *sharedDelivery) isShared() bool { return true }

--- a/tasks/event_order_test.go
+++ b/tasks/event_order_test.go
@@ -19,7 +19,7 @@ type eventOrderHandler struct {
 }
 
 func (h *eventOrderHandler) StartShared(ctx context.Context, title string) error {
-	_, task := StartSharedTask[struct{}](ctx, title)
+	ctx, task := StartTask[struct{}](ctx, title, Shared())
 	if task == nil {
 		return aprot.NewError(aprot.CodeInternalError, "task not created")
 	}

--- a/tasks/writers.go
+++ b/tasks/writers.go
@@ -3,131 +3,54 @@ package tasks
 import (
 	"io"
 	"time"
-
-	"github.com/marrasen/aprot"
 )
 
-// taskOutputWriter implements io.WriteCloser and sends written data as output
-// attached to a specific task node via the request-scoped progress channel.
-type taskOutputWriter struct {
-	tree *taskTree
+// outputWriter implements io.WriteCloser and sends written data as output
+// attached to a specific task node via its delivery.
+type outputWriter struct {
 	node *taskNode
 }
 
-func (w *taskOutputWriter) Write(p []byte) (int, error) {
+func (w *outputWriter) Write(p []byte) (int, error) {
 	if len(p) > 0 {
-		w.tree.sender.SendJSON(taskNodeOutputMessage{
-			Type:   aprot.TypeProgress,
-			ID:     w.tree.sender.RequestID(),
-			TaskID: w.node.id,
-			Output: string(p),
-		})
+		w.node.output(string(p))
 	}
 	return len(p), nil
 }
 
-func (w *taskOutputWriter) Close() error {
-	w.node.setStatus(TaskNodeStatusCompleted)
-	w.tree.send()
+func (w *outputWriter) Close() error {
+	w.node.closeNode()
 	return nil
 }
 
-// sharedOutputWriter implements io.WriteCloser for output within the shared
-// task system.
-type sharedOutputWriter struct {
-	core *sharedTaskCore
-	node *sharedTaskNode
-}
-
-func (w *sharedOutputWriter) Write(p []byte) (int, error) {
-	if len(p) > 0 {
-		s := string(p)
-		w.core.manager.sendUpdate(w.node.id, &s, nil, nil)
-	}
-	return len(p), nil
-}
-
-func (w *sharedOutputWriter) Close() error {
-	w.node.mu.Lock()
-	w.node.status = TaskNodeStatusCompleted
-	w.node.mu.Unlock()
-	w.core.manager.broadcastNow()
-	return nil
-}
-
-// taskProgressWriter implements io.WriteCloser and tracks bytes as progress
-// via the request-scoped progress channel.
-type taskProgressWriter struct {
-	tree     *taskTree
+// progressWriter implements io.WriteCloser and tracks bytes written as progress
+// via the node's delivery.
+type progressWriter struct {
 	node     *taskNode
 	written  int
 	total    int
 	lastSend time.Time
 }
 
-func (w *taskProgressWriter) Write(p []byte) (int, error) {
+func (w *progressWriter) Write(p []byte) (int, error) {
 	w.written += len(p)
 	w.node.setProgress(w.written, w.total)
 
 	if time.Since(w.lastSend) >= 100*time.Millisecond {
-		w.tree.sender.SendJSON(taskNodeProgressMessage{
-			Type:    aprot.TypeProgress,
-			ID:      w.tree.sender.RequestID(),
-			TaskID:  w.node.id,
-			Current: w.written,
-			Total:   w.total,
-		})
+		w.node.delivery.sendProgress(w.node.id, w.written, w.total)
 		w.lastSend = time.Now()
 	}
 
 	return len(p), nil
 }
 
-func (w *taskProgressWriter) Close() error {
+func (w *progressWriter) Close() error {
 	w.node.setProgress(w.written, w.total)
-	w.node.setStatus(TaskNodeStatusCompleted)
-	w.tree.send()
+	w.node.closeNode()
 	return nil
 }
 
-// sharedProgressWriter implements io.WriteCloser for byte-tracking progress
-// within the shared task system.
-type sharedProgressWriter struct {
-	core     *sharedTaskCore
-	node     *sharedTaskNode
-	written  int
-	total    int
-	lastSend time.Time
-}
-
-func (w *sharedProgressWriter) Write(p []byte) (int, error) {
-	w.written += len(p)
-	w.node.mu.Lock()
-	w.node.current = w.written
-	w.node.total = w.total
-	w.node.mu.Unlock()
-
-	if time.Since(w.lastSend) >= 100*time.Millisecond {
-		current := w.written
-		total := w.total
-		w.core.manager.sendUpdate(w.node.id, nil, &current, &total)
-		w.lastSend = time.Now()
-	}
-
-	return len(p), nil
-}
-
-func (w *sharedProgressWriter) Close() error {
-	w.node.mu.Lock()
-	w.node.current = w.written
-	w.node.total = w.total
-	w.node.status = TaskNodeStatusCompleted
-	w.node.mu.Unlock()
-	w.core.manager.broadcastNow()
-	return nil
-}
-
-// discardWriteCloser is a no-op WriteCloser for when no task tree is present.
+// discardWriteCloser is a no-op WriteCloser for when no delivery is present.
 type discardWriteCloser struct{}
 
 func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
@@ -135,9 +58,7 @@ func (discardWriteCloser) Close() error                 { return nil }
 
 // Ensure interface compliance at compile time.
 var (
-	_ io.WriteCloser = (*taskOutputWriter)(nil)
-	_ io.WriteCloser = (*sharedOutputWriter)(nil)
-	_ io.WriteCloser = (*taskProgressWriter)(nil)
-	_ io.WriteCloser = (*sharedProgressWriter)(nil)
+	_ io.WriteCloser = (*outputWriter)(nil)
+	_ io.WriteCloser = (*progressWriter)(nil)
 	_ io.WriteCloser = discardWriteCloser{}
 )


### PR DESCRIPTION
## Summary

Closes #96

- Replace dual type system (`Task[M]` + `SharedTask[M]`/`SharedTaskSub[M]`) with a single `Task[M]` that accepts a `Shared()` option
- Extract delivery behavior behind a `taskDelivery` interface: `requestDelivery` (single client) and `sharedDelivery` (broadcast)
- Merge `taskTree`, `sharedTaskCore`, `sharedTaskNode`, `sharedContext` into unified `taskNode` with delivery field
- Reduce 4 writer types to 2, eliminate all shared-vs-request branching in free functions
- Net reduction of ~185 lines with zero wire protocol changes

### API change
```go
// Before
ctx, task := tasks.StartSharedTask[Meta](ctx, title)
sub := task.SubTask("step")
sub.Complete()

// After  
ctx, task := tasks.StartTask[Meta](ctx, title, tasks.Shared())
sub := task.SubTask("step")
sub.Close()
```

## Test plan

- [x] All existing Go tests pass (`go test ./...`)
- [x] TypeScript regenerated — zero diff on generated files
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Smoke test: run react example, trigger shared task from UI, verify broadcast to all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)