### PR TITLE
Fix useIsLoading getting stuck after WebSocket reconnect

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -7,8 +7,8 @@ import { EventSource } from 'eventsource';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Polyfill browser APIs for Node.js test environment
-(globalThis as any).WebSocket = WebSocket;
-(globalThis as any).EventSource = EventSource;
+(globalThis as unknown as Record<string, unknown>).WebSocket = WebSocket;
+(globalThis as unknown as Record<string, unknown>).EventSource = EventSource;
 
 export function getServerAddr(): string {
     return readFileSync(join(__dirname, '..', '.test-server-addr'), 'utf-8').trim();

--- a/e2e/tests/ws.test.ts
+++ b/e2e/tests/ws.test.ts
@@ -130,7 +130,7 @@ describe('WebSocket Transport', () => {
 
         // Subscribe and wait for initial data
         await new Promise<void>((resolve) => {
-            subscribeListUsers(client, (result: ListUsersResponse) => {
+            subscribeListUsers(client, (_result: ListUsersResponse) => {
                 resolve();
             });
         });

--- a/e2e/tests/ws.test.ts
+++ b/e2e/tests/ws.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { wsUrl } from './helpers';
 import { ApiClient, ApiError } from '../api/client';
-import { TaskStatus, createUser, getUser, listUsers, getTask, processBatch, sendNotification, onUserCreatedEvent, onSystemNotificationEvent } from '../api/public-handlers';
+import { TaskStatus, createUser, getUser, listUsers, getTask, processBatch, sendNotification, onUserCreatedEvent, onSystemNotificationEvent, subscribeListUsers } from '../api/public-handlers';
+import type { ListUsersResponse } from '../api/public-handlers';
 
 describe('WebSocket Transport', () => {
     let client: ApiClient;
@@ -121,6 +122,22 @@ describe('WebSocket Transport', () => {
             expect(err).toBeInstanceOf(ApiError);
             expect((err as ApiError).isInvalidParams()).toBe(true);
         }
+    });
+
+    test('getLoadingCount excludes subscription pending entries', async () => {
+        // Before subscribing, loading count should be 0
+        expect(client.getLoadingCount()).toBe(0);
+
+        // Subscribe and wait for initial data
+        await new Promise<void>((resolve) => {
+            subscribeListUsers(client, (result: ListUsersResponse) => {
+                resolve();
+            });
+        });
+
+        // After subscription data arrives, loading count should still be 0.
+        // Subscription pending entries must not count toward getLoadingCount().
+        expect(client.getLoadingCount()).toBe(0);
     });
 
     test('unknown method throws ApiError with isNotFound', async () => {

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -433,7 +433,11 @@ export class ApiClient {
     }
 
     getLoadingCount(): number {
-        return this.pending.size + this.buffer.length;
+        let count = this.buffer.length;
+        for (const id of this.pending.keys()) {
+            if (!this.subscriptions.has(id)) count++;
+        }
+        return count;
     }
 
     isConnected(): boolean {
@@ -665,6 +669,7 @@ export class ApiClient {
             });
             this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params });
         }
+        this.notifyLoadingChange();
     }
 
     onPush<T>(event: string, handler: PushHandler<T>): () => void {

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -431,7 +431,11 @@ export class ApiClient {
     }
 
     getLoadingCount(): number {
-        return this.pending.size + this.buffer.length;
+        let count = this.buffer.length;
+        for (const id of this.pending.keys()) {
+            if (!this.subscriptions.has(id)) count++;
+        }
+        return count;
     }
 
     isConnected(): boolean {
@@ -663,6 +667,7 @@ export class ApiClient {
             });
             this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params });
         }
+        this.notifyLoadingChange();
     }
 
     onPush<T>(event: string, handler: PushHandler<T>): () => void {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -437,7 +437,11 @@ export class ApiClient {
     }
 
     getLoadingCount(): number {
-        return this.pending.size + this.buffer.length;
+        let count = this.buffer.length;
+        for (const id of this.pending.keys()) {
+            if (!this.subscriptions.has(id)) count++;
+        }
+        return count;
     }
 
     isConnected(): boolean {
@@ -669,6 +673,7 @@ export class ApiClient {
             });
             this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params });
         }
+        this.notifyLoadingChange();
     }
 
     onPush<T>(event: string, handler: PushHandler<T>): () => void {


### PR DESCRIPTION
## Summary

Closes #160

- `getLoadingCount()` now excludes subscription entries from `this.pending` by checking against `this.subscriptions`, so `useIsLoading()` only reflects actual user-initiated requests
- `resubscribeAll()` now calls `notifyLoadingChange()` after re-adding subscription entries to `pending`

The cached subscription hooks (`useQuery` with cache) were not affected — they track `isLoading` via their own `snapshot.isLoading`.

## Test plan

- [x] Existing Go tests pass (`go test ./...`)
- [x] Regenerated vanilla, react, and e2e clients
- [x] React client TypeScript check passes (`npx tsc --noEmit`)
- [x] New e2e test: `getLoadingCount excludes subscription pending entries`
- [x] All WS, subscription, and query-cache e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)