### PR TITLE
Surface CodeValidationFailed structured data on ApiError (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,28 @@ registry.SetValidator(aprot.NewPlaygroundValidator())
 
 Invalid requests are automatically rejected with structured errors (code `-32604`) before reaching your handler. Uses [go-playground/validator](https://github.com/go-playground/validator) — see their docs for the full tag reference.
 
+The structured error payload (a `[]FieldError`) flows through to the generated TypeScript client. Catch `ApiError` and use the exported `getValidationErrors` helper to map server-side failures to per-field UI state without re-implementing the type-narrowing dance:
+
+```typescript
+import { ApiError, getValidationErrors } from "./api/client";
+
+try {
+    await api.users.update(input);
+} catch (err) {
+    const fields = getValidationErrors(err);
+    if (fields) {
+        for (const f of fields) setFieldError(f.field, f.message);
+        return;
+    }
+    if (err instanceof ApiError) {
+        // Other server error — generic toast, etc.
+    }
+    throw err;
+}
+```
+
+`getValidationErrors` returns `null` for any error that isn't a `CodeValidationFailed` response, so the same form-submit catch block can handle both validation failures and other errors with a single check. The `FieldError` interface mirrors the Go `FieldError` struct in `validate.go`.
+
 ### Zod Schemas
 
 Enable Zod to generate TypeScript validation schemas from the same struct tags:

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -10,6 +10,7 @@ export const ErrorCode = {
     MethodNotFound: -32601,
     InvalidParams: -32602,
     InternalError: -32603,
+    ValidationFailed: -32604,
     Canceled: -32800,
     Unauthorized: -32001,
     ConnectionRejected: -32002,
@@ -20,14 +21,31 @@ export type ErrorCodeType = typeof ErrorCode[keyof typeof ErrorCode];
 
 
 
+// FieldError is one entry in the structured payload that the server returns
+// alongside CodeValidationFailed (-32604) responses. The shape mirrors the Go
+// FieldError struct in validate.go on the server side.
+export interface FieldError {
+    field: string;
+    tag: string;
+    value: unknown;
+    param: string;
+    message: string;
+}
+
 // ApiError is thrown when the server returns an error response
 export class ApiError extends Error {
     readonly code: number;
+    // data is the structured payload the server attached to the error, if any.
+    // For CodeValidationFailed responses this is FieldError[]; for other codes
+    // it may be undefined or carry a code-specific shape. Use getValidationErrors
+    // to safely extract field-level validation failures.
+    readonly data?: unknown;
 
-    constructor(code: number, message: string) {
+    constructor(code: number, message: string, data?: unknown) {
         super(message);
         this.name = 'ApiError';
         this.code = code;
+        this.data = data;
     }
 
     // Helper methods for checking error types
@@ -35,8 +53,19 @@ export class ApiError extends Error {
     isForbidden(): boolean { return this.code === ErrorCode.Forbidden; }
     isNotFound(): boolean { return this.code === ErrorCode.MethodNotFound; }
     isInvalidParams(): boolean { return this.code === ErrorCode.InvalidParams; }
+    isValidationFailed(): boolean { return this.code === ErrorCode.ValidationFailed; }
     isCanceled(): boolean { return this.code === ErrorCode.Canceled; }
     isConnectionRejected(): boolean { return this.code === ErrorCode.ConnectionRejected; }
+}
+
+// getValidationErrors returns the structured FieldError list when err is a
+// validation failure (code -32604), or null otherwise. Use this instead of
+// hand-rolling the instanceof + code check + Array.isArray + cast pattern.
+export function getValidationErrors(err: unknown): FieldError[] | null {
+    if (!(err instanceof ApiError)) return null;
+    if (err.code !== ErrorCode.ValidationFailed) return null;
+    if (!Array.isArray(err.data)) return null;
+    return err.data as FieldError[];
 }
 
 
@@ -519,17 +548,17 @@ export class ApiClient {
                 if (p) {
                     this.pending.delete(msg.id);
                     p.onSettle?.();
-                    p.reject(new ApiError(msg.code, msg.message));
+                    p.reject(new ApiError(msg.code, msg.message, msg.data));
                     this.notifyLoadingChange();
                 } else if (msg.code === ErrorCode.ConnectionRejected) {
                     this.manualDisconnect = true;
-                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message));
+                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message, msg.data));
                     this.transport.disconnect();
                 } else {
                     // Server-driven subscription refresh error
                     const sub = this.subscriptions.get(msg.id);
                     if (sub) {
-                        sub.onError?.(new ApiError(msg.code, msg.message));
+                        sub.onError?.(new ApiError(msg.code, msg.message, msg.data));
                     }
                 }
                 break;

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -8,6 +8,7 @@ export const ErrorCode = {
     MethodNotFound: -32601,
     InvalidParams: -32602,
     InternalError: -32603,
+    ValidationFailed: -32604,
     Canceled: -32800,
     Unauthorized: -32001,
     ConnectionRejected: -32002,
@@ -18,14 +19,31 @@ export type ErrorCodeType = typeof ErrorCode[keyof typeof ErrorCode];
 
 
 
+// FieldError is one entry in the structured payload that the server returns
+// alongside CodeValidationFailed (-32604) responses. The shape mirrors the Go
+// FieldError struct in validate.go on the server side.
+export interface FieldError {
+    field: string;
+    tag: string;
+    value: unknown;
+    param: string;
+    message: string;
+}
+
 // ApiError is thrown when the server returns an error response
 export class ApiError extends Error {
     readonly code: number;
+    // data is the structured payload the server attached to the error, if any.
+    // For CodeValidationFailed responses this is FieldError[]; for other codes
+    // it may be undefined or carry a code-specific shape. Use getValidationErrors
+    // to safely extract field-level validation failures.
+    readonly data?: unknown;
 
-    constructor(code: number, message: string) {
+    constructor(code: number, message: string, data?: unknown) {
         super(message);
         this.name = 'ApiError';
         this.code = code;
+        this.data = data;
     }
 
     // Helper methods for checking error types
@@ -33,8 +51,19 @@ export class ApiError extends Error {
     isForbidden(): boolean { return this.code === ErrorCode.Forbidden; }
     isNotFound(): boolean { return this.code === ErrorCode.MethodNotFound; }
     isInvalidParams(): boolean { return this.code === ErrorCode.InvalidParams; }
+    isValidationFailed(): boolean { return this.code === ErrorCode.ValidationFailed; }
     isCanceled(): boolean { return this.code === ErrorCode.Canceled; }
     isConnectionRejected(): boolean { return this.code === ErrorCode.ConnectionRejected; }
+}
+
+// getValidationErrors returns the structured FieldError list when err is a
+// validation failure (code -32604), or null otherwise. Use this instead of
+// hand-rolling the instanceof + code check + Array.isArray + cast pattern.
+export function getValidationErrors(err: unknown): FieldError[] | null {
+    if (!(err instanceof ApiError)) return null;
+    if (err.code !== ErrorCode.ValidationFailed) return null;
+    if (!Array.isArray(err.data)) return null;
+    return err.data as FieldError[];
 }
 
 
@@ -517,17 +546,17 @@ export class ApiClient {
                 if (p) {
                     this.pending.delete(msg.id);
                     p.onSettle?.();
-                    p.reject(new ApiError(msg.code, msg.message));
+                    p.reject(new ApiError(msg.code, msg.message, msg.data));
                     this.notifyLoadingChange();
                 } else if (msg.code === ErrorCode.ConnectionRejected) {
                     this.manualDisconnect = true;
-                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message));
+                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message, msg.data));
                     this.transport.disconnect();
                 } else {
                     // Server-driven subscription refresh error
                     const sub = this.subscriptions.get(msg.id);
                     if (sub) {
-                        sub.onError?.(new ApiError(msg.code, msg.message));
+                        sub.onError?.(new ApiError(msg.code, msg.message, msg.data));
                     }
                 }
                 break;

--- a/generate_test.go
+++ b/generate_test.go
@@ -289,6 +289,32 @@ func TestGenerateMultipleFiles(t *testing.T) {
 		t.Error("Missing ApiError in client.ts")
 	}
 
+	// #170: ApiError should carry the structured `data` payload from
+	// CodeValidationFailed responses, and `getValidationErrors` should be
+	// exported as the safe way to extract it.
+	apiErrorChecks := []struct {
+		substr string
+		desc   string
+	}{
+		{"readonly data?: unknown", "ApiError.data field"},
+		{"constructor(code: number, message: string, data?: unknown)", "ApiError constructor accepts data"},
+		{"this.data = data", "ApiError stores data"},
+		{"export interface FieldError", "FieldError interface exported"},
+		{"export function getValidationErrors", "getValidationErrors helper exported"},
+		{"isValidationFailed(): boolean", "isValidationFailed helper method"},
+		{"ValidationFailed: -32604", "ErrorCode.ValidationFailed constant"},
+	}
+	for _, c := range apiErrorChecks {
+		if !strings.Contains(baseContent, c.substr) {
+			t.Errorf("ApiError #170: %s — expected substring %q in client.ts", c.desc, c.substr)
+		}
+	}
+
+	// #170: every site that constructs an ApiError must pass msg.data through.
+	if strings.Contains(baseContent, "new ApiError(msg.code, msg.message)") {
+		t.Error("ApiError #170: at least one new ApiError(...) site does not pass msg.data through")
+	}
+
 	// Check handler file
 	handlerContent, ok := files["test-handlers.ts"]
 	if !ok {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -8,6 +8,7 @@ export const ErrorCode = {
     MethodNotFound: -32601,
     InvalidParams: -32602,
     InternalError: -32603,
+    ValidationFailed: -32604,
     Canceled: -32800,
     Unauthorized: -32001,
     ConnectionRejected: -32002,
@@ -21,14 +22,31 @@ export type ErrorCodeType = typeof ErrorCode[keyof typeof ErrorCode];
 {{end}}
 
 {{define "api-error"}}
+// FieldError is one entry in the structured payload that the server returns
+// alongside CodeValidationFailed (-32604) responses. The shape mirrors the Go
+// FieldError struct in validate.go on the server side.
+export interface FieldError {
+    field: string;
+    tag: string;
+    value: unknown;
+    param: string;
+    message: string;
+}
+
 // ApiError is thrown when the server returns an error response
 export class ApiError extends Error {
     readonly code: number;
+    // data is the structured payload the server attached to the error, if any.
+    // For CodeValidationFailed responses this is FieldError[]; for other codes
+    // it may be undefined or carry a code-specific shape. Use getValidationErrors
+    // to safely extract field-level validation failures.
+    readonly data?: unknown;
 
-    constructor(code: number, message: string) {
+    constructor(code: number, message: string, data?: unknown) {
         super(message);
         this.name = 'ApiError';
         this.code = code;
+        this.data = data;
     }
 
     // Helper methods for checking error types
@@ -36,11 +54,22 @@ export class ApiError extends Error {
     isForbidden(): boolean { return this.code === ErrorCode.Forbidden; }
     isNotFound(): boolean { return this.code === ErrorCode.MethodNotFound; }
     isInvalidParams(): boolean { return this.code === ErrorCode.InvalidParams; }
+    isValidationFailed(): boolean { return this.code === ErrorCode.ValidationFailed; }
     isCanceled(): boolean { return this.code === ErrorCode.Canceled; }
     isConnectionRejected(): boolean { return this.code === ErrorCode.ConnectionRejected; }
 {{- range .CustomErrorCodes}}
     {{.MethodName}}(): boolean { return this.code === ErrorCode.{{.Name}}; }
 {{- end}}
+}
+
+// getValidationErrors returns the structured FieldError list when err is a
+// validation failure (code -32604), or null otherwise. Use this instead of
+// hand-rolling the instanceof + code check + Array.isArray + cast pattern.
+export function getValidationErrors(err: unknown): FieldError[] | null {
+    if (!(err instanceof ApiError)) return null;
+    if (err.code !== ErrorCode.ValidationFailed) return null;
+    if (!Array.isArray(err.data)) return null;
+    return err.data as FieldError[];
 }
 {{end}}
 
@@ -523,17 +552,17 @@ export class ApiClient {
                 if (p) {
                     this.pending.delete(msg.id);
                     p.onSettle?.();
-                    p.reject(new ApiError(msg.code, msg.message));
+                    p.reject(new ApiError(msg.code, msg.message, msg.data));
                     this.notifyLoadingChange();
                 } else if (msg.code === ErrorCode.ConnectionRejected) {
                     this.manualDisconnect = true;
-                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message));
+                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message, msg.data));
                     this.transport.disconnect();
                 } else {
                     // Server-driven subscription refresh error
                     const sub = this.subscriptions.get(msg.id);
                     if (sub) {
-                        sub.onError?.(new ApiError(msg.code, msg.message));
+                        sub.onError?.(new ApiError(msg.code, msg.message, msg.data));
                     }
                 }
                 break;

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -351,7 +351,7 @@ export class ApiClient {
                 if (p) {
                     this.pending.delete(msg.id);
                     p.onSettle?.();
-                    p.reject(new ApiError(msg.code, msg.message));
+                    p.reject(new ApiError(msg.code, msg.message, msg.data));
                     this.notifyLoadingChange();
                 }
                 break;

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -349,7 +349,7 @@ export class ApiClient {
                 if (p) {
                     this.pending.delete(msg.id);
                     p.onSettle?.();
-                    p.reject(new ApiError(msg.code, msg.message));
+                    p.reject(new ApiError(msg.code, msg.message, msg.data));
                     this.notifyLoadingChange();
                 }
                 break;


### PR DESCRIPTION
Closes #170.

## Summary

The generated TypeScript `ApiError` class now carries the structured `data` payload that the server attaches to error responses. Consumers can map `CodeValidationFailed` (`-32604`) failures to per-field UI errors without re-implementing the type-narrowing dance — and without needing aprot's structured `FieldError[]` to be thrown away at the wire boundary.

## What changed

All edits live in templates plus the generator's existing test fixtures. The generated example clients are also updated to reflect the new template output.

### `templates/_client-common.ts.tmpl`

- **`ErrorCode`** now exports `ValidationFailed: -32604` alongside the other JSON-RPC and aprot codes. Was missing — even though the server uses `CodeValidationFailed` from `errors.go`, the constant was never plumbed into the TypeScript side.
- **`ApiError`** gains `readonly data?: unknown` and an optional third constructor argument:
  ```ts
  constructor(code: number, message: string, data?: unknown) {
      super(message);
      this.name = 'ApiError';
      this.code = code;
      this.data = data;
  }
  ```
  Existing two-arg call sites still compile (the third arg is optional). `unknown` (not `any`) so consumers have to type-guard before reading.
- **`ApiError.isValidationFailed()`** added alongside the other helper methods.
- **`FieldError` interface** newly exported. The shape mirrors the Go `FieldError` struct in `validate.go`:
  ```ts
  export interface FieldError {
      field: string;
      tag: string;
      value: unknown;
      param: string;
      message: string;
  }
  ```
- **`getValidationErrors(err: unknown): FieldError[] | null`** helper newly exported. Returns the field list when `err` is a validation failure (`instanceof ApiError && code === ValidationFailed && Array.isArray(data)`), otherwise `null`. So consumers don't have to hand-roll the same four-step narrowing.

### Three template call sites — all pass `msg.data` through

`templates/_client-common.ts.tmpl` had three `new ApiError(msg.code, msg.message)` sites (the main `pending.reject` site, the `onConnectionRejected` site, and the subscription `onError` site). All three now pass `msg.data`. The two parallel sites in `templates/client.ts.tmpl:352` and `templates/client-react.ts.tmpl:354` were updated to match.

### Example clients regenerated

`example/react/client/src/api/client.ts` and `example/vanilla/client/static/api/client.ts` are checked in with the new output. `npx tsc --noEmit` on the react example passes.

### `README.md`

The validation section grew a short worked example showing the consumer pattern with `getValidationErrors`. Includes the `FieldError` import and a single try/catch with the recommended fall-through to a generic toast.

## Tests

`generate_test.go` (the existing `TestGenerate*` checks for `client.ts`'s base content) grew assertions for:

- `readonly data?: unknown` field
- `constructor(code: number, message: string, data?: unknown)` signature
- `this.data = data` body
- `export interface FieldError`
- `export function getValidationErrors`
- `isValidationFailed(): boolean` helper
- `ValidationFailed: -32604` in `ErrorCode`

And a regression assertion that **no** `new ApiError(msg.code, msg.message)` site forgets the `msg.data` argument:

```go
if strings.Contains(baseContent, "new ApiError(msg.code, msg.message)") {
    t.Error("ApiError #170: at least one new ApiError(...) site does not pass msg.data through")
}
```

This guards all five template sites from regression in one assertion since the regenerated `client.ts` aggregates them.

## Verification

- `go test ./...` — clean (full suite, including the new fixture assertions)
- `cd example/vanilla/tools/generate && go run main.go` and react equivalent — both produce the expected diffs in `client.ts`
- `cd example/react/client && npx tsc --noEmit` — clean (the optional `data?: unknown` constructor arg is backwards-compatible)
- `gofmt -w generate_test.go` applied

## Out of scope

- **Typing `data` more strictly than `unknown`.** Different error codes carry different `data` shapes (e.g. `CodeInvalidParams` might carry a different payload). `unknown` plus the helper is the contract; further type-narrowing is the consumer's job.
- **Auto-generating `FieldError` from the Go struct.** `validate.FieldError` isn't a registered handler response type so it doesn't flow through `goTypeToTS`. Hand-writing the interface in the template is fine — there's exactly one of them and the shape is small. Comments in the template point at `validate.go` so the two stay in sync.
- **Subscription `onError` callback signature.** Receives `ApiError`; the widened class is a strict superset, so no signature change needed.

## Downstream context

Hit while wiring the tgtr pilot's mutation forms to client-side validation. Right now every form's catch block has to fall back to a generic toast for server-side validation failures because the structured payload was being dropped at `new ApiError(msg.code, msg.message)`. With this PR merged and aprot republished, that consumer can map `-32604` errors to the same per-field UI state its `useFormValidation` hook uses for client-side Zod failures.