### PR TITLE
Fix slice wrapper types with marshalers resolving to any[]

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -882,6 +882,12 @@ func (g *Generator) goTypeToTS(t reflect.Type) string {
 
 	// Check if the type has a custom JSON/text marshaler that produces a primitive.
 	if mt := g.inferTypeFromMarshalCached(t); mt != nil {
+		// For slice-kind types with marshalers (e.g. NonNilSlice[T]), refine
+		// the element type using Go reflection instead of the zero-value marshal
+		// output, which can only produce any[].
+		if t.Kind() == reflect.Slice && strings.HasSuffix(mt.TSType, "[]") {
+			return g.goTypeToTS(t.Elem()) + "[]"
+		}
 		return mt.TSType
 	}
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -2077,3 +2077,177 @@ func TestGenerateCustomMarshalerTypes(t *testing.T) {
 		t.Error("Expected MarshalerResponse.score to be 'number' (from NumberMarshaler)")
 	}
 }
+
+// Types for TestGenerateMixedMarshalerAndStructFields
+
+// NestedDetail is a plain exported struct (no marshaler).
+type NestedDetail struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type MixedFieldsRequest struct {
+	ID      UUIDLike        `json:"id"`
+	Score   NumberMarshaler `json:"score"`
+	Detail  NestedDetail    `json:"detail"`
+	Details []NestedDetail  `json:"details"`
+}
+
+type MixedFieldsResponse struct {
+	ID      UUIDLike        `json:"id"`
+	Score   NumberMarshaler `json:"score"`
+	Detail  NestedDetail    `json:"detail"`
+	Details []NestedDetail  `json:"details"`
+}
+
+type MixedFieldsHandlers struct{}
+
+func (h *MixedFieldsHandlers) ProcessMixed(ctx context.Context, req *MixedFieldsRequest) (*MixedFieldsResponse, error) {
+	return nil, nil
+}
+
+func TestGenerateMixedMarshalerAndStructFields(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&MixedFieldsHandlers{})
+
+	gen := NewGenerator(registry)
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("GenerateTo failed: %v", err)
+	}
+	out := buf.String()
+
+	// NestedDetail (non-marshaler struct used as field type) MUST generate an interface
+	if !strings.Contains(out, "export interface NestedDetail") {
+		t.Error("expected NestedDetail interface to be generated (plain struct used as field type)")
+	}
+
+	// Extract MixedFieldsRequest interface block to check field types
+	reqStart := strings.Index(out, "interface MixedFieldsRequest")
+	if reqStart == -1 {
+		t.Fatal("MixedFieldsRequest interface not found in output")
+	}
+	reqBlock := out[reqStart:]
+	braceEnd := strings.Index(reqBlock, "}")
+	if braceEnd == -1 {
+		t.Fatal("could not find closing brace for MixedFieldsRequest")
+	}
+	reqBlock = reqBlock[:braceEnd+1]
+
+	// detail field should resolve to NestedDetail, not any
+	if !strings.Contains(reqBlock, "detail: NestedDetail") {
+		t.Errorf("expected MixedFieldsRequest.detail to be 'NestedDetail', got:\n%s", reqBlock)
+	}
+	// details field should resolve to NestedDetail[], not any[]
+	if !strings.Contains(reqBlock, "details: NestedDetail[]") {
+		t.Errorf("expected MixedFieldsRequest.details to be 'NestedDetail[]', got:\n%s", reqBlock)
+	}
+	// id field should resolve to string (UUIDLike marshaler)
+	if !strings.Contains(reqBlock, "id: string") {
+		t.Errorf("expected MixedFieldsRequest.id to be 'string' (from UUIDLike marshaler), got:\n%s", reqBlock)
+	}
+	// score field should resolve to number (NumberMarshaler)
+	if !strings.Contains(reqBlock, "score: number") {
+		t.Errorf("expected MixedFieldsRequest.score to be 'number' (from NumberMarshaler), got:\n%s", reqBlock)
+	}
+
+	// Marshaler types should NOT generate interfaces
+	if strings.Contains(out, "export interface UUIDLike") {
+		t.Error("UUIDLike should not generate an interface — it marshals to string")
+	}
+	if strings.Contains(out, "export interface NumberMarshaler") {
+		t.Error("NumberMarshaler should not generate an interface — it marshals to number")
+	}
+}
+
+// NonNilSlice is a generic wrapper that ensures nil slices marshal as [] not null.
+type NonNilSlice[T any] []T
+
+func (s NonNilSlice[T]) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]T(s))
+}
+
+// Types for TestGenerateSliceMarshalerWrapper
+
+type WrappedSliceRequest struct {
+	ID      UUIDLike                  `json:"id"`
+	Details NonNilSlice[NestedDetail] `json:"details"`
+	Tags    NonNilSlice[string]       `json:"tags"`
+}
+
+type WrappedSliceResponse struct {
+	Items NonNilSlice[NestedDetail] `json:"items"`
+}
+
+type WrappedSliceHandlers struct{}
+
+func (h *WrappedSliceHandlers) ListItems(ctx context.Context, req *WrappedSliceRequest) (*WrappedSliceResponse, error) {
+	return nil, nil
+}
+
+func TestGenerateSliceMarshalerWrapper(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&WrappedSliceHandlers{})
+
+	gen := NewGenerator(registry)
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("GenerateTo failed: %v", err)
+	}
+	out := buf.String()
+
+	// NestedDetail MUST generate an interface even when only used inside NonNilSlice
+	if !strings.Contains(out, "export interface NestedDetail") {
+		t.Error("expected NestedDetail interface to be generated (used as element type in NonNilSlice)")
+	}
+
+	// NonNilSlice itself should NOT generate an interface
+	if strings.Contains(out, "interface NonNilSlice") {
+		t.Error("NonNilSlice should not generate an interface — it's a slice wrapper with a marshaler")
+	}
+
+	// Extract WrappedSliceRequest interface block
+	reqStart := strings.Index(out, "interface WrappedSliceRequest")
+	if reqStart == -1 {
+		t.Fatal("WrappedSliceRequest interface not found in output")
+	}
+	reqBlock := out[reqStart:]
+	braceEnd := strings.Index(reqBlock, "}")
+	if braceEnd == -1 {
+		t.Fatal("could not find closing brace for WrappedSliceRequest")
+	}
+	reqBlock = reqBlock[:braceEnd+1]
+
+	// details field: NonNilSlice[NestedDetail] should resolve to NestedDetail[], not any[]
+	if !strings.Contains(reqBlock, "details: NestedDetail[]") {
+		t.Errorf("expected WrappedSliceRequest.details to be 'NestedDetail[]', got:\n%s", reqBlock)
+	}
+	// tags field: NonNilSlice[string] should resolve to string[], not any[]
+	if !strings.Contains(reqBlock, "tags: string[]") {
+		t.Errorf("expected WrappedSliceRequest.tags to be 'string[]', got:\n%s", reqBlock)
+	}
+	// id field should still resolve to string (UUIDLike marshaler)
+	if !strings.Contains(reqBlock, "id: string") {
+		t.Errorf("expected WrappedSliceRequest.id to be 'string', got:\n%s", reqBlock)
+	}
+
+	// Extract WrappedSliceResponse interface block
+	respStart := strings.Index(out, "interface WrappedSliceResponse")
+	if respStart == -1 {
+		t.Fatal("WrappedSliceResponse interface not found in output")
+	}
+	respBlock := out[respStart:]
+	braceEnd = strings.Index(respBlock, "}")
+	if braceEnd == -1 {
+		t.Fatal("could not find closing brace for WrappedSliceResponse")
+	}
+	respBlock = respBlock[:braceEnd+1]
+
+	// items field: NonNilSlice[NestedDetail] should resolve to NestedDetail[], not any[]
+	if !strings.Contains(respBlock, "items: NestedDetail[]") {
+		t.Errorf("expected WrappedSliceResponse.items to be 'NestedDetail[]', got:\n%s", respBlock)
+	}
+}

