### PR TITLE
Add native support for database/sql nullable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,10 +1205,17 @@ Go types are mapped to TypeScript types during code generation:
 | `map[K]V` | `Record<K, V>` | |
 | `*T` | `T` (optional) | Pointer fields become optional (`?`) |
 | `time.Time` | `string` | RFC 3339 format (Go's `encoding/json` default) |
+| `sql.NullString` | `string \| null` | All `database/sql` nullable types supported |
+| `sql.NullInt64`, etc. | `number \| null` | `NullInt32`, `NullInt16`, `NullFloat64`, `NullByte` |
+| `sql.NullBool` | `boolean \| null` | |
+| `sql.NullTime` | `string \| null` | Underlying `time.Time` marshals as string |
+| `sql.Null[T]` | `T \| null` | Generic nullable (Go 1.22+) |
 | `struct` | `interface` | Named structs become TypeScript interfaces |
 | Registered enum | Const object + type | See [Enum Support](#enum-support) |
 
 `time.Time` fields (including `*time.Time`) are generated as `string` because Go's `encoding/json` marshals them as RFC 3339 strings. This applies anywhere `time.Time` appears: direct fields, slices (`[]time.Time` → `string[]`), map values, etc.
+
+`database/sql` nullable types (`sql.NullString`, `sql.NullInt64`, `sql.NullBool`, `sql.NullFloat64`, `sql.NullInt32`, `sql.NullInt16`, `sql.NullByte`, `sql.NullTime`, and the generic `sql.Null[T]`) are generated as `T | null`. These fields are **not** optional — they are always present in the JSON but may be `null`. Slices of nullable types use parenthesized syntax: `[]sql.NullString` → `(string | null)[]`.
 
 ## Generated Output
 

--- a/generate.go
+++ b/generate.go
@@ -86,6 +86,40 @@ func InferTypeFromMarshal(t reflect.Type) *MarshalTSType {
 	}
 }
 
+// SQLNullTSType checks whether t is a database/sql nullable type (NullString,
+// NullInt64, NullBool, NullFloat64, NullInt32, NullInt16, NullByte, NullTime,
+// or the generic Null[T]) and returns the corresponding TypeScript type
+// (e.g. "string | null"). Returns "" if t is not a sql.Null type.
+//
+// typeResolver is called for the generic Null[T] case to convert the inner
+// Go type to its TypeScript representation.
+func SQLNullTSType(t reflect.Type, typeResolver func(reflect.Type) string) string {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.PkgPath() != "database/sql" {
+		return ""
+	}
+	switch t.Name() {
+	case "NullString":
+		return "string | null"
+	case "NullInt64", "NullInt32", "NullInt16", "NullFloat64", "NullByte":
+		return "number | null"
+	case "NullBool":
+		return "boolean | null"
+	case "NullTime":
+		return "string | null"
+	default:
+		// Generic sql.Null[T] — has fields V (of type T) and Valid (bool).
+		if strings.HasPrefix(t.Name(), "Null[") {
+			if vField, ok := t.FieldByName("V"); ok {
+				return typeResolver(vField.Type) + " | null"
+			}
+		}
+		return ""
+	}
+}
+
 // inferObjectType unmarshals JSON object data and infers a Record<string, T> type.
 // Returns Record<string, any> for empty or heterogeneous objects.
 func inferObjectType(data []byte) *MarshalTSType {
@@ -872,7 +906,7 @@ func (g *Generator) inferTypeFromMarshalCached(t reflect.Type) *MarshalTSType {
 // overrides the default struct serialization. Used by type collection to skip
 // struct-field recursion for types whose wire format differs from their Go fields.
 func (g *Generator) hasMarshalOverride(t reflect.Type) bool {
-	return g.inferTypeFromMarshalCached(t) != nil
+	return g.inferTypeFromMarshalCached(t) != nil || SQLNullTSType(t, g.goTypeToTS) != ""
 }
 
 // shouldSkipField returns true for fields that should be excluded from reflected interfaces.
@@ -897,9 +931,18 @@ func (g *Generator) goTypeToTS(t reflect.Type) string {
 		// the element type using Go reflection instead of the zero-value marshal
 		// output, which can only produce any[].
 		if t.Kind() == reflect.Slice && strings.HasSuffix(mt.TSType, "[]") {
-			return g.goTypeToTS(t.Elem()) + "[]"
+			elemType := g.goTypeToTS(t.Elem())
+			if strings.Contains(elemType, " | ") {
+				return "(" + elemType + ")[]"
+			}
+			return elemType + "[]"
 		}
 		return mt.TSType
+	}
+
+	// Check for database/sql nullable types.
+	if tsType := SQLNullTSType(t, g.goTypeToTS); tsType != "" {
+		return tsType
 	}
 
 	switch t.Kind() {
@@ -913,6 +956,9 @@ func (g *Generator) goTypeToTS(t reflect.Type) string {
 		return "boolean"
 	case reflect.Slice:
 		elemType := g.goTypeToTS(t.Elem())
+		if strings.Contains(elemType, " | ") {
+			return "(" + elemType + ")[]"
+		}
 		return elemType + "[]"
 	case reflect.Map:
 		keyType := g.goTypeToTS(t.Key())

--- a/generate_test.go
+++ b/generate_test.go
@@ -3,6 +3,7 @@ package aprot
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -2249,5 +2250,182 @@ func TestGenerateSliceMarshalerWrapper(t *testing.T) {
 	// items field: NonNilSlice[NestedDetail] should resolve to NestedDetail[], not any[]
 	if !strings.Contains(respBlock, "items: NestedDetail[]") {
 		t.Errorf("expected WrappedSliceResponse.items to be 'NestedDetail[]', got:\n%s", respBlock)
+	}
+}
+
+// --- sql.Null type tests ---
+
+func TestSQLNullTSType(t *testing.T) {
+	resolver := func(t reflect.Type) string {
+		switch t.Kind() {
+		case reflect.String:
+			return "string"
+		case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Float32, reflect.Float64, reflect.Uint8:
+			return "number"
+		case reflect.Bool:
+			return "boolean"
+		default:
+			return "any"
+		}
+	}
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want string
+	}{
+		{"NullString", reflect.TypeOf(sql.NullString{}), "string | null"},
+		{"NullInt64", reflect.TypeOf(sql.NullInt64{}), "number | null"},
+		{"NullInt32", reflect.TypeOf(sql.NullInt32{}), "number | null"},
+		{"NullInt16", reflect.TypeOf(sql.NullInt16{}), "number | null"},
+		{"NullFloat64", reflect.TypeOf(sql.NullFloat64{}), "number | null"},
+		{"NullBool", reflect.TypeOf(sql.NullBool{}), "boolean | null"},
+		{"NullByte", reflect.TypeOf(sql.NullByte{}), "number | null"},
+		{"NullTime", reflect.TypeOf(sql.NullTime{}), "string | null"},
+		{"Null[string]", reflect.TypeOf(sql.Null[string]{}), "string | null"},
+		{"Null[int]", reflect.TypeOf(sql.Null[int]{}), "number | null"},
+		{"Null[bool]", reflect.TypeOf(sql.Null[bool]{}), "boolean | null"},
+		{"Null[float64]", reflect.TypeOf(sql.Null[float64]{}), "number | null"},
+		{"plain struct → empty", reflect.TypeOf(CreateUserRequest{}), ""},
+		{"time.Time → empty", reflect.TypeOf(time.Time{}), ""},
+		{"int → empty", reflect.TypeOf(0), ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SQLNullTSType(tc.typ, resolver)
+			if got != tc.want {
+				t.Errorf("SQLNullTSType(%v) = %q, want %q", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGoTypeToTSSQLNull(t *testing.T) {
+	registry := NewRegistry()
+	g := NewGenerator(registry)
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want string
+	}{
+		{"NullString", reflect.TypeOf(sql.NullString{}), "string | null"},
+		{"NullInt64", reflect.TypeOf(sql.NullInt64{}), "number | null"},
+		{"NullInt32", reflect.TypeOf(sql.NullInt32{}), "number | null"},
+		{"NullInt16", reflect.TypeOf(sql.NullInt16{}), "number | null"},
+		{"NullFloat64", reflect.TypeOf(sql.NullFloat64{}), "number | null"},
+		{"NullBool", reflect.TypeOf(sql.NullBool{}), "boolean | null"},
+		{"NullByte", reflect.TypeOf(sql.NullByte{}), "number | null"},
+		{"NullTime", reflect.TypeOf(sql.NullTime{}), "string | null"},
+		{"Null[string]", reflect.TypeOf(sql.Null[string]{}), "string | null"},
+		{"Null[int]", reflect.TypeOf(sql.Null[int]{}), "number | null"},
+		{"slice of NullString", reflect.TypeOf([]sql.NullString{}), "(string | null)[]"},
+		{"pointer to NullString", reflect.TypeOf((*sql.NullString)(nil)), "string | null"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := g.goTypeToTS(tc.typ)
+			if got != tc.want {
+				t.Errorf("goTypeToTS(%v) = %q, want %q", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+// Types for TestGenerateSQLNullTypes
+
+type SQLNullRequest struct {
+	Name   sql.NullString   `json:"name"`
+	Age    sql.NullInt64    `json:"age"`
+	Active sql.NullBool     `json:"active"`
+	Score  sql.NullFloat64  `json:"score"`
+	Rank   sql.NullInt32    `json:"rank"`
+	Level  sql.NullInt16    `json:"level"`
+	Code   sql.NullByte     `json:"code"`
+	Born   sql.NullTime     `json:"born"`
+	Tags   []sql.NullString `json:"tags"`
+	Note   sql.Null[string] `json:"note"`
+}
+
+type SQLNullResponse struct {
+	ID string `json:"id"`
+}
+
+type SQLNullHandlers struct{}
+
+func (h *SQLNullHandlers) DoThing(ctx context.Context, req *SQLNullRequest) (*SQLNullResponse, error) {
+	return nil, nil
+}
+
+func TestGenerateSQLNullTypes(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&SQLNullHandlers{})
+
+	gen := NewGenerator(registry)
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("GenerateTo failed: %v", err)
+	}
+	out := buf.String()
+
+	// Must NOT generate interfaces for sql.Null types
+	for _, bad := range []string{
+		"export interface NullString",
+		"export interface NullInt64",
+		"export interface NullInt32",
+		"export interface NullInt16",
+		"export interface NullFloat64",
+		"export interface NullBool",
+		"export interface NullByte",
+		"export interface NullTime",
+	} {
+		if strings.Contains(out, bad) {
+			t.Errorf("Should not generate %s — sql.Null types are primitives", bad)
+		}
+	}
+
+	// Extract SQLNullRequest interface block
+	reqStart := strings.Index(out, "interface SQLNullRequest")
+	if reqStart == -1 {
+		t.Fatal("SQLNullRequest interface not found in output")
+	}
+	reqBlock := out[reqStart:]
+	braceEnd := strings.Index(reqBlock, "}")
+	if braceEnd == -1 {
+		t.Fatal("could not find closing brace for SQLNullRequest")
+	}
+	reqBlock = reqBlock[:braceEnd+1]
+
+	// Fields should be nullable primitives, not optional
+	expectations := []struct {
+		field string
+		want  string
+	}{
+		{"name", "name: string | null;"},
+		{"age", "age: number | null;"},
+		{"active", "active: boolean | null;"},
+		{"score", "score: number | null;"},
+		{"rank", "rank: number | null;"},
+		{"level", "level: number | null;"},
+		{"code", "code: number | null;"},
+		{"born", "born: string | null;"},
+		{"tags", "tags: (string | null)[];"},
+		{"note", "note: string | null;"},
+	}
+
+	for _, exp := range expectations {
+		if !strings.Contains(reqBlock, exp.want) {
+			t.Errorf("Expected field %q to be %q in:\n%s", exp.field, exp.want, reqBlock)
+		}
+	}
+
+	// Fields should NOT be optional (no ? marker)
+	for _, field := range []string{"name", "age", "active", "score", "rank", "level", "code", "born", "tags", "note"} {
+		if strings.Contains(reqBlock, field+"?:") {
+			t.Errorf("sql.Null field %q should not be optional", field)
+		}
 	}
 }

--- a/tasks/codegen.go
+++ b/tasks/codegen.go
@@ -66,7 +66,7 @@ func appendTaskConvenienceCode(results map[string]string, mode aprot.OutputMode,
 // hasMarshalOverride returns true if t has a custom JSON/text marshaler that
 // overrides the default struct serialization.
 func hasMarshalOverride(t reflect.Type) bool {
-	return aprot.InferTypeFromMarshal(t) != nil
+	return aprot.InferTypeFromMarshal(t) != nil || aprot.SQLNullTSType(t, goTypeToTS) != ""
 }
 
 // buildMetaInterfaces converts a meta type to template data via reflection.
@@ -174,9 +174,18 @@ func goTypeToTS(t reflect.Type) string {
 		// the element type using Go reflection instead of the zero-value marshal
 		// output, which can only produce any[].
 		if t.Kind() == reflect.Slice && strings.HasSuffix(mt.TSType, "[]") {
-			return goTypeToTS(t.Elem()) + "[]"
+			elemType := goTypeToTS(t.Elem())
+			if strings.Contains(elemType, " | ") {
+				return "(" + elemType + ")[]"
+			}
+			return elemType + "[]"
 		}
 		return mt.TSType
+	}
+
+	// Check for database/sql nullable types.
+	if tsType := aprot.SQLNullTSType(t, goTypeToTS); tsType != "" {
+		return tsType
 	}
 
 	switch t.Kind() {
@@ -189,7 +198,11 @@ func goTypeToTS(t reflect.Type) string {
 	case reflect.Bool:
 		return "boolean"
 	case reflect.Slice:
-		return goTypeToTS(t.Elem()) + "[]"
+		elemType := goTypeToTS(t.Elem())
+		if strings.Contains(elemType, " | ") {
+			return "(" + elemType + ")[]"
+		}
+		return elemType + "[]"
 	case reflect.Map:
 		return fmt.Sprintf("Record<%s, %s>", goTypeToTS(t.Key()), goTypeToTS(t.Elem()))
 	case reflect.Struct:


### PR DESCRIPTION
## Summary
- Add `SQLNullTSType()` exported function that detects all `database/sql` nullable types (`NullString`, `NullInt64`, `NullBool`, `NullFloat64`, `NullInt32`, `NullInt16`, `NullByte`, `NullTime`, and generic `Null[T]`) via reflection and maps them to TypeScript union types (e.g. `string | null`)
- Integrate into both `generate.go` and `tasks/codegen.go` type resolution and collection pipelines
- Fix slice parenthesization for union element types: `[]sql.NullString` → `(string | null)[]`
- Update README type mapping table with all nullable types

## Test plan
- [x] `TestSQLNullTSType` — unit tests for all concrete types + generic `Null[T]` + negative cases
- [x] `TestGoTypeToTSSQLNull` — integration with `goTypeToTS()` including slices and pointers
- [x] `TestGenerateSQLNullTypes` — full generation test verifying correct TS output, no spurious interfaces, and no optional markers
- [x] Full test suite passes (`go test ./...`)
- [x] Example generation and TypeScript compilation verified

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)