### PR TITLE
Fix: remove unused _options parameter from useMutation

### DIFF
--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -776,7 +776,6 @@ export function useQuery<TArgs extends unknown[], TRes>(
 // Generic mutation hook
 export function useMutation<TArgs extends unknown[], TRes>(
     fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>,
-    _options?: UseMutationOptions,
 ): UseMutationResult<TArgs, TRes> {
     const client = useApiClient();
     const [data, setData] = useState<TRes | null>(null);

--- a/templates/client-handler-react.ts.tmpl
+++ b/templates/client-handler-react.ts.tmpl
@@ -65,7 +65,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         (client: ApiClient, signal: AbortSignal) => {{.MethodName}}(client, { signal, onProgress: options?.onProgress }),
         [options?.onProgress],
     );
-    return useMutation(wrappedFn, options);
+    return useMutation(wrappedFn);
 }
 {{- else}}
 export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
@@ -77,7 +77,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         (client: ApiClient, signal: AbortSignal, {{paramDecl .Params}}) => {{.MethodName}}(client, {{paramNames .Params}}, { signal, onProgress: options?.onProgress }),
         [options?.onProgress],
     );
-    return useMutation(wrappedFn, options);
+    return useMutation(wrappedFn);
 }
 {{- end}}
 {{end}}

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -480,7 +480,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         (client: ApiClient, signal: AbortSignal) => {{.MethodName}}(client, { signal, onProgress: options?.onProgress }),
         [options?.onProgress],
     );
-    return useMutation(wrappedFn, options);
+    return useMutation(wrappedFn);
 }
 {{- else}}
 export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
@@ -492,7 +492,7 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
         (client: ApiClient, signal: AbortSignal, {{paramDecl .Params}}) => {{.MethodName}}(client, {{paramNames .Params}}, { signal, onProgress: options?.onProgress }),
         [options?.onProgress],
     );
-    return useMutation(wrappedFn, options);
+    return useMutation(wrappedFn);
 }
 {{- end}}
 {{end}}


### PR DESCRIPTION
## Summary

- Remove unused `_options?: UseMutationOptions` parameter from the `useMutation` generic hook signature
- Remove the second argument from all `useMutation()` call sites in `client-react.ts.tmpl` and `client-handler-react.ts.tmpl`
- Fixes lint error: `'_options' is defined but never used  @typescript-eslint/no-unused-vars`

## Test plan

- [x] `npx tsc --noEmit` passes on regenerated React client
- [x] `go test ./...` passes

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)