--- a/tasks/codegen.go
+++ b/tasks/codegen.go
@@ -170,6 +170,12 @@ func goTypeToTS(t reflect.Type) string {
 
 	// Check if the type has a custom JSON/text marshaler that produces a primitive.
 	if mt := aprot.InferTypeFromMarshal(t); mt != nil {
+		// For slice-kind types with marshalers (e.g. NonNilSlice[T]), refine
+		// the element type using Go reflection instead of the zero-value marshal
+		// output, which can only produce any[].
+		if t.Kind() == reflect.Slice && strings.HasSuffix(mt.TSType, "[]") {
+			return goTypeToTS(t.Elem()) + "[]"
+		}
 		return mt.TSType
 	}
 

--- a/tasks/generate_test.go
+++ b/tasks/generate_test.go
@@ -366,3 +366,119 @@ func TestGenerateWithMetaCustomMarshal(t *testing.T) {
 		t.Error("expected MetaWithCustomMarshaler.label to be 'string'")
 	}
 }
+
+// MetaNestedInfo is a plain struct with no custom marshaler.
+type MetaNestedInfo struct {
+	Source   string `json:"source"`
+	Priority int    `json:"priority"`
+}
+
+// MetaWithMixedFields has both a plain struct field and a custom marshaler field.
+type MetaWithMixedFields struct {
+	Info      MetaNestedInfo   `json:"info"`
+	Items     []MetaNestedInfo `json:"items"`
+	RequestID CustomID         `json:"requestId"`
+}
+
+func TestGenerateWithMetaMixedFields(t *testing.T) {
+	registry := aprot.NewRegistry()
+	registry.Register(&genTestHandler{})
+	EnableWithMeta[MetaWithMixedFields](registry)
+
+	gen := aprot.NewGenerator(registry)
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("GenerateTo failed: %v", err)
+	}
+	out := buf.String()
+
+	// MetaNestedInfo (non-marshaler struct) MUST generate an interface
+	if !strings.Contains(out, "interface MetaNestedInfo") {
+		t.Error("expected MetaNestedInfo interface to be generated (plain struct used as field type)")
+	}
+
+	// Extract MetaWithMixedFields interface block
+	metaStart := strings.Index(out, "interface MetaWithMixedFields")
+	if metaStart == -1 {
+		t.Fatal("MetaWithMixedFields interface not found in output")
+	}
+	metaBlock := out[metaStart:]
+	braceEnd := strings.Index(metaBlock, "}")
+	if braceEnd == -1 {
+		t.Fatal("could not find closing brace for MetaWithMixedFields")
+	}
+	metaBlock = metaBlock[:braceEnd+1]
+
+	// info field should resolve to MetaNestedInfo, not any
+	if !strings.Contains(metaBlock, "info: MetaNestedInfo") {
+		t.Errorf("expected MetaWithMixedFields.info to be 'MetaNestedInfo', got:\n%s", metaBlock)
+	}
+	// items field should resolve to MetaNestedInfo[], not any[]
+	if !strings.Contains(metaBlock, "items: MetaNestedInfo[]") {
+		t.Errorf("expected MetaWithMixedFields.items to be 'MetaNestedInfo[]', got:\n%s", metaBlock)
+	}
+	// requestId field should resolve to string (CustomID marshaler)
+	if !strings.Contains(metaBlock, "requestId: string") {
+		t.Errorf("expected MetaWithMixedFields.requestId to be 'string' (from CustomID marshaler), got:\n%s", metaBlock)
+	}
+}
+
+// NonNilSlice is a generic wrapper that ensures nil slices marshal as [] not null.
+type NonNilSlice[T any] []T
+
+func (s NonNilSlice[T]) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]T(s))
+}
+
+// MetaWithWrappedSlice uses NonNilSlice wrapper fields in the task meta type.
+type MetaWithWrappedSlice struct {
+	Items     NonNilSlice[MetaNestedInfo] `json:"items"`
+	Tags      NonNilSlice[string]         `json:"tags"`
+	RequestID CustomID                    `json:"requestId"`
+}
+
+func TestGenerateWithMetaSliceMarshalerWrapper(t *testing.T) {
+	registry := aprot.NewRegistry()
+	registry.Register(&genTestHandler{})
+	EnableWithMeta[MetaWithWrappedSlice](registry)
+
+	gen := aprot.NewGenerator(registry)
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("GenerateTo failed: %v", err)
+	}
+	out := buf.String()
+
+	// MetaNestedInfo MUST generate an interface even when only used inside NonNilSlice
+	if !strings.Contains(out, "interface MetaNestedInfo") {
+		t.Error("expected MetaNestedInfo interface to be generated (used as element type in NonNilSlice)")
+	}
+
+	// Extract MetaWithWrappedSlice interface block
+	metaStart := strings.Index(out, "interface MetaWithWrappedSlice")
+	if metaStart == -1 {
+		t.Fatal("MetaWithWrappedSlice interface not found in output")
+	}
+	metaBlock := out[metaStart:]
+	braceEnd := strings.Index(metaBlock, "}")
+	if braceEnd == -1 {
+		t.Fatal("could not find closing brace for MetaWithWrappedSlice")
+	}
+	metaBlock = metaBlock[:braceEnd+1]
+
+	// items field: NonNilSlice[MetaNestedInfo] should resolve to MetaNestedInfo[], not any[]
+	if !strings.Contains(metaBlock, "items: MetaNestedInfo[]") {
+		t.Errorf("expected MetaWithWrappedSlice.items to be 'MetaNestedInfo[]', got:\n%s", metaBlock)
+	}
+	// tags field: NonNilSlice[string] should resolve to string[], not any[]
+	if !strings.Contains(metaBlock, "tags: string[]") {
+		t.Errorf("expected MetaWithWrappedSlice.tags to be 'string[]', got:\n%s", metaBlock)
+	}
+	// requestId field should still resolve to string (CustomID marshaler)
+	if !strings.Contains(metaBlock, "requestId: string") {
+		t.Errorf("expected MetaWithWrappedSlice.requestId to be 'string', got:\n%s", metaBlock)
+	}
+}


### PR DESCRIPTION
## Summary

- Generic slice wrapper types (e.g. `NonNilSlice[T]`) with custom `json.Marshaler` implementations now correctly resolve to `T[]` instead of `any[]` in generated TypeScript
- Affects both the main generator (`generate.go`) and the tasks meta codegen (`tasks/codegen.go`)
- The fix detects when a marshaler returns an array type on a `reflect.Slice`-kind type and refines the element type using Go reflection instead of the zero-value marshal output

## Test plan

- [x] New `TestGenerateSliceMarshalerWrapper` in `generate_test.go` — verifies `NonNilSlice[NestedDetail]` resolves to `NestedDetail[]`, `NonNilSlice[string]` resolves to `string[]`
- [x] New `TestGenerateWithMetaSliceMarshalerWrapper` in `tasks/generate_test.go` — same verification for the tasks meta codegen path
- [x] New `TestGenerateMixedMarshalerAndStructFields` — regression test for mixed marshaler/non-marshaler struct fields
- [x] New `TestGenerateWithMetaMixedFields` — same for tasks meta path
- [x] All existing tests pass (`go test ./...`)
- [x] Example regeneration + `tsc --noEmit` pass

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)