### PR TITLE
Add AbortController cancellation to useQuery hook

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -374,6 +374,27 @@ func TestGenerateReact(t *testing.T) {
 	if !strings.Contains(output, "signal: AbortSignal") {
 		t.Error("Mutation hooks should forward AbortSignal for cancellation")
 	}
+
+	// useQuery should use AbortController to cancel in-flight requests
+	useQuerySection := strings.SplitN(output, "export function useQuery", 2)
+	if len(useQuerySection) == 2 {
+		useQueryEnd := strings.SplitN(useQuerySection[1], "export function useMutation", 2)
+		if len(useQueryEnd) == 2 && !strings.Contains(useQueryEnd[0], "AbortController") {
+			t.Error("useQuery should use AbortController for request cancellation")
+		}
+	}
+
+	// Per-handler query hooks should also forward signal (not just mutation hooks)
+	if len(parts) == 2 {
+		handlerHooksSection := parts[1]
+		// Count occurrences of signal: AbortSignal — should appear in both query and mutation hooks
+		signalCount := strings.Count(handlerHooksSection, "signal: AbortSignal")
+		// We expect at least 2 per method (one for query hook, one for mutation hook)
+		// With 2 methods (GetUser, CreateUser), that's at least 4
+		if signalCount < 4 {
+			t.Errorf("Expected signal: AbortSignal in both query and mutation per-handler hooks, got %d occurrences", signalCount)
+		}
+	}
 }
 
 func TestGenerateReactMultiFileGenericHooks(t *testing.T) {
@@ -431,6 +452,22 @@ func TestGenerateReactMultiFileGenericHooks(t *testing.T) {
 	// Mutation hooks should forward AbortSignal for cancellation
 	if !strings.Contains(handlerContent, "signal: AbortSignal") {
 		t.Error("Mutation hooks should forward AbortSignal for cancellation")
+	}
+
+	// useQuery in client.ts should use AbortController to cancel in-flight requests
+	useQuerySection := strings.SplitN(clientContent, "export function useQuery", 2)
+	if len(useQuerySection) == 2 {
+		useQueryEnd := strings.SplitN(useQuerySection[1], "export function useMutation", 2)
+		if len(useQueryEnd) == 2 && !strings.Contains(useQueryEnd[0], "AbortController") {
+			t.Error("useQuery should use AbortController for request cancellation")
+		}
+	}
+
+	// Per-handler query hooks should also forward signal (not just mutation hooks)
+	signalCount := strings.Count(handlerContent, "signal: AbortSignal")
+	// Each method should have signal in both query and mutation hooks
+	if signalCount < 4 {
+		t.Errorf("Expected signal: AbortSignal in both query and mutation per-handler hooks, got %d occurrences", signalCount)
 	}
 }
 

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -711,39 +711,51 @@ export interface UsePushResult<T> {
 
 {{define "react-generic-hooks"}}
 // Generic query hook
-export function useQuery<TRes>(fn: (client: ApiClient) => Promise<TRes>, options?: UseQueryOptions): UseQueryResult<TRes>;
-export function useQuery<TArgs extends unknown[], TRes>(fn: (client: ApiClient, ...args: TArgs) => Promise<TRes>, options: UseQueryOptions & { params: TArgs }): UseQueryResult<TRes>;
+export function useQuery<TRes>(fn: (client: ApiClient, signal: AbortSignal) => Promise<TRes>, options?: UseQueryOptions): UseQueryResult<TRes>;
+export function useQuery<TArgs extends unknown[], TRes>(fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>, options: UseQueryOptions & { params: TArgs }): UseQueryResult<TRes>;
 export function useQuery<TArgs extends unknown[], TRes>(
-    fn: (client: ApiClient, ...args: TArgs) => Promise<TRes>,
+    fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>,
     options?: UseQueryOptions & { params?: TArgs },
 ): UseQueryResult<TRes> {
     const client = useApiClient();
     const [data, setData] = useState<TRes | null>(null);
     const [error, setError] = useState<Error | null>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
 
     const params = options?.params;
     const paramsKey = params ? JSON.stringify(params) : '[]';
 
     const fetch = useCallback(async () => {
         if (options?.enabled === false) return;
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
         setIsLoading(true);
         setError(null);
         try {
             const result = params
-                ? await fn(client, ...params)
-                : await (fn as unknown as (client: ApiClient) => Promise<TRes>)(client);
+                ? await fn(client, controller.signal, ...params)
+                : await (fn as unknown as (client: ApiClient, signal: AbortSignal) => Promise<TRes>)(client, controller.signal);
+            if (abortRef.current !== controller) return;
             setData(result);
         } catch (err) {
+            if (abortRef.current !== controller) return;
+            if (controller.signal.aborted) return;
             setError(err as Error);
         } finally {
-            setIsLoading(false);
+            if (abortRef.current === controller) {
+                setIsLoading(false);
+            }
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, fn, options?.enabled, paramsKey]);
 
     useEffect(() => {
         fetch();
+        return () => {
+            abortRef.current?.abort();
+        };
     }, [fetch]);
 
     useEffect(() => {

--- a/templates/client-handler-react.ts.tmpl
+++ b/templates/client-handler-react.ts.tmpl
@@ -57,7 +57,11 @@ export function {{.HandlerName}}(client: ApiClient, handler: PushHandler<{{.Data
 {{range .Methods}}
 {{- if not (hasParams .Params)}}
 export function {{.HookName}}(options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
-    return useQuery({{.MethodName}}, options);
+    const wrappedFn = useCallback(
+        (client: ApiClient, signal: AbortSignal) => {{.MethodName}}(client, { signal }),
+        [],
+    );
+    return useQuery(wrappedFn, options);
 }
 
 export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[], {{.ResponseType}}> {
@@ -69,7 +73,11 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
 }
 {{- else}}
 export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
-    return useQuery({{.MethodName}}, { ...options, params: [{{paramNames .Params}}] });
+    const wrappedFn = useCallback(
+        (client: ApiClient, signal: AbortSignal, {{paramDecl .Params}}) => {{.MethodName}}(client, {{paramNames .Params}}, { signal }),
+        [],
+    );
+    return useQuery(wrappedFn, { ...options, params: [{{paramNames .Params}}] });
 }
 
 export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[{{paramDecl .Params}}], {{.ResponseType}}> {

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -472,7 +472,11 @@ export function {{.HandlerName}}(client: ApiClient, handler: PushHandler<{{.Data
 {{range .Methods}}
 {{- if not (hasParams .Params)}}
 export function {{.HookName}}(options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
-    return useQuery({{.MethodName}}, options);
+    const wrappedFn = useCallback(
+        (client: ApiClient, signal: AbortSignal) => {{.MethodName}}(client, { signal }),
+        [],
+    );
+    return useQuery(wrappedFn, options);
 }
 
 export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[], {{.ResponseType}}> {
@@ -484,7 +488,11 @@ export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutation
 }
 {{- else}}
 export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
-    return useQuery({{.MethodName}}, { ...options, params: [{{paramNames .Params}}] });
+    const wrappedFn = useCallback(
+        (client: ApiClient, signal: AbortSignal, {{paramDecl .Params}}) => {{.MethodName}}(client, {{paramNames .Params}}, { signal }),
+        [],
+    );
+    return useQuery(wrappedFn, { ...options, params: [{{paramNames .Params}}] });
 }
 
 export function {{.HookName}}Mutation(options?: UseMutationOptions): UseMutationResult<[{{paramDecl .Params}}], {{.ResponseType}}> {


### PR DESCRIPTION
## Summary

- `useQuery` now cancels in-flight requests when parameters change, on refetch, and on unmount
- Per-handler query hooks wrap the plain function with `signal: AbortSignal` forwarding (mirroring mutation hooks)
- Stale responses are guarded against via `abortRef.current !== controller` checks

Closes #117

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `npx tsc --noEmit` on react example — no type errors
- [ ] Verify in a running React app that changing query parameters cancels the previous request's server context

🤖 Generated with [Claude Code](https://claude.com/claude-code)