### PR TITLE
Fix useQuery.refetch() no-op in cached subscription mode (#167)

### DIFF
--- a/e2e/tests/query-cache.test.ts
+++ b/e2e/tests/query-cache.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { wsUrl } from './helpers';
 import { ApiClient } from '../api/client';
-import { createUser } from '../api/public-handlers';
+import { createUser, listUsers } from '../api/public-handlers';
 import type { ListUsersResponse } from '../api/public-handlers';
 
 // ---------------------------------------------------------------------------
@@ -106,6 +106,22 @@ function subscribeCached<T>(
     }
 
     return { subscribe, getSnapshot };
+}
+
+// Mirrors the generated client's updateCachedSnapshot helper. Used by
+// useQuery.refetch() in cached mode to publish fresh data into the shared
+// cache and notify every listener.
+function updateCachedSnapshot<T>(
+    client: ApiClient,
+    key: string,
+    snapshot: Snapshot<T>,
+): void {
+    const cache = caches.get(client);
+    if (!cache) return;
+    const entry = cache.get(key);
+    if (!entry) return;
+    entry.snapshot = snapshot as Snapshot;
+    for (const l of entry.listeners) l();
 }
 
 // ---------------------------------------------------------------------------
@@ -294,6 +310,54 @@ describe('Query Subscription Cache', () => {
 
         expect(snap.data).not.toBeNull();
         expect(Array.isArray(snap.data!.users)).toBe(true);
+    });
+
+    test('updateCachedSnapshot notifies all subscribers with fresh data', async () => {
+        const key = 'listUsers:[]';
+        const store = subscribeCached<ListUsersResponse>(
+            client, key, 'PublicHandlers.ListUsers', [],
+        );
+
+        let notifyCountA = 0;
+        let notifyCountB = 0;
+        let lastSnapA: Snapshot<ListUsersResponse> | null = null;
+        let lastSnapB: Snapshot<ListUsersResponse> | null = null;
+
+        // Wait for initial subscription data before adding the second listener.
+        await new Promise<void>((resolve) => {
+            store.subscribe(() => {
+                const s = store.getSnapshot();
+                lastSnapA = s;
+                notifyCountA++;
+                if (!s.isLoading) resolve();
+            });
+        });
+        store.subscribe(() => {
+            lastSnapB = store.getSnapshot();
+            notifyCountB++;
+        });
+
+        const notifyCountABefore = notifyCountA;
+        const notifyCountBBefore = notifyCountB;
+
+        // Fetch fresh data out-of-band (simulates what refetch() does in
+        // cached mode) and publish it into the shared cache. No server-side
+        // TriggerRefresh is involved -- the push must be driven purely by
+        // updateCachedSnapshot's notify loop.
+        const fresh = await listUsers(client);
+        updateCachedSnapshot<ListUsersResponse>(client, key, {
+            data: fresh,
+            error: null,
+            isLoading: false,
+        });
+
+        expect(notifyCountA).toBe(notifyCountABefore + 1);
+        expect(notifyCountB).toBe(notifyCountBBefore + 1);
+        expect(lastSnapA).not.toBeNull();
+        expect(lastSnapB).not.toBeNull();
+        expect(lastSnapA!.data).toBe(fresh);
+        expect(lastSnapB!.data).toBe(fresh);
+        expect(store.getSnapshot().data).toBe(fresh);
     });
 
     test('snapshot starts with isLoading true before data arrives', () => {

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -1020,6 +1020,27 @@ function subscribeCached<T>(
 }
 
 /**
+ * Push a new snapshot into a shared subscription cache entry and notify all
+ * listeners. Used by `useQuery.refetch()` in cached mode to publish manually
+ * fetched data so every subscriber across components sees the update --
+ * without this, refetch would fetch from the server but the cached `data`
+ * returned to consumers would stay stale until the next server-side
+ * TriggerRefresh.
+ */
+function updateCachedSnapshot<T>(
+    client: ApiClient,
+    key: string,
+    snapshot: SubscriptionSnapshot<T>,
+): void {
+    const cache = subscriptionCaches.get(client);
+    if (!cache) return;
+    const entry = cache.get(key);
+    if (!entry) return;
+    entry.snapshot = snapshot as SubscriptionSnapshot;
+    for (const l of entry.listeners) l();
+}
+
+/**
  * Generic query hook. Prefer the generated per-handler hooks (e.g.,
  * `useListUsers()`) which call this internally with the correct function
  * and subscription metadata.
@@ -1148,8 +1169,41 @@ export function useQuery<TArgs extends unknown[], TRes>(
     }, [fetch, subscribeMethod, options?.refetchInterval]);
 
     const refetch = useCallback(() => {
-        fetch();
-    }, [fetch]);
+        if (!shouldCache) {
+            fetch();
+            return;
+        }
+        // Cached subscription mode: fetch fresh data and push it into the
+        // shared cache so every subscriber (across components) sees the
+        // new value. The cached `data` returned to consumers reads from
+        // the cache snapshot, not from the local `data` state that
+        // fetch() updates -- see issue #167.
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+        (async () => {
+            try {
+                const result = params
+                    ? await fn(client, controller.signal, ...params)
+                    : await (fn as unknown as (client: ApiClient, signal: AbortSignal) => Promise<TRes>)(client, controller.signal);
+                if (abortRef.current !== controller) return;
+                updateCachedSnapshot<TRes>(client, cacheKey, {
+                    data: result,
+                    error: null,
+                    isLoading: false,
+                });
+            } catch (err) {
+                if (abortRef.current !== controller) return;
+                if (controller.signal.aborted) return;
+                updateCachedSnapshot<TRes>(client, cacheKey, {
+                    data: null,
+                    error: err as Error,
+                    isLoading: false,
+                });
+            }
+        })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [client, fn, paramsKey, shouldCache, cacheKey, fetch]);
 
     const mutate = useCallback(async (action: Promise<unknown> | (() => Promise<unknown>)) => {
         setLocalLoading(true);

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -1047,6 +1047,27 @@ function subscribeCached<T>(
 }
 
 /**
+ * Push a new snapshot into a shared subscription cache entry and notify all
+ * listeners. Used by `useQuery.refetch()` in cached mode to publish manually
+ * fetched data so every subscriber across components sees the update --
+ * without this, refetch would fetch from the server but the cached `data`
+ * returned to consumers would stay stale until the next server-side
+ * TriggerRefresh.
+ */
+function updateCachedSnapshot<T>(
+    client: ApiClient,
+    key: string,
+    snapshot: SubscriptionSnapshot<T>,
+): void {
+    const cache = subscriptionCaches.get(client);
+    if (!cache) return;
+    const entry = cache.get(key);
+    if (!entry) return;
+    entry.snapshot = snapshot as SubscriptionSnapshot;
+    for (const l of entry.listeners) l();
+}
+
+/**
  * Generic query hook. Prefer the generated per-handler hooks (e.g.,
  * `useListUsers()`) which call this internally with the correct function
  * and subscription metadata.
@@ -1175,8 +1196,41 @@ export function useQuery<TArgs extends unknown[], TRes>(
     }, [fetch, subscribeMethod, options?.refetchInterval]);
 
     const refetch = useCallback(() => {
-        fetch();
-    }, [fetch]);
+        if (!shouldCache) {
+            fetch();
+            return;
+        }
+        // Cached subscription mode: fetch fresh data and push it into the
+        // shared cache so every subscriber (across components) sees the
+        // new value. The cached `data` returned to consumers reads from
+        // the cache snapshot, not from the local `data` state that
+        // fetch() updates -- see issue #167.
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+        (async () => {
+            try {
+                const result = params
+                    ? await fn(client, controller.signal, ...params)
+                    : await (fn as unknown as (client: ApiClient, signal: AbortSignal) => Promise<TRes>)(client, controller.signal);
+                if (abortRef.current !== controller) return;
+                updateCachedSnapshot<TRes>(client, cacheKey, {
+                    data: result,
+                    error: null,
+                    isLoading: false,
+                });
+            } catch (err) {
+                if (abortRef.current !== controller) return;
+                if (controller.signal.aborted) return;
+                updateCachedSnapshot<TRes>(client, cacheKey, {
+                    data: null,
+                    error: err as Error,
+                    isLoading: false,
+                });
+            }
+        })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [client, fn, paramsKey, shouldCache, cacheKey, fetch]);
 
     const mutate = useCallback(async (action: Promise<unknown> | (() => Promise<unknown>)) => {
         setLocalLoading(true);


### PR DESCRIPTION
Closes #167.

## Summary
- In cached subscription mode, `useQuery.refetch()` performed the network round-trip but wrote the result into local `useState` that cached consumers never read — the visible `data` stayed stuck on the last server-pushed value until the next `TriggerRefresh`.
- Add `updateCachedSnapshot(client, key, snapshot)` helper that publishes a fresh snapshot into the shared `subscriptionCaches` entry and notifies every listener.
- Rewrite `refetch` so that in cached mode it aborts any in-flight refetch, fetches with `AbortController` cancellation (mirroring `fetch()`), and publishes the result (or error) through the new helper. `refetch()` is now a real "fetch now" escape hatch across all subscribing components.

## Root cause
`templates/_client-common.ts.tmpl` — `refetch = useCallback(() => { fetch(); }, [fetch])`. `fetch` updates the local `data` state via `setData`, but `shouldCache` mode returns `cachedSnapshot.data` from the shared WeakMap cache, so the new value was unreachable.

## Test plan
- [x] `e2e/tests/query-cache.test.ts` — new `'updateCachedSnapshot notifies all subscribers with fresh data'` case. Two subscribers share a cache key, the test fetches fresh `listUsers` out-of-band and publishes via a test-local mirror of the helper, then asserts both subscribers were notified with the new data — all without a server-side `TriggerRefresh`. 9/9 query-cache tests green.
- [x] `go test ./...` — green.
- [x] `cd example/react/client && npx tsc --noEmit` — green. Confirms the regenerated React client with the new helper + refetch branch still typechecks.
- [x] Regenerated vanilla + e2e clients (no functional diff; only the React template emits `useQuery` / `updateCachedSnapshot`).

## Follow-up
Per the issue's "Notes & open questions": `mutate()` in cached mode has the same latent pattern — it awaits the action and relies on server-side `TriggerRefresh` to push the new value. Worth a separate issue to decide whether `mutate` should optionally trigger an `updateCachedSnapshot`-style refresh or whether the `TriggerRefresh` convention should be enforced server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)