### PR TITLE
Add naming convention plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,67 @@ function getStatusLabel(status: TaskStatusType): string {
 }
 ```
 
+## Naming Plugins
+
+By default, aprot converts Go PascalCase names to idiomatic TypeScript conventions: kebab-case filenames (`PublicHandlers` -> `public-handlers.ts`) and camelCase methods (`CreateUser` -> `createUser`). Naming plugins let you customize this behavior.
+
+### NamingPlugin Interface
+
+```go
+type NamingPlugin interface {
+    FileName(groupName string) string        // handler struct name -> filename stem
+    MethodName(name string) string            // handler method name -> TS function name
+    HookName(name string) string              // handler/event name -> React hook name
+    HandlerName(eventName string) string      // push event name -> event handler name
+    ErrorMethodName(errorName string) string  // error code name -> type-guard method name
+}
+```
+
+### Built-in Plugins
+
+**DefaultNaming** - reproduces current behavior, with an option to fix acronym splitting:
+
+```go
+// Without FixAcronyms (default): BulkXMLHandlers -> bulk-x-m-l-handlers.ts
+gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
+    OutputDir: "./client/api",
+    Mode:      aprot.OutputVanilla,
+    Naming:    aprot.DefaultNaming{FixAcronyms: false},
+})
+
+// With FixAcronyms: BulkXMLHandlers -> bulk-xml-handlers.ts, XMLParser -> xmlParser
+gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
+    OutputDir: "./client/api",
+    Mode:      aprot.OutputVanilla,
+    Naming:    aprot.DefaultNaming{FixAcronyms: true},
+})
+```
+
+**PreserveNaming** - keeps Go method names unchanged (PascalCase) in generated TypeScript:
+
+```go
+// CreateUser stays CreateUser (not createUser), filenames still kebab-case
+gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
+    OutputDir: "./client/api",
+    Mode:      aprot.OutputVanilla,
+    Naming:    aprot.PreserveNaming{FixAcronyms: true},
+})
+```
+
+### Custom Plugins
+
+Implement the `NamingPlugin` interface for full control:
+
+```go
+type MyNaming struct{}
+
+func (m MyNaming) FileName(groupName string) string     { return strings.ToLower(groupName) }
+func (m MyNaming) MethodName(name string) string         { return name }
+func (m MyNaming) HookName(name string) string           { return "use" + name }
+func (m MyNaming) HandlerName(eventName string) string   { return "on" + eventName }
+func (m MyNaming) ErrorMethodName(errorName string) string { return "is" + errorName }
+```
+
 ## Type Mapping
 
 Go types are mapped to TypeScript types during code generation:

--- a/generate.go
+++ b/generate.go
@@ -206,6 +206,10 @@ type GeneratorOptions struct {
 
 	// Mode specifies vanilla or react output.
 	Mode OutputMode
+
+	// Naming controls how Go names are transformed into TypeScript names.
+	// If nil, DefaultNaming{} is used (preserving current behavior).
+	Naming NamingPlugin
 }
 
 // Generator generates TypeScript client code from a registry.
@@ -230,6 +234,13 @@ func NewGenerator(registry *Registry) *Generator {
 		marshalCache:   make(map[reflect.Type]*MarshalTSType),
 		marshalChecked: make(map[reflect.Type]bool),
 	}
+}
+
+func (g *Generator) naming() NamingPlugin {
+	if g.options.Naming != nil {
+		return g.options.Naming
+	}
+	return DefaultNaming{}
 }
 
 // WithOptions sets generator options.
@@ -327,7 +338,7 @@ func (g *Generator) Generate() (map[string]string, error) {
 		baseData.CustomErrorCodes = append(baseData.CustomErrorCodes, errorCodeData{
 			Name:       ec.Name,
 			Code:       ec.Code,
-			MethodName: "is" + ec.Name,
+			MethodName: g.naming().ErrorMethodName(ec.Name),
 		})
 	}
 
@@ -492,8 +503,8 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 		data.Methods = append(data.Methods, methodData{
 			Name:         shortName,
 			WireMethod:   qualifiedName,
-			MethodName:   toLowerCamel(shortName),
-			HookName:     "use" + shortName,
+			MethodName:   g.naming().MethodName(shortName),
+			HookName:     g.naming().HookName(shortName),
 			ResponseType: respType,
 			IsVoid:       isVoid,
 			Params:       g.buildParamData(info, paramNames),
@@ -504,8 +515,8 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 	for _, event := range g.registry.PushEvents() {
 		data.PushEvents = append(data.PushEvents, pushEventData{
 			Name:        event.Name,
-			HandlerName: "on" + event.Name,
-			HookName:    "use" + event.Name,
+			HandlerName: g.naming().HandlerName(event.Name),
+			HookName:    g.naming().HookName(event.Name),
 			DataType:    event.DataType.Name(),
 		})
 	}
@@ -515,7 +526,7 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 		data.CustomErrorCodes = append(data.CustomErrorCodes, errorCodeData{
 			Name:       ec.Name,
 			Code:       ec.Code,
-			MethodName: "is" + ec.Name,
+			MethodName: g.naming().ErrorMethodName(ec.Name),
 		})
 	}
 
@@ -551,7 +562,7 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 func (g *Generator) buildTemplateData(group *HandlerGroup, paramNames map[string]map[string][]string) templateData {
 	data := templateData{
 		StructName: group.Name,
-		FileName:   toKebab(group.Name) + ".ts",
+		FileName:   g.naming().FileName(group.Name) + ".ts",
 	}
 
 	// Build interfaces
@@ -586,8 +597,8 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, paramNames map[string
 		data.Methods = append(data.Methods, methodData{
 			Name:         name,
 			WireMethod:   group.Name + "." + name,
-			MethodName:   toLowerCamel(name),
-			HookName:     "use" + name,
+			MethodName:   g.naming().MethodName(name),
+			HookName:     g.naming().HookName(name),
 			ResponseType: respType,
 			IsVoid:       isVoid,
 			Params:       g.buildParamData(info, paramNames),
@@ -598,8 +609,8 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, paramNames map[string
 	for _, event := range group.PushEvents {
 		data.PushEvents = append(data.PushEvents, pushEventData{
 			Name:        event.Name,
-			HandlerName: "on" + event.Name,
-			HookName:    "use" + event.Name,
+			HandlerName: g.naming().HandlerName(event.Name),
+			HookName:    g.naming().HookName(event.Name),
 			DataType:    event.DataType.Name(),
 		})
 	}
@@ -609,7 +620,7 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, paramNames map[string
 		data.CustomErrorCodes = append(data.CustomErrorCodes, errorCodeData{
 			Name:       ec.Name,
 			Code:       ec.Code,
-			MethodName: "is" + ec.Name,
+			MethodName: g.naming().ErrorMethodName(ec.Name),
 		})
 	}
 

--- a/naming.go
+++ b/naming.go
@@ -1,0 +1,181 @@
+package aprot
+
+import (
+	"strings"
+	"unicode"
+)
+
+// NamingPlugin controls how Go names are transformed into TypeScript names
+// during code generation.
+type NamingPlugin interface {
+	// FileName converts a handler group name (e.g. "PublicHandlers") to a
+	// filename stem (without extension). The generator appends ".ts".
+	FileName(groupName string) string
+
+	// MethodName converts a Go handler method name (e.g. "CreateUser") to a
+	// TypeScript function name (e.g. "createUser" or "CreateUser").
+	MethodName(name string) string
+
+	// HookName converts a Go handler/event name to a React hook name.
+	// Default: "use" + name (e.g. "useCreateUser").
+	HookName(name string) string
+
+	// HandlerName converts a push event name to an event handler callback name.
+	// Default: "on" + name (e.g. "onUserCreated").
+	HandlerName(eventName string) string
+
+	// ErrorMethodName converts a custom error code name to a type-guard method name.
+	// Default: "is" + name (e.g. "isNotFound").
+	ErrorMethodName(errorName string) string
+}
+
+// DefaultNaming reproduces the current naming behavior.
+// Set FixAcronyms to true to treat consecutive uppercase letters as a single
+// word (e.g. "BulkXMLHandlers" → "bulk-xml-handlers" instead of "bulk-x-m-l-handlers").
+type DefaultNaming struct {
+	FixAcronyms bool
+}
+
+func (d DefaultNaming) FileName(groupName string) string {
+	if d.FixAcronyms {
+		return toKebabAcronyms(groupName)
+	}
+	return toKebab(groupName)
+}
+
+func (d DefaultNaming) MethodName(name string) string {
+	if d.FixAcronyms {
+		return toLowerCamelAcronyms(name)
+	}
+	return toLowerCamel(name)
+}
+
+func (d DefaultNaming) HookName(name string) string {
+	return "use" + name
+}
+
+func (d DefaultNaming) HandlerName(eventName string) string {
+	return "on" + eventName
+}
+
+func (d DefaultNaming) ErrorMethodName(errorName string) string {
+	return "is" + errorName
+}
+
+// PreserveNaming keeps Go PascalCase method names unchanged in the generated
+// TypeScript. Filenames still use kebab-case (filesystem convention).
+type PreserveNaming struct {
+	FixAcronyms bool
+}
+
+func (p PreserveNaming) FileName(groupName string) string {
+	if p.FixAcronyms {
+		return toKebabAcronyms(groupName)
+	}
+	return toKebab(groupName)
+}
+
+func (p PreserveNaming) MethodName(name string) string {
+	return name
+}
+
+func (p PreserveNaming) HookName(name string) string {
+	return "use" + name
+}
+
+func (p PreserveNaming) HandlerName(eventName string) string {
+	return "on" + eventName
+}
+
+func (p PreserveNaming) ErrorMethodName(errorName string) string {
+	return "is" + errorName
+}
+
+// toKebabAcronyms converts PascalCase to kebab-case, treating consecutive
+// uppercase letters as a single acronym word.
+//
+// Examples:
+//
+//	"PublicHandlers"  → "public-handlers"
+//	"BulkXMLHandlers" → "bulk-xml-handlers"
+//	"XMLParser"       → "xml-parser"
+//	"MyHTTPSServer"   → "my-https-server"
+func toKebabAcronyms(s string) string {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return ""
+	}
+	var result strings.Builder
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if !unicode.IsUpper(r) {
+			result.WriteRune(r)
+			continue
+		}
+		// r is uppercase. Determine if it starts a new word.
+		if i > 0 {
+			result.WriteRune('-')
+		}
+		// Collect the uppercase run.
+		j := i
+		for j < len(runes) && unicode.IsUpper(runes[j]) {
+			j++
+		}
+		runLen := j - i
+		if runLen == 1 || j == len(runes) {
+			// Single uppercase letter or acronym at end of string — emit all lowercase.
+			for k := i; k < j; k++ {
+				result.WriteRune(unicode.ToLower(runes[k]))
+			}
+			i = j - 1
+		} else {
+			// Multiple uppercase followed by lowercase: last uppercase starts the next word.
+			for k := i; k < j-1; k++ {
+				result.WriteRune(unicode.ToLower(runes[k]))
+			}
+			// The last uppercase char of the run starts a new word.
+			i = j - 2 // -1 because the loop does i++
+		}
+	}
+	return result.String()
+}
+
+// toLowerCamelAcronyms converts PascalCase to camelCase, lowercasing a leading
+// acronym run rather than just the first character.
+//
+// Examples:
+//
+//	"CreateUser"      → "createUser"
+//	"XMLParser"       → "xmlParser"
+//	"HTTPSConnection" → "httpsConnection"
+func toLowerCamelAcronyms(s string) string {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return ""
+	}
+	// Find the length of the leading uppercase run.
+	upper := 0
+	for upper < len(runes) && unicode.IsUpper(runes[upper]) {
+		upper++
+	}
+	if upper == 0 {
+		return s
+	}
+	// If the entire string is uppercase, lowercase all.
+	if upper == len(runes) {
+		for i := 0; i < len(runes); i++ {
+			runes[i] = unicode.ToLower(runes[i])
+		}
+		return string(runes)
+	}
+	// If only one uppercase letter, just lowercase it.
+	if upper == 1 {
+		runes[0] = unicode.ToLower(runes[0])
+		return string(runes)
+	}
+	// Multiple uppercase: lowercase all except the last (which starts the next word).
+	for i := 0; i < upper-1; i++ {
+		runes[i] = unicode.ToLower(runes[i])
+	}
+	return string(runes)
+}

--- a/naming_test.go
+++ b/naming_test.go
@@ -1,0 +1,159 @@
+package aprot
+
+import "testing"
+
+func TestToKebabAcronyms(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"Simple", "simple"},
+		{"PublicHandlers", "public-handlers"},
+		{"BulkXMLHandlers", "bulk-xml-handlers"},
+		{"XMLParser", "xml-parser"},
+		{"MyHTTPSServer", "my-https-server"},
+		{"getUser", "get-user"},
+		{"A", "a"},
+		{"AB", "ab"},
+		{"ABC", "abc"},
+		{"ABCDef", "abc-def"},
+		{"AWord", "a-word"},
+		{"HTMLToJSON", "html-to-json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := toKebabAcronyms(tt.input)
+			if got != tt.want {
+				t.Errorf("toKebabAcronyms(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToLowerCamelAcronyms(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"CreateUser", "createUser"},
+		{"XMLParser", "xmlParser"},
+		{"HTTPSConnection", "httpsConnection"},
+		{"A", "a"},
+		{"AB", "ab"},
+		{"ABC", "abc"},
+		{"ABCDef", "abcDef"},
+		{"Simple", "simple"},
+		{"getUser", "getUser"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := toLowerCamelAcronyms(tt.input)
+			if got != tt.want {
+				t.Errorf("toLowerCamelAcronyms(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultNaming(t *testing.T) {
+	t.Run("without FixAcronyms", func(t *testing.T) {
+		n := DefaultNaming{}
+
+		// FileName should match current toKebab behavior
+		if got := n.FileName("PublicHandlers"); got != "public-handlers" {
+			t.Errorf("FileName = %q, want %q", got, "public-handlers")
+		}
+		if got := n.FileName("BulkXMLHandlers"); got != "bulk-x-m-l-handlers" {
+			t.Errorf("FileName = %q, want %q", got, "bulk-x-m-l-handlers")
+		}
+
+		// MethodName should match current toLowerCamel behavior
+		if got := n.MethodName("CreateUser"); got != "createUser" {
+			t.Errorf("MethodName = %q, want %q", got, "createUser")
+		}
+		if got := n.MethodName("XMLParser"); got != "xMLParser" {
+			t.Errorf("MethodName = %q, want %q", got, "xMLParser")
+		}
+
+		// Prefixed names
+		if got := n.HookName("CreateUser"); got != "useCreateUser" {
+			t.Errorf("HookName = %q, want %q", got, "useCreateUser")
+		}
+		if got := n.HandlerName("UserCreated"); got != "onUserCreated" {
+			t.Errorf("HandlerName = %q, want %q", got, "onUserCreated")
+		}
+		if got := n.ErrorMethodName("NotFound"); got != "isNotFound" {
+			t.Errorf("ErrorMethodName = %q, want %q", got, "isNotFound")
+		}
+	})
+
+	t.Run("with FixAcronyms", func(t *testing.T) {
+		n := DefaultNaming{FixAcronyms: true}
+
+		if got := n.FileName("BulkXMLHandlers"); got != "bulk-xml-handlers" {
+			t.Errorf("FileName = %q, want %q", got, "bulk-xml-handlers")
+		}
+		if got := n.FileName("PublicHandlers"); got != "public-handlers" {
+			t.Errorf("FileName = %q, want %q", got, "public-handlers")
+		}
+
+		if got := n.MethodName("XMLParser"); got != "xmlParser" {
+			t.Errorf("MethodName = %q, want %q", got, "xmlParser")
+		}
+		if got := n.MethodName("CreateUser"); got != "createUser" {
+			t.Errorf("MethodName = %q, want %q", got, "createUser")
+		}
+	})
+}
+
+func TestPreserveNaming(t *testing.T) {
+	t.Run("without FixAcronyms", func(t *testing.T) {
+		n := PreserveNaming{}
+
+		// MethodName preserves PascalCase
+		if got := n.MethodName("CreateUser"); got != "CreateUser" {
+			t.Errorf("MethodName = %q, want %q", got, "CreateUser")
+		}
+		if got := n.MethodName("XMLParser"); got != "XMLParser" {
+			t.Errorf("MethodName = %q, want %q", got, "XMLParser")
+		}
+
+		// FileName still kebab-cases
+		if got := n.FileName("PublicHandlers"); got != "public-handlers" {
+			t.Errorf("FileName = %q, want %q", got, "public-handlers")
+		}
+
+		// Prefixed names same as default
+		if got := n.HookName("CreateUser"); got != "useCreateUser" {
+			t.Errorf("HookName = %q, want %q", got, "useCreateUser")
+		}
+		if got := n.HandlerName("UserCreated"); got != "onUserCreated" {
+			t.Errorf("HandlerName = %q, want %q", got, "onUserCreated")
+		}
+		if got := n.ErrorMethodName("NotFound"); got != "isNotFound" {
+			t.Errorf("ErrorMethodName = %q, want %q", got, "isNotFound")
+		}
+	})
+
+	t.Run("with FixAcronyms", func(t *testing.T) {
+		n := PreserveNaming{FixAcronyms: true}
+
+		// MethodName still preserves PascalCase
+		if got := n.MethodName("XMLParser"); got != "XMLParser" {
+			t.Errorf("MethodName = %q, want %q", got, "XMLParser")
+		}
+
+		// FileName uses acronym-aware kebab
+		if got := n.FileName("BulkXMLHandlers"); got != "bulk-xml-handlers" {
+			t.Errorf("FileName = %q, want %q", got, "bulk-xml-handlers")
+		}
+	})
+}
+
+func TestNamingPluginInterface(t *testing.T) {
+	// Verify both types implement the interface
+	var _ NamingPlugin = DefaultNaming{}
+	var _ NamingPlugin = PreserveNaming{}
+}


### PR DESCRIPTION
## Summary

- Add `NamingPlugin` interface to `GeneratorOptions` for customizable name transformations
- Ship `DefaultNaming` plugin (current behavior + `FixAcronyms` option to fix `BulkXMLHandlers` → `bulk-xml-handlers`)
- Ship `PreserveNaming` plugin (keeps Go PascalCase method names in generated TS)
- Replace all 11 hardcoded naming call sites in `generate.go` to go through the plugin
- Fully backwards compatible — `nil` Naming uses `DefaultNaming{}`

Closes #112

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests for `toKebabAcronyms`, `toLowerCamelAcronyms`, `DefaultNaming`, `PreserveNaming`
- [x] Example generators produce unchanged output (`vanilla` and `react`)
- [x] TypeScript type-checks pass (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)