### PR TITLE
Add cancel cause reporting to request contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Go library for building type-safe real-time APIs with automatic TypeScript cli
 - **Progress reporting** - Built-in support for long-running operations with progress updates
 - **Hierarchical sub-tasks** - Nested task trees with progress tracking, streamed to clients during handler execution
 - **Shared tasks** - Server-wide tasks visible to all clients via push events, with cancel support
-- **Request cancellation** - Clients can cancel in-flight requests via AbortController
+- **Request cancellation** - Clients can cancel in-flight requests via AbortController, with cancel cause reporting (client cancel, disconnect, server shutdown)
 - **Server push** - Broadcast events to all connected clients
 - **Server-pushed config** - Automatically configure client reconnect/heartbeat settings
 - **Dual transport** - WebSocket and SSE+HTTP transports with identical API
@@ -285,7 +285,38 @@ info := aprot.HandlerInfoFromContext(ctx)  // Handler metadata and options
 req := aprot.RequestFromContext(ctx)       // Request ID, method, params
 conn := aprot.Connection(ctx)              // WebSocket connection
 progress := aprot.Progress(ctx)            // Progress reporter
+cause := aprot.CancelCause(ctx)           // Why the request was canceled (nil if not canceled)
 ```
+
+### Cancel Cause
+
+When a handler's context is canceled, `aprot.CancelCause(ctx)` returns the reason. Use `errors.Is` to distinguish between the three cancellation sources:
+
+```go
+func (h *Handlers) LongRunning(ctx context.Context, req *Request) (*Response, error) {
+    select {
+    case <-ctx.Done():
+        cause := aprot.CancelCause(ctx)
+        switch {
+        case errors.Is(cause, aprot.ErrClientCanceled):
+            // Client explicitly canceled the request (AbortController, TypeCancel message)
+        case errors.Is(cause, aprot.ErrConnectionClosed):
+            // Client disconnected (closed tab, network loss)
+        case errors.Is(cause, aprot.ErrServerShutdown):
+            // Server is shutting down via server.Stop()
+        }
+        return nil, aprot.ErrCanceled()
+    case result := <-doWork(ctx):
+        return result, nil
+    }
+}
+```
+
+| Sentinel | Trigger |
+|---|---|
+| `aprot.ErrClientCanceled` | Client sends a cancel message |
+| `aprot.ErrConnectionClosed` | Client disconnects |
+| `aprot.ErrServerShutdown` | `server.Stop()` is called |
 
 ### Sub-Tasks
 

--- a/connection.go
+++ b/connection.go
@@ -21,7 +21,7 @@ type ConnInfo struct {
 type Conn struct {
 	transport transport
 	server    *Server
-	requests  map[string]context.CancelFunc
+	requests  map[string]context.CancelCauseFunc
 	mu        sync.Mutex
 	closed    bool
 	userID    string          // associated user ID (set by middleware)
@@ -134,7 +134,7 @@ func newConn(t transport, server *Server, id uint64, r *http.Request, ctx contex
 	return &Conn{
 		transport: t,
 		server:    server,
-		requests:  make(map[string]context.CancelFunc),
+		requests:  make(map[string]context.CancelCauseFunc),
 		id:        id,
 		ctx:       ctx,
 		info: ConnInfo{
@@ -224,7 +224,7 @@ func (c *Conn) sendPong() {
 	_ = c.sendJSON(msg)
 }
 
-func (c *Conn) registerRequest(id string, cancel context.CancelFunc) {
+func (c *Conn) registerRequest(id string, cancel context.CancelCauseFunc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.requests[id] = cancel
@@ -241,7 +241,7 @@ func (c *Conn) cancelRequest(id string) {
 	cancel, ok := c.requests[id]
 	c.mu.Unlock()
 	if ok {
-		cancel()
+		cancel(ErrClientCanceled)
 	}
 }
 
@@ -275,11 +275,11 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancelCause(context.Background())
 	c.registerRequest(msg.ID, cancel)
 	defer func() {
 		c.unregisterRequest(msg.ID)
-		cancel()
+		cancel(nil)
 	}()
 
 	// Add progress reporter and connection to context
@@ -331,7 +331,7 @@ func (c *Conn) close() {
 	c.closed = true
 	// Cancel all pending requests
 	for _, cancel := range c.requests {
-		cancel()
+		cancel(ErrConnectionClosed)
 	}
 	c.mu.Unlock()
 	c.transport.Close()
@@ -345,7 +345,7 @@ func (c *Conn) closeGracefully() {
 	}
 	c.closed = true
 	for _, cancel := range c.requests {
-		cancel()
+		cancel(ErrServerShutdown)
 	}
 	c.mu.Unlock()
 	_ = c.transport.CloseGracefully()

--- a/context.go
+++ b/context.go
@@ -67,3 +67,11 @@ func withRequest(ctx context.Context, req *Request) context.Context {
 	return context.WithValue(ctx, requestKey, req)
 }
 
+// CancelCause returns the reason the request context was canceled.
+// Returns nil if the context has not been canceled or no cause was set.
+// The returned error will be one of ErrClientCanceled, ErrConnectionClosed,
+// or ErrServerShutdown.
+func CancelCause(ctx context.Context) error {
+	return context.Cause(ctx)
+}
+

--- a/errors.go
+++ b/errors.go
@@ -77,3 +77,19 @@ func ErrForbidden(message string) *ProtocolError {
 func ErrConnectionRejected(message string) *ProtocolError {
 	return NewError(CodeConnectionRejected, message)
 }
+
+// CancelReason represents why a request context was canceled.
+type CancelReason struct {
+	reason string
+}
+
+func (r *CancelReason) Error() string { return r.reason }
+
+var (
+	// ErrClientCanceled indicates the client explicitly canceled the request.
+	ErrClientCanceled = &CancelReason{"client canceled"}
+	// ErrConnectionClosed indicates the client disconnected.
+	ErrConnectionClosed = &CancelReason{"connection closed"}
+	// ErrServerShutdown indicates the server is shutting down.
+	ErrServerShutdown = &CancelReason{"server shutdown"}
+)

--- a/server_test.go
+++ b/server_test.go
@@ -47,7 +47,8 @@ type NotificationEvent struct {
 
 // Integration test handlers
 type IntegrationHandlers struct {
-	server *Server
+	server      *Server
+	cancelCause chan error // receives cancel cause from CancelCauseCapture handler
 }
 
 func (h *IntegrationHandlers) Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error) {
@@ -78,6 +79,18 @@ func (h *IntegrationHandlers) TriggerPush(ctx context.Context, req *BroadcastReq
 		conn.Push(&NotificationEvent{Message: req.Message})
 	}
 	return &BroadcastResponse{Sent: true}, nil
+}
+
+func (h *IntegrationHandlers) CancelCauseCapture(ctx context.Context, req *SlowRequest) (*SlowResponse, error) {
+	for i := 1; i <= req.Steps; i++ {
+		select {
+		case <-ctx.Done():
+			h.cancelCause <- CancelCause(ctx)
+			return nil, ErrCanceled()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	return &SlowResponse{Completed: true}, nil
 }
 
 func setupTestServer(t *testing.T) (*httptest.Server, *Server, *IntegrationHandlers) {
@@ -1430,5 +1443,112 @@ func TestServerOptionsDefaults(t *testing.T) {
 	}
 	if msg.HeartbeatTimeout != 5000 {
 		t.Errorf("Expected default HeartbeatTimeout 5000, got %d", msg.HeartbeatTimeout)
+	}
+}
+
+func TestCancelCause_ClientCancel(t *testing.T) {
+	ts, _, handlers := setupTestServer(t)
+	defer ts.Close()
+	handlers.cancelCause = make(chan error, 1)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// Start slow request
+	req := IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "1",
+		Method: "IntegrationHandlers.CancelCauseCapture",
+		Params: jsontext.Value(`[{"steps":100}]`),
+	}
+	if err := ws.WriteJSON(req); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Wait a bit then cancel
+	time.Sleep(50 * time.Millisecond)
+
+	cancel := IncomingMessage{
+		Type: TypeCancel,
+		ID:   "1",
+	}
+	if err := ws.WriteJSON(cancel); err != nil {
+		t.Fatalf("Write cancel failed: %v", err)
+	}
+
+	select {
+	case cause := <-handlers.cancelCause:
+		if !errors.Is(cause, ErrClientCanceled) {
+			t.Errorf("Expected ErrClientCanceled, got %v", cause)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for cancel cause")
+	}
+}
+
+func TestCancelCause_ConnectionClose(t *testing.T) {
+	ts, _, handlers := setupTestServer(t)
+	defer ts.Close()
+	handlers.cancelCause = make(chan error, 1)
+
+	ws := connectWS(t, ts)
+
+	// Start slow request
+	req := IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "1",
+		Method: "IntegrationHandlers.CancelCauseCapture",
+		Params: jsontext.Value(`[{"steps":100}]`),
+	}
+	if err := ws.WriteJSON(req); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Wait a bit then close the connection
+	time.Sleep(50 * time.Millisecond)
+	ws.Close()
+
+	select {
+	case cause := <-handlers.cancelCause:
+		if !errors.Is(cause, ErrConnectionClosed) {
+			t.Errorf("Expected ErrConnectionClosed, got %v", cause)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for cancel cause")
+	}
+}
+
+func TestCancelCause_ServerShutdown(t *testing.T) {
+	ts, server, handlers := setupTestServer(t)
+	handlers.cancelCause = make(chan error, 1)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// Start slow request
+	req := IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "1",
+		Method: "IntegrationHandlers.CancelCauseCapture",
+		Params: jsontext.Value(`[{"steps":100}]`),
+	}
+	if err := ws.WriteJSON(req); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Wait a bit then shutdown the server
+	time.Sleep(50 * time.Millisecond)
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelCtx()
+	server.Stop(ctx)
+	ts.Close()
+
+	select {
+	case cause := <-handlers.cancelCause:
+		if !errors.Is(cause, ErrServerShutdown) {
+			t.Errorf("Expected ErrServerShutdown, got %v", cause)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for cancel cause")
 	}
 }

--- a/testing.go
+++ b/testing.go
@@ -67,7 +67,7 @@ func NewTestPushConn(id uint64, pushEvents ...any) *TestPushConn {
 	conn := &Conn{
 		transport: rt,
 		server:    server,
-		requests:  make(map[string]context.CancelFunc),
+		requests:  make(map[string]context.CancelCauseFunc),
 		id:        id,
 	}
 	return &TestPushConn{Conn: conn, transport: rt}


### PR DESCRIPTION
Closes #119

## Summary

- Add `CancelCause(ctx)` context accessor that returns why a request was canceled
- Add three sentinel errors: `ErrClientCanceled`, `ErrConnectionClosed`, `ErrServerShutdown`
- Switch internal context creation from `context.WithCancel` to `context.WithCancelCause`
- Pass the appropriate cause at each cancellation site (client cancel, connection close, server shutdown)

## Test plan

- [x] `TestCancelCause_ClientCancel` — verifies `ErrClientCanceled` when client sends TypeCancel
- [x] `TestCancelCause_ConnectionClose` — verifies `ErrConnectionClosed` when WebSocket is closed
- [x] `TestCancelCause_ServerShutdown` — verifies `ErrServerShutdown` when server.Stop() is called
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)