### PR TITLE
Fix phantom shared type imports from substring matching

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -818,6 +818,32 @@ func (g *Generator) buildEnums() []enumTemplateData {
 	return enums
 }
 
+// isIdentChar reports whether c is a valid Go/TypeScript identifier character.
+func isIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+// containsTypeName checks whether name appears as a complete identifier in typeStr,
+// not as a substring of a longer identifier. For example, containsTypeName("UserProfile", "User")
+// returns false, but containsTypeName("User[]", "User") returns true.
+func containsTypeName(typeStr, name string) bool {
+	idx := 0
+	for {
+		i := strings.Index(typeStr[idx:], name)
+		if i < 0 {
+			return false
+		}
+		start := idx + i
+		end := start + len(name)
+		startOk := start == 0 || !isIdentChar(typeStr[start-1])
+		endOk := end == len(typeStr) || !isIdentChar(typeStr[end])
+		if startOk && endOk {
+			return true
+		}
+		idx = start + 1
+	}
+}
+
 // findBaseTypeImports returns the set of base type names referenced by the handler's
 // interface fields, method responses, and push event data types. These need to be
 // imported from './client' in multi-file mode.
@@ -826,7 +852,7 @@ func findBaseTypeImports(data *templateData, baseTypeNames map[string]bool) []st
 	for _, iface := range data.Interfaces {
 		for _, field := range iface.Fields {
 			for name := range baseTypeNames {
-				if strings.Contains(field.Type, name) {
+				if containsTypeName(field.Type, name) {
 					referenced[name] = true
 				}
 			}
@@ -834,13 +860,13 @@ func findBaseTypeImports(data *templateData, baseTypeNames map[string]bool) []st
 	}
 	for _, m := range data.Methods {
 		for name := range baseTypeNames {
-			if strings.Contains(m.ResponseType, name) {
+			if containsTypeName(m.ResponseType, name) {
 				referenced[name] = true
 			}
 		}
 		for _, p := range m.Params {
 			for name := range baseTypeNames {
-				if strings.Contains(p.Type, name) {
+				if containsTypeName(p.Type, name) {
 					referenced[name] = true
 				}
 			}
@@ -848,7 +874,7 @@ func findBaseTypeImports(data *templateData, baseTypeNames map[string]bool) []st
 	}
 	for _, ev := range data.PushEvents {
 		for name := range baseTypeNames {
-			if strings.Contains(ev.DataType, name) {
+			if containsTypeName(ev.DataType, name) {
 				referenced[name] = true
 			}
 		}
@@ -877,7 +903,7 @@ func findSharedTypeImports(data *templateData, sharedTypeNames map[string]string
 	byModule := make(map[string]map[string]bool)
 	scanRef := func(text string) {
 		for name, module := range sharedTypeNames {
-			if strings.Contains(text, name) {
+			if containsTypeName(text, name) {
 				if byModule[module] == nil {
 					byModule[module] = make(map[string]bool)
 				}

--- a/generate_test.go
+++ b/generate_test.go
@@ -2606,3 +2606,93 @@ func TestGenerateSharedTypeDedupWithNestedTypes(t *testing.T) {
 		t.Error("Expected GetUserRequest import from './aprot' in push-group-a.ts")
 	}
 }
+
+func TestContainsTypeName(t *testing.T) {
+	tests := []struct {
+		typeStr string
+		name    string
+		want    bool
+	}{
+		{"StationHistoryActionType", "HistoryAction", false},
+		{"HistoryAction[]", "HistoryAction", true},
+		{"HistoryAction", "HistoryAction", true},
+		{"Record<string, HistoryAction>", "HistoryAction", true},
+		{"HistoryAction | null", "HistoryAction", true},
+		{"SomeHistoryAction", "HistoryAction", false},
+		{"HistoryActionExtra", "HistoryAction", false},
+		{"User", "User", true},
+		{"User[]", "User", true},
+		{"UserProfile", "User", false},
+		{"AdminUser", "User", false},
+	}
+	for _, tt := range tests {
+		got := containsTypeName(tt.typeStr, tt.name)
+		if got != tt.want {
+			t.Errorf("containsTypeName(%q, %q) = %v, want %v", tt.typeStr, tt.name, got, tt.want)
+		}
+	}
+}
+
+// PhantomResp is shared between two groups. It has a field whose type name
+// is a superstring of PhantomResp's name (PhantomRespDetailType enum).
+type PhantomResp struct {
+	ID     string               `json:"id"`
+	Detail PhantomRespDetailType `json:"detail"`
+}
+
+type PhantomRespDetailType string
+
+type PhantomGroupSpecific struct {
+	Value string `json:"value"`
+}
+
+type PhantomGroupA struct{}
+
+func (h *PhantomGroupA) DoA(ctx context.Context) (*PhantomResp, error) { return nil, nil }
+
+type PhantomGroupB struct{}
+
+func (h *PhantomGroupB) DoB(ctx context.Context) (*PhantomResp, error)            { return nil, nil }
+func (h *PhantomGroupB) DoB2(ctx context.Context) (*PhantomGroupSpecific, error) { return nil, nil }
+
+func TestGenerateSharedTypeNoPhantomImports(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&PhantomGroupA{})
+	registry.Register(&PhantomGroupB{})
+
+	gen := NewGenerator(registry)
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// PhantomResp is shared, goes to aprot.ts
+	sharedContent, ok := files["aprot.ts"]
+	if !ok {
+		t.Fatalf("Expected aprot.ts, got files: %v", mapKeys(files))
+	}
+	if !strings.Contains(sharedContent, "export interface PhantomResp") {
+		t.Error("Expected PhantomResp in aprot.ts")
+	}
+
+	// PhantomGroupB has DoB2 returning PhantomGroupSpecific — it references PhantomResp
+	// only via method return type, not PhantomRespDetailType. The handler should NOT
+	// import PhantomResp (it's not used directly in the handler file — only in the shared file's fields).
+	groupBContent := files["phantom-group-b.ts"]
+
+	// PhantomGroupSpecific should be in handler file (only used by group B)
+	if !strings.Contains(groupBContent, "export interface PhantomGroupSpecific") {
+		t.Error("Expected PhantomGroupSpecific in phantom-group-b.ts")
+	}
+
+	// PhantomResp SHOULD be imported (it's the return type of DoB)
+	if !strings.Contains(groupBContent, "PhantomResp") {
+		t.Error("Expected PhantomResp import in phantom-group-b.ts")
+	}
+
+	// PhantomRespDetailType should NOT be imported (it's only used inside PhantomResp in the shared file)
+	// This is the phantom import bug — "PhantomResp" is a substring of "PhantomRespDetailType"
+	if strings.Contains(groupBContent, "PhantomRespDetailType") {
+		t.Error("PhantomRespDetailType should NOT be imported in phantom-group-b.ts (phantom import from substring match)")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #123

`findBaseTypeImports` and `findSharedTypeImports` used `strings.Contains` to check if a type name appears in a TypeScript type string. This caused false positives when one type name is a substring of another — e.g., `HistoryAction` matched inside `StationHistoryActionType`, producing unused imports.

Replaced with `containsTypeName`, a word-boundary-aware check that only matches complete identifiers.

## Test plan

- [x] `TestContainsTypeName` — unit tests for word-boundary matching (11 cases including substring false positives)
- [x] `TestGenerateSharedTypeNoPhantomImports` — integration test with shared type whose field has a superstring enum name
- [x] All existing tests pass (`go test ./...`)
- [x] React example TypeScript type check (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)