### PR TITLE
Fix Zod codegen: validate omitempty, required+min dedup, sql.Null* nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,11 +364,17 @@ This produces `{handler}.schema.ts` files with Zod schemas for any struct that h
 import { z } from 'zod';
 
 export const CreateUserRequestSchema = z.object({
-    name: z.string().min(1).min(2).max(100),
+    name: z.string().min(2).max(100),
     email: z.string().min(1).email(),
     age: z.number().int().min(13).max(120),
 });
 ```
+
+A few validate-tag semantics worth knowing when designing your request structs:
+
+- **`omitempty` on a string** (`validate:"omitempty,url,max=500"`) mirrors `go-playground/validator`'s server behavior: the empty string is the Go zero value, so subsequent rules are skipped. The generated Zod schema wraps the chain in `z.union([z.literal(""), ...]).optional()`, so `""` and `undefined` both pass — useful for optional form fields where the browser submits `""` rather than omitting the key. `omitempty` on non-string kinds just appends `.optional()`.
+- **`sql.NullString` / `sql.NullInt64` / `sql.NullTime` / `sql.NullBool` / `sql.Null[T]`** are unwrapped on both sides: the TypeScript type becomes `T | null` and the Zod schema becomes `z.<base>().nullable()`, with any `validate` tag constraints still applied to the inner type.
+- **`url` and `email` are absolute-only** because that's how `go-playground/validator` defines them upstream. `validate:"url"` rejects app-internal paths like `/images/123/mobile`, and `email` is strict about the formats it accepts. Not an aprot choice — just a footgun to know about so you don't fight it for half an hour. If you need relative URLs, fall back to `validate:"max=500"` or a custom validator.
 
 ## REST Adapter
 

--- a/example/react/client/src/api/todos.schema.ts
+++ b/example/react/client/src/api/todos.schema.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 export const CreateTodoRequestSchema = z.object({
-    title: z.string().min(1).min(1).max(200),
+    title: z.string().min(1).max(200),
     description: z.string().max(1000),
     priority: z.number().int().min(1).max(5),
 });
@@ -10,8 +10,8 @@ export const CreateTodoRequestSchema = z.object({
 export type CreateTodoRequest = z.infer<typeof CreateTodoRequestSchema>;
 
 export const UpdateTodoRequestSchema = z.object({
-    title: z.string().min(1).max(200).optional(),
-    description: z.string().max(1000).optional(),
+    title: z.union([z.literal(""), z.string().min(1).max(200)]).optional(),
+    description: z.union([z.literal(""), z.string().max(1000)]).optional(),
     priority: z.number().int().min(1).max(5).optional(),
     done: z.boolean().optional(),
 });

--- a/generate.go
+++ b/generate.go
@@ -120,6 +120,40 @@ func SQLNullTSType(t reflect.Type, typeResolver func(reflect.Type) string) strin
 	}
 }
 
+// SQLNullGoKind returns the unwrapped Go kind string ("string", "int", "float",
+// "bool") for database/sql nullable wrappers, parallel to SQLNullTSType. Returns
+// "" if t is not a sql.Null type. kindResolver handles the generic Null[T] case
+// and is typically goKindString.
+//
+// This is the Zod-side companion to SQLNullTSType: rather than sniffing the
+// TypeScript output for a " | null" suffix, we derive the unwrapped kind
+// directly from reflection so fieldData carries the information explicitly.
+func SQLNullGoKind(t reflect.Type, kindResolver func(reflect.Type) string) string {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.PkgPath() != "database/sql" {
+		return ""
+	}
+	switch t.Name() {
+	case "NullString", "NullTime":
+		return "string"
+	case "NullInt64", "NullInt32", "NullInt16", "NullByte":
+		return "int"
+	case "NullFloat64":
+		return "float"
+	case "NullBool":
+		return "bool"
+	default:
+		if strings.HasPrefix(t.Name(), "Null[") {
+			if vField, ok := t.FieldByName("V"); ok {
+				return kindResolver(vField.Type)
+			}
+		}
+		return ""
+	}
+}
+
 // inferObjectType unmarshals JSON object data and infers a Record<string, T> type.
 // Returns Record<string, any> for empty or heterogeneous objects.
 func inferObjectType(data []byte) *MarshalTSType {
@@ -331,6 +365,11 @@ type fieldData struct {
 	Optional    bool
 	GoType      string // Go kind for Zod/OpenAPI mapping (e.g., "string", "int", "float64")
 	ValidateTag string // raw validate tag, e.g., "required,min=3,max=100"
+	// SQLNullKind is non-empty when the underlying Go type is a database/sql
+	// nullable wrapper (NullString, NullInt64, Null[T], etc.). Its value is the
+	// unwrapped Go kind ("string", "int", "float", "bool"); Zod codegen uses it
+	// to emit the correct base type + a trailing .nullable(). Empty otherwise.
+	SQLNullKind string
 }
 
 type paramData struct {
@@ -1045,6 +1084,7 @@ func (g *Generator) collectInterfaceFields(t reflect.Type) []fieldData {
 			Optional:    g.isOptional(field),
 			GoType:      goKindString(field.Type),
 			ValidateTag: field.Tag.Get("validate"),
+			SQLNullKind: SQLNullGoKind(field.Type, goKindString),
 		})
 	}
 	return fields

--- a/zod.go
+++ b/zod.go
@@ -22,24 +22,76 @@ type zodFieldData struct {
 // goKind is "string", "int", "uint", "float", "bool", "slice", "map", or "struct".
 // tsType is the TypeScript type from goTypeToTS.
 // validateTag is the raw validate struct tag.
-func goTypeToZod(goKind string, tsType string, validateTag string, optional bool) string {
-	base := zodBaseType(goKind, tsType)
+// sqlNullKind is non-empty for database/sql nullable wrappers (NullString, etc.);
+// its value is the unwrapped kind ("string", "int", "float", "bool") and the
+// emitted chain gets a trailing .nullable().
+func goTypeToZod(goKind string, tsType string, validateTag string, optional bool, sqlNullKind string) string {
 	rules := ParseValidateTag(validateTag)
 
+	// Issue 3: sql.Null* wrappers. Use the unwrapped kind for base + constraints,
+	// then append .nullable() after constraints but before .optional().
+	effectiveKind := goKind
+	isNullable := false
+	if sqlNullKind != "" {
+		effectiveKind = sqlNullKind
+		isNullable = true
+	}
+
+	// Issue 1: validate-tag omitempty forces .optional(). For string kind, also
+	// wrap the chain in z.union([z.literal(""), ...]) so empty strings pass —
+	// go-playground/validator skips subsequent rules on the zero value ("" for
+	// strings), and client forms almost always emit "" rather than undefined.
+	hasValidateOmitempty := false
+	for _, r := range rules {
+		if r.Tag == "omitempty" {
+			hasValidateOmitempty = true
+			break
+		}
+	}
+	if hasValidateOmitempty {
+		optional = true
+	}
+
+	// Issue 2: if an explicit min rule is present on a string, skip the
+	// implicit required -> min(1) so we don't emit .min(1).min(N).
+	hasExplicitMin := false
+	for _, r := range rules {
+		if r.Tag == "min" {
+			hasExplicitMin = true
+			break
+		}
+	}
+
 	var chain []string
-	chain = append(chain, base)
+	chain = append(chain, zodBaseType(effectiveKind, tsType))
 
 	for _, r := range rules {
-		if zod := zodConstraint(goKind, r); zod != "" {
+		if r.Tag == "omitempty" {
+			continue
+		}
+		if r.Tag == "required" && effectiveKind == "string" && hasExplicitMin {
+			continue
+		}
+		if zod := zodConstraint(effectiveKind, r); zod != "" {
 			chain = append(chain, zod)
 		}
 	}
 
-	if optional {
-		chain = append(chain, "optional()")
+	if isNullable {
+		chain = append(chain, "nullable()")
 	}
 
-	return "z." + strings.Join(chain, ".")
+	body := "z." + strings.Join(chain, ".")
+
+	if hasValidateOmitempty && effectiveKind == "string" {
+		body = `z.union([z.literal(""), ` + body + `])`
+	}
+
+	if optional {
+		body += ".optional()"
+	}
+
+	return body
 }
 
 // zodBaseType returns the base Zod type for a Go kind.
@@ -138,7 +190,7 @@ func buildZodSchemas(interfaces []interfaceData) []zodSchemaData {
 		for _, f := range iface.Fields {
 			schema.Fields = append(schema.Fields, zodFieldData{
 				Name:    f.Name,
-				ZodType: goTypeToZod(f.GoType, f.Type, f.ValidateTag, f.Optional),
+				ZodType: goTypeToZod(f.GoType, f.Type, f.ValidateTag, f.Optional, f.SQLNullKind),
 			})
 		}
 		schemas = append(schemas, schema)

--- a/zod_test.go
+++ b/zod_test.go
@@ -1,9 +1,26 @@
 package aprot
 
 import (
+	"context"
+	"database/sql"
 	"strings"
 	"testing"
 )
+
+// PilotQuirksRequest exercises the three Zod codegen fixes from issue #163:
+// Issue 1 (validate omitempty), Issue 2 (required+min dedup), Issue 3 (sql.Null*).
+type PilotQuirksRequest struct {
+	Name     string         `json:"name"     validate:"required,min=2,max=50"` // Issue 2: no leading .min(1)
+	ImageURL string         `json:"imageUrl" validate:"omitempty,url,max=500"` // Issue 1: empty-literal union
+	ParentID sql.NullInt64  `json:"parentId"`                                  // Issue 3: nullable number
+	Bio      sql.NullString `json:"bio"      validate:"max=500"`               // Issue 3 + constraint
+}
+
+type PilotQuirksHandlers struct{}
+
+func (h *PilotQuirksHandlers) Submit(ctx context.Context, req *PilotQuirksRequest) error {
+	return nil
+}
 
 func TestGoTypeToZod(t *testing.T) {
 	tests := []struct {
@@ -12,23 +29,50 @@ func TestGoTypeToZod(t *testing.T) {
 		tsType      string
 		validateTag string
 		optional    bool
+		sqlNullKind string
 		want        string
 	}{
-		{"string required min/max", "string", "string", "required,min=3,max=100", false, "z.string().min(1).min(3).max(100)"},
-		{"string email", "string", "string", "email", false, "z.string().email()"},
-		{"int range", "int", "number", "gte=12,lte=110", false, "z.number().int().min(12).max(110)"},
-		{"optional string", "string", "string", "", true, "z.string().optional()"},
-		{"uuid", "string", "string", "uuid", false, "z.string().uuid()"},
-		{"url", "string", "string", "url", false, "z.string().url()"},
-		{"bool no validation", "bool", "boolean", "", false, "z.boolean()"},
-		{"float", "float", "number", "gte=0", false, "z.number().min(0)"},
+		// Baselines
+		{"string required min/max", "string", "string", "required,min=3,max=100", false, "", "z.string().min(3).max(100)"},
+		{"string email", "string", "string", "email", false, "", "z.string().email()"},
+		{"int range", "int", "number", "gte=12,lte=110", false, "", "z.number().int().min(12).max(110)"},
+		{"optional string", "string", "string", "", true, "", "z.string().optional()"},
+		{"uuid", "string", "string", "uuid", false, "", "z.string().uuid()"},
+		{"url", "string", "string", "url", false, "", "z.string().url()"},
+		{"bool no validation", "bool", "boolean", "", false, "", "z.boolean()"},
+		{"float", "float", "number", "gte=0", false, "", "z.number().min(0)"},
+
+		// Issue 2: required + explicit min dedup (regression coverage below)
+		{"string required alone keeps min(1)", "string", "string", "required", false, "", "z.string().min(1)"},
+		{"string required + max keeps min(1)", "string", "string", "required,max=50", false, "", "z.string().min(1).max(50)"},
+		{"int required no min(1)", "int", "number", "required,gte=1", false, "", "z.number().int().min(1)"},
+
+		// Issue 1: validate-tag omitempty on strings wraps with empty-literal union
+		{"string omitempty url max", "string", "string", "omitempty,url,max=500", false, "", `z.union([z.literal(""), z.string().url().max(500)]).optional()`},
+		{"string omitempty alone", "string", "string", "omitempty", false, "", `z.union([z.literal(""), z.string()]).optional()`},
+		{"string omitempty email", "string", "string", "omitempty,email", false, "", `z.union([z.literal(""), z.string().email()]).optional()`},
+		// Non-string kinds just get .optional(), no union wrap
+		{"int omitempty gte", "int", "number", "omitempty,gte=1", false, "", "z.number().int().min(1).optional()"},
+		{"bool omitempty", "bool", "boolean", "omitempty", false, "", "z.boolean().optional()"},
+		// json-omitempty (already sets optional=true) on a string without validate omitempty keeps plain .optional()
+		{"pointer string no validate omitempty", "string", "string", "", true, "", "z.string().optional()"},
+
+		// Issue 3: SQLNullKind drives nullable base + constraints
+		{"sql NullString", "struct", "string | null", "", false, "string", "z.string().nullable()"},
+		{"sql NullString with max", "struct", "string | null", "max=10", false, "string", "z.string().max(10).nullable()"},
+		{"sql NullInt64", "struct", "number | null", "", false, "int", "z.number().int().nullable()"},
+		{"sql NullInt64 with range", "struct", "number | null", "gte=0,lte=100", false, "int", "z.number().int().min(0).max(100).nullable()"},
+		{"sql NullFloat64", "struct", "number | null", "", false, "float", "z.number().nullable()"},
+		{"sql NullBool", "struct", "boolean | null", "", false, "bool", "z.boolean().nullable()"},
+		// Regression: plain struct with no SQLNullKind still falls through to z.any()
+		{"plain struct any", "struct", "SomeStruct", "", false, "", "z.any()"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := goTypeToZod(tt.goKind, tt.tsType, tt.validateTag, tt.optional)
+			got := goTypeToZod(tt.goKind, tt.tsType, tt.validateTag, tt.optional, tt.sqlNullKind)
 			if got != tt.want {
-				t.Errorf("goTypeToZod(%q, %q, %q, %v) = %q, want %q", tt.goKind, tt.tsType, tt.validateTag, tt.optional, got, tt.want)
+				t.Errorf("goTypeToZod(%q, %q, %q, %v, %q) = %q, want %q", tt.goKind, tt.tsType, tt.validateTag, tt.optional, tt.sqlNullKind, got, tt.want)
 			}
 		})
 	}
@@ -99,5 +143,59 @@ func TestZodGeneration_Integration(t *testing.T) {
 	}
 	if !strings.Contains(schemaFile, "z.number().int()") {
 		t.Error("schema file should contain z.number().int() for int fields")
+	}
+}
+
+func TestZodGeneration_PilotQuirks(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&PilotQuirksHandlers{})
+
+	gen := NewGenerator(registry).WithOptions(GeneratorOptions{
+		Mode: OutputVanilla,
+		Zod:  true,
+	})
+
+	results, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	var schemaFile string
+	for name, content := range results {
+		if strings.HasSuffix(name, ".schema.ts") {
+			schemaFile = content
+			break
+		}
+	}
+	if schemaFile == "" {
+		t.Fatal("expected a .schema.ts file to be generated")
+	}
+
+	expectations := []struct {
+		substr string
+		desc   string
+	}{
+		// Issue 2: required,min=2,max=50 emits .min(2).max(50), not .min(1).min(2).max(50)
+		{"name: z.string().min(2).max(50)", "Name field: no redundant .min(1)"},
+		// Issue 1: omitempty,url,max=500 on string wraps in empty-literal union and appends .optional()
+		{`imageUrl: z.union([z.literal(""), z.string().url().max(500)]).optional()`, "ImageURL: empty-literal union + optional"},
+		// Issue 3: sql.NullInt64 → z.number().int().nullable()
+		{"parentId: z.number().int().nullable()", "ParentID: nullable int base"},
+		// Issue 3 + existing constraint: sql.NullString with validate max=500 → z.string().max(500).nullable()
+		{"bio: z.string().max(500).nullable()", "Bio: sql.NullString with constraint + nullable"},
+	}
+	for _, exp := range expectations {
+		if !strings.Contains(schemaFile, exp.substr) {
+			t.Errorf("%s — expected schema to contain %q\n---\n%s", exp.desc, exp.substr, schemaFile)
+		}
+	}
+
+	// Regression: no .min(1).min(2) sequence anywhere (Issue 2 fix applies globally)
+	if strings.Contains(schemaFile, ".min(1).min(2)") {
+		t.Error("schema should not emit redundant .min(1) before explicit .min(N)")
+	}
+	// Regression: no .any() fallthrough for sql.Null fields (Issue 3 fix applies)
+	if strings.Contains(schemaFile, "parentId: z.any()") || strings.Contains(schemaFile, "bio: z.any()") {
+		t.Error("sql.Null* fields should not fall through to z.any()")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the three Zod codegen quirks documented in #163, all surfaced while wiring up the tgtr pilot:

1. **`validate:"omitempty,..."` is now honored.** For string kinds the chain is wrapped as `z.union([z.literal(""), ...]).optional()` so empty strings pass, matching go-playground/validator's server-side zero-value skip (which is what forms actually produce). Non-string kinds get plain `.optional()` since `0` / `false` shouldn't silently pass.
2. **`required,min=N` on strings no longer double-emits `.min(1)`.** `required` alone still emits `.min(1)`; adding an explicit `min` rule suppresses the implicit one.
3. **`sql.Null*` types now map to `z.<base>().nullable()`** instead of falling through to `z.any()`. New `SQLNullGoKind` helper parallels `SQLNullTSType` and a new `fieldData.SQLNullKind` field threads the unwrapped kind through to `goTypeToZod` so constraints still apply to the inner type.

Implementation follows the preferred approach from the issue: structured `SQLNullKind` field on `fieldData` (not sniffing `" | null"` suffix on `tsType`) to keep the data flow explicit and avoid coupling the Zod path to an undocumented invariant of `goTypeToTS`'s output.

## Evidence from the example regen

`example/react/client/src/api/todos.schema.ts` picks up both Issues 1 and 2 on real code:

\`\`\`diff
 export const CreateTodoRequestSchema = z.object({
-    title: z.string().min(1).min(1).max(200),
+    title: z.string().min(1).max(200),
     description: z.string().max(1000),
     priority: z.number().int().min(1).max(5),
 });

 export const UpdateTodoRequestSchema = z.object({
-    title: z.string().min(1).max(200).optional(),
-    description: z.string().max(1000).optional(),
+    title: z.union([z.literal(""), z.string().min(1).max(200)]).optional(),
+    description: z.union([z.literal(""), z.string().max(1000)]).optional(),
     priority: z.number().int().min(1).max(5).optional(),
     done: z.boolean().optional(),
 });
\`\`\`

- `CreateTodoRequest.Title` uses `validate:"required,min=1,max=200"` — Issue 2 fix drops the redundant `.min(1).min(1)`.
- `UpdateTodoRequest.Title` / `.Description` use `validate:"omitempty,...,"` — Issue 1 fix wraps with the empty-literal union. The `Priority` field (int with `omitempty`) keeps plain `.optional()` as designed.
- No `sql.Null*` fields in the example — Issue 3 is covered by a new integration test (`TestZodGeneration_PilotQuirks`).

## Tests

- **`TestGoTypeToZod`**: +16 new table cases covering Issue 1 (string + non-string omitempty), Issue 2 (`required` alone, `required,max`, `required,min,max`, int `required,gte`), Issue 3 (NullString, NullInt64, NullFloat64, NullBool, with and without constraints, plus a regression for plain structs still falling through to `z.any()`). The existing `"string required min/max"` expectation was flipped to match the corrected Issue 2 output.
- **`TestZodGeneration_PilotQuirks`**: new end-to-end test with a `PilotQuirksRequest` struct combining all three fixes + assertions against the generated `.schema.ts`.
- **Red-first confirmed**: test signature change made `go test ./...` fail to compile; fixes turn all 24 table cases + both integration tests green.

## Test plan

- [x] `go test ./...` — all passing
- [x] Regenerate `example/vanilla/tools/generate` + `example/react/tools/generate` clients
- [x] `cd example/react/client && npx tsc --noEmit` — clean
- [x] `gofmt -w zod.go zod_test.go generate.go`
- [x] Visual diff of regenerated `todos.schema.ts` — every change maps to one of the three fixes
- [x] `README.md` updated with validate-tag semantics note (omitempty on strings, `sql.Null*` mapping, `url`/`email` absolute-only footgun)

Fixes #163