### PR TITLE
Add LICENSE file to unblock pkg.go.dev documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcus Johansson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds a standalone ``LICENSE`` file at the module root with the full MIT license text
- Matches the MIT declaration already in ``README.md``
- Unblocks [pkg.go.dev/github.com/marrasen/aprot](https://pkg.go.dev/github.com/marrasen/aprot) which currently shows *"Documentation not displayed due to license restrictions"*

## Why

pkg.go.dev uses [``licensecheck``](https://pkg.go.dev/github.com/google/licensecheck) to detect a recognized OSI-approved license file. A mention in README is not sufficient — it needs an actual ``LICENSE`` / ``COPYING`` / ``LICENSE.md`` file with the full text. Without it, all godoc is hidden from the public documentation site.

After this merges and a new version is tagged, pkg.go.dev will pick up the license on its next module fetch via ``proxy.golang.org`` and start displaying the docs.

## Test plan

- [x] ``LICENSE`` file present at module root with full MIT text
- [x] Copyright line matches git author (Marcus Johansson, 2026)
- [ ] After merge + new tag, verify pkg.go.dev displays documentation

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)