### PR TITLE
Fix subscribeCached.getSnapshot returning fresh object every call

### DIFF
--- a/e2e/tests/query-cache.test.ts
+++ b/e2e/tests/query-cache.test.ts
@@ -18,6 +18,14 @@ interface Snapshot<T = unknown> {
     isLoading: boolean;
 }
 
+// Stable fallback returned by getSnapshot before data arrives. Mirrors the
+// generated client -- see templates/_client-common.ts.tmpl.
+const EMPTY_SNAPSHOT: Snapshot = Object.freeze({
+    data: null,
+    error: null,
+    isLoading: true,
+});
+
 interface CacheEntry {
     snapshot: Snapshot;
     listeners: Set<() => void>;
@@ -94,7 +102,7 @@ function subscribeCached<T>(
 
     function getSnapshot(): Snapshot<T> {
         const entry = cache.get(key);
-        return (entry?.snapshot ?? { data: null, error: null, isLoading: true }) as Snapshot<T>;
+        return (entry?.snapshot ?? EMPTY_SNAPSHOT) as Snapshot<T>;
     }
 
     return { subscribe, getSnapshot };
@@ -298,5 +306,23 @@ describe('Query Subscription Cache', () => {
         expect(snap.data).toBeNull();
         expect(snap.isLoading).toBe(true);
         expect(snap.error).toBeNull();
+    });
+
+    test('getSnapshot returns stable reference before data arrives (issue #164)', () => {
+        const store = subscribeCached<ListUsersResponse>(
+            client, 'stable-ref:[]', 'PublicHandlers.ListUsers', [],
+        );
+
+        const s1 = store.getSnapshot();
+        const s2 = store.getSnapshot();
+        const s3 = store.getSnapshot();
+
+        // Object.is -- same identity check React's useSyncExternalStore uses.
+        // Without a stable fallback, React aborts with an "infinite loop"
+        // warning and the hook never receives subscription updates.
+        expect(Object.is(s1, s2)).toBe(true);
+        expect(Object.is(s2, s3)).toBe(true);
+        expect(s1.data).toBeNull();
+        expect(s1.isLoading).toBe(true);
     });
 });

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -927,6 +927,16 @@ interface SubscriptionSnapshot<T = unknown> {
     isLoading: boolean;
 }
 
+// Stable fallback returned by getSnapshot before the subscription has produced
+// data. React's useSyncExternalStore compares snapshots with Object.is and
+// aborts with an "infinite loop" warning if getSnapshot returns a fresh object
+// on each call.
+const EMPTY_SNAPSHOT: SubscriptionSnapshot = Object.freeze({
+    data: null,
+    error: null,
+    isLoading: true,
+});
+
 interface SubscriptionCacheEntry {
     snapshot: SubscriptionSnapshot;
     listeners: Set<() => void>;
@@ -1003,7 +1013,7 @@ function subscribeCached<T>(
 
     function getSnapshot(): SubscriptionSnapshot<T> {
         const entry = cache.get(key);
-        return (entry?.snapshot ?? { data: null, error: null, isLoading: true }) as SubscriptionSnapshot<T>;
+        return (entry?.snapshot ?? EMPTY_SNAPSHOT) as SubscriptionSnapshot<T>;
     }
 
     return { subscribe, getSnapshot };

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -954,6 +954,16 @@ interface SubscriptionSnapshot<T = unknown> {
     isLoading: boolean;
 }
 
+// Stable fallback returned by getSnapshot before the subscription has produced
+// data. React's useSyncExternalStore compares snapshots with Object.is and
+// aborts with an "infinite loop" warning if getSnapshot returns a fresh object
+// on each call.
+const EMPTY_SNAPSHOT: SubscriptionSnapshot = Object.freeze({
+    data: null,
+    error: null,
+    isLoading: true,
+});
+
 interface SubscriptionCacheEntry {
     snapshot: SubscriptionSnapshot;
     listeners: Set<() => void>;
@@ -1030,7 +1040,7 @@ function subscribeCached<T>(
 
     function getSnapshot(): SubscriptionSnapshot<T> {
         const entry = cache.get(key);
-        return (entry?.snapshot ?? { data: null, error: null, isLoading: true }) as SubscriptionSnapshot<T>;
+        return (entry?.snapshot ?? EMPTY_SNAPSHOT) as SubscriptionSnapshot<T>;
     }
 
     return { subscribe, getSnapshot };


### PR DESCRIPTION
## Summary

- `templates/_client-common.ts.tmpl`: `getSnapshot` returned a fresh `{data, error, isLoading}` literal whenever the cache entry didn't exist yet. React's `useSyncExternalStore` compares snapshots with `Object.is`, so every call looked like a change — React aborted the consumer with *"The result of getSnapshot should be cached to avoid an infinite loop"* and the hook never received subscription updates. Return a frozen module-level `EMPTY_SNAPSHOT` constant as the fallback so identity holds until a real payload arrives.
- `e2e/tests/query-cache.test.ts`: mirror the fix in the hand-rolled replica and add a regression test asserting `Object.is` identity across consecutive pre-data `getSnapshot` calls.
- `example/react/client/src/api/client.ts`: regenerated from the updated template.

Fixes #164

## Test plan

- [x] `go test ./...`
- [x] `cd example/react/tools/generate && go run main.go` (regenerates client cleanly)
- [x] `cd example/react/client && npx tsc --noEmit`
- [x] `cd e2e && npx vitest run tests/query-cache.test.ts` — 8/8 pass, including the new `getSnapshot returns stable reference before data arrives (issue #164)` case

🤖 Generated with [Claude Code](https://claude.com/claude-code)