### PR TITLE
Fix omitempty on ResponseMessage.Result dropping empty slices

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -37,7 +37,7 @@ type IncomingMessage struct {
 type ResponseMessage struct {
 	Type   MessageType `json:"type"`
 	ID     string      `json:"id"`
-	Result any         `json:"result,omitempty"`
+	Result any         `json:"result"`
 }
 
 // ErrorMessage represents an error response from server to client.


### PR DESCRIPTION
## Summary
- Remove `omitempty` from `ResponseMessage.Result` in `protocol.go`
- The `go-json-experiment/json` library treats empty slices as "empty" for `omitempty`, causing the `result` field to be omitted entirely when handlers return empty slices (e.g. `[]Holiday{}`)
- Clients then receive `undefined` instead of `[]`, causing crashes like `can't access property "some", holidays is undefined`

Closes #154

## Test plan
- [ ] All existing aprot tests pass
- [ ] Start a server with a handler returning an empty slice, verify the response includes `"result":[]`
- [ ] Verify client receives `[]` instead of `undefined` for empty results

🤖 Generated with [Claude Code](https://claude.com/claude-code)