### PR TITLE
Docs: add README files for example projects

### DIFF
--- a/example/react/README.md
+++ b/example/react/README.md
@@ -1,0 +1,56 @@
+# React Example
+
+Demonstrates aprot with React hooks. Covers generated `useQuery`/`useMutation`/`usePushEvent` hooks, progress tracking, cancellation, and shared tasks with sub-task hierarchies visible to all connected clients.
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js
+
+## Getting Started
+
+1. **Install client dependencies**
+
+   ```bash
+   cd client && npm install
+   ```
+
+2. **Generate React TypeScript client**
+
+   ```bash
+   cd tools/generate && go run main.go
+   ```
+
+3. **Development** (two terminals)
+
+   Terminal 1 — Go server:
+
+   ```bash
+   cd server && go run .
+   ```
+
+   Terminal 2 — Vite dev server (proxies `/ws` to `:8080`):
+
+   ```bash
+   cd client && npm run dev
+   ```
+
+   Open `http://localhost:5173`
+
+4. **Production**
+
+   ```bash
+   cd client && npm run build
+   cd server && go run .
+   ```
+
+   Open `http://localhost:8080`
+
+## Project Structure
+
+| Directory         | Description                                        |
+| ----------------- | -------------------------------------------------- |
+| `api/`            | Handler definitions, events, and types              |
+| `client/`         | React app (Vite + TypeScript)                       |
+| `server/`         | Go server entry point                               |
+| `tools/generate/` | Code generator for the React TypeScript client      |

--- a/example/vanilla/README.md
+++ b/example/vanilla/README.md
@@ -1,0 +1,58 @@
+# Vanilla TypeScript Example
+
+Demonstrates aprot with plain TypeScript (no framework). Covers authentication, middleware, protected handlers, push events, progress tracking, sub-tasks, and both WebSocket and SSE transports.
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js
+
+## Getting Started
+
+1. **Install client dependencies**
+
+   ```bash
+   cd client && npm install
+   ```
+
+2. **Generate TypeScript client**
+
+   ```bash
+   cd tools/generate && go run main.go
+   ```
+
+3. **Build client**
+
+   ```bash
+   cd client && npm run build
+   ```
+
+   Or use watch mode for development:
+
+   ```bash
+   cd client && npm run watch
+   ```
+
+4. **Run server**
+
+   ```bash
+   cd server && go run .
+   ```
+
+5. **Open** `http://localhost:8080`
+
+## Transports
+
+The server exposes two transports:
+
+- **WebSocket** at `/ws`
+- **SSE** at `/sse`
+
+## Project Structure
+
+| Directory         | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| `api/`            | Handler definitions, middleware, events, and types |
+| `client/`         | TypeScript client app (esbuild)                  |
+| `server/`         | Go server entry point                            |
+| `tools/generate/` | Code generator for the TypeScript client          |


### PR DESCRIPTION
## Summary

- Add `example/vanilla/README.md` — covers prerequisites, setup, transports (WebSocket + SSE), and project structure
- Add `example/react/README.md` — covers prerequisites, setup (dev + production), and project structure

## Test plan

- [ ] Verify instructions work end-to-end for vanilla example
- [ ] Verify instructions work end-to-end for React example

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)