### PR TITLE
Fix mobile reconnection failure after app switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Request cancellation** — clients cancel via AbortController; handlers see cancel cause
 - **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
-- **Automatic reconnection** — page visibility + network-aware, with exponential backoff
+- **Automatic reconnection** — page visibility + network-aware, with exponential backoff; supports dynamic URL functions for token refresh on reconnect
 
 ## Installation
 
@@ -296,6 +296,16 @@ function UsersList() {
         </>
     );
 }
+```
+
+**With auth tokens** (dynamic URL for automatic token refresh on reconnect):
+
+```typescript
+const client = new ApiClient(async () => {
+    const token = await getAuthToken();
+    return `${getWebSocketUrl()}?token=${encodeURIComponent(token)}`;
+});
+await client.connect();
 ```
 
 **Vanilla:**

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -114,13 +114,24 @@ class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
     connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
+            // Detach and close previous socket so its deferred onclose
+            // cannot interfere with the new connection (mobile wake race).
+            if (this.ws) {
+                this.ws.onclose = null;
+                this.ws.onerror = null;
+                this.ws.onmessage = null;
+                this.ws.close();
+                this.ws = null;
+            }
+            let opened = false;
             this.ws = new WebSocket(url);
-            this.ws.onopen = () => resolve();
+            this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
             this.ws.onclose = () => {
                 this.ws = null;
+                if (!opened) reject(new Error('WebSocket closed before open'));
                 onClose();
             };
         });
@@ -258,9 +269,16 @@ class SSETransport implements ClientTransport {
     }
 }
 
+/**
+ * url can be a string or a function returning a (possibly async) string.
+ * When a function is provided it is called before every connection attempt,
+ * allowing the caller to supply a fresh auth token on each reconnect.
+ */
+export type ApiClientUrl = string | (() => string | Promise<string>);
+
 export class ApiClient {
     private transport: ClientTransport;
-    private url: string;
+    private url: ApiClientUrl;
     private options: ResolvedOptions;
     private requestId = 0;
     private pending = new Map<string, {
@@ -294,7 +312,7 @@ export class ApiClient {
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
-    constructor(url: string, options?: ApiClientOptions) {
+    constructor(url: ApiClientUrl, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
         this.transport = this.options.transport === 'sse'
@@ -311,11 +329,13 @@ export class ApiClient {
         return this.doConnect();
     }
 
-    private doConnect(): Promise<void> {
+    private async doConnect(): Promise<void> {
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
+        const url = typeof this.url === 'function' ? await this.url() : this.url;
+
         return this.transport.connect(
-            this.url,
+            url,
             (data) => this.handleMessage(data),
             () => this.handleClose(),
         ).then(() => {

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -112,13 +112,24 @@ class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
     connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
+            // Detach and close previous socket so its deferred onclose
+            // cannot interfere with the new connection (mobile wake race).
+            if (this.ws) {
+                this.ws.onclose = null;
+                this.ws.onerror = null;
+                this.ws.onmessage = null;
+                this.ws.close();
+                this.ws = null;
+            }
+            let opened = false;
             this.ws = new WebSocket(url);
-            this.ws.onopen = () => resolve();
+            this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
             this.ws.onclose = () => {
                 this.ws = null;
+                if (!opened) reject(new Error('WebSocket closed before open'));
                 onClose();
             };
         });
@@ -256,9 +267,16 @@ class SSETransport implements ClientTransport {
     }
 }
 
+/**
+ * url can be a string or a function returning a (possibly async) string.
+ * When a function is provided it is called before every connection attempt,
+ * allowing the caller to supply a fresh auth token on each reconnect.
+ */
+export type ApiClientUrl = string | (() => string | Promise<string>);
+
 export class ApiClient {
     private transport: ClientTransport;
-    private url: string;
+    private url: ApiClientUrl;
     private options: ResolvedOptions;
     private requestId = 0;
     private pending = new Map<string, {
@@ -292,7 +310,7 @@ export class ApiClient {
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
-    constructor(url: string, options?: ApiClientOptions) {
+    constructor(url: ApiClientUrl, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
         this.transport = this.options.transport === 'sse'
@@ -309,11 +327,13 @@ export class ApiClient {
         return this.doConnect();
     }
 
-    private doConnect(): Promise<void> {
+    private async doConnect(): Promise<void> {
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
+        const url = typeof this.url === 'function' ? await this.url() : this.url;
+
         return this.transport.connect(
-            this.url,
+            url,
             (data) => this.handleMessage(data),
             () => this.handleClose(),
         ).then(() => {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -118,13 +118,24 @@ class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
     connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
+            // Detach and close previous socket so its deferred onclose
+            // cannot interfere with the new connection (mobile wake race).
+            if (this.ws) {
+                this.ws.onclose = null;
+                this.ws.onerror = null;
+                this.ws.onmessage = null;
+                this.ws.close();
+                this.ws = null;
+            }
+            let opened = false;
             this.ws = new WebSocket(url);
-            this.ws.onopen = () => resolve();
+            this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
             this.ws.onclose = () => {
                 this.ws = null;
+                if (!opened) reject(new Error('WebSocket closed before open'));
                 onClose();
             };
         });
@@ -262,9 +273,16 @@ class SSETransport implements ClientTransport {
     }
 }
 
+/**
+ * url can be a string or a function returning a (possibly async) string.
+ * When a function is provided it is called before every connection attempt,
+ * allowing the caller to supply a fresh auth token on each reconnect.
+ */
+export type ApiClientUrl = string | (() => string | Promise<string>);
+
 export class ApiClient {
     private transport: ClientTransport;
-    private url: string;
+    private url: ApiClientUrl;
     private options: ResolvedOptions;
     private requestId = 0;
     private pending = new Map<string, {
@@ -298,7 +316,7 @@ export class ApiClient {
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
-    constructor(url: string, options?: ApiClientOptions) {
+    constructor(url: ApiClientUrl, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
         this.transport = this.options.transport === 'sse'
@@ -315,11 +333,13 @@ export class ApiClient {
         return this.doConnect();
     }
 
-    private doConnect(): Promise<void> {
+    private async doConnect(): Promise<void> {
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
+        const url = typeof this.url === 'function' ? await this.url() : this.url;
+
         return this.transport.connect(
-            this.url,
+            url,
             (data) => this.handleMessage(data),
             () => this.handleClose(),
         ).then(() => {


### PR DESCRIPTION
Closes #151

## Summary

- Accept `url` as `string | (() => string | Promise<string>)` in `ApiClient` constructor — each reconnection attempt resolves the URL function, allowing callers to supply a fresh auth token on every reconnect
- Clean up the previous WebSocket before creating a new one in `connect()`, preventing the old socket's deferred `onclose` from sabotaging the new connection on mobile wake
- Properly reject the `connect()` Promise when the WebSocket closes before opening, so `doConnect()`'s `.catch()` triggers `scheduleReconnect()` instead of leaving a dangling promise

## Test plan

- [x] `go test ./...` passes
- [x] `npx tsc --noEmit` passes on generated React client
- [x] Example clients regenerated
- [ ] Manual mobile test: connect → switch to another app for 2+ minutes → switch back → should reconnect silently with a fresh token

🤖 Generated with [Claude Code](https://claude.com/claude-code)