### PR TITLE
Topologically sort Zod schemas so leaves precede references

### DIFF
--- a/zod.go
+++ b/zod.go
@@ -198,6 +198,13 @@ func zodConstraint(goKind string, rule ValidateRule) string {
 
 // buildZodSchemas builds Zod schema data from interface data.
 // Only includes interfaces that have at least one field with a validate tag.
+//
+// Output is topologically sorted so that leaf schemas always appear before
+// schemas that reference them. This is required because the generated file
+// uses top-level `const X = z.object({...})` declarations: a schema that
+// substitutes an element schema (e.g., `Links: z.array(EventLinkInputSchema)`)
+// must be evaluated after the element schema's `const` runs, otherwise the
+// reference hits a temporal-dead-zone error at module init time.
 func buildZodSchemas(interfaces []interfaceData) []zodSchemaData {
 	// Pre-pass: collect the names of every interface that will produce a
 	// schema, so slice/map element types can be substituted (#169). An
@@ -213,7 +220,8 @@ func buildZodSchemas(interfaces []interfaceData) []zodSchemaData {
 		}
 	}
 
-	var schemas []zodSchemaData
+	// Build the schema list in source order first.
+	bySource := make([]zodSchemaData, 0, len(interfaces))
 	for _, iface := range interfaces {
 		if !knownSchemas[iface.Name] {
 			continue
@@ -225,7 +233,78 @@ func buildZodSchemas(interfaces []interfaceData) []zodSchemaData {
 				ZodType: fieldToZod(f, knownSchemas),
 			})
 		}
-		schemas = append(schemas, schema)
+		bySource = append(bySource, schema)
 	}
-	return schemas
+
+	// Topologically sort so leaf schemas come before any schema that
+	// references them. We collect dependencies by walking each interface's
+	// field list once, looking at slice/map element type names. Cycles fall
+	// back to source order (cycles are out of scope for #169 — the codegen
+	// emits z.any() for self-referential structs).
+	deps := make(map[string][]string, len(bySource))
+	ifaceByName := make(map[string]interfaceData, len(interfaces))
+	for _, iface := range interfaces {
+		ifaceByName[iface.Name] = iface
+	}
+	for _, schema := range bySource {
+		iface := ifaceByName[schema.Name]
+		var schemaDeps []string
+		seen := make(map[string]bool)
+		for _, f := range iface.Fields {
+			if f.ElemTypeName != "" && knownSchemas[f.ElemTypeName] && !seen[f.ElemTypeName] {
+				schemaDeps = append(schemaDeps, f.ElemTypeName)
+				seen[f.ElemTypeName] = true
+			}
+		}
+		deps[schema.Name] = schemaDeps
+	}
+
+	return topoSortSchemas(bySource, deps)
+}
+
+// topoSortSchemas reorders schemas so that every schema appears after its
+// dependencies. Uses iterative DFS with three-color marking; on cycles, the
+// affected schemas are emitted in their original order (the runtime
+// reference still works because cycles can only happen via z.any(), which
+// doesn't dereference the cyclic name).
+func topoSortSchemas(schemas []zodSchemaData, deps map[string][]string) []zodSchemaData {
+	const (
+		white = 0 // unvisited
+		gray  = 1 // on stack (cycle marker)
+		black = 2 // finished
+	)
+	color := make(map[string]int, len(schemas))
+	byName := make(map[string]zodSchemaData, len(schemas))
+	for _, s := range schemas {
+		color[s.Name] = white
+		byName[s.Name] = s
+	}
+
+	out := make([]zodSchemaData, 0, len(schemas))
+	var visit func(name string)
+	visit = func(name string) {
+		if color[name] != white {
+			return
+		}
+		color[name] = gray
+		for _, dep := range deps[name] {
+			if _, ok := byName[dep]; !ok {
+				continue
+			}
+			if color[dep] == gray {
+				// Cycle: skip this edge so the original-order fallback
+				// is preserved for the affected schemas.
+				continue
+			}
+			visit(dep)
+		}
+		color[name] = black
+		out = append(out, byName[name])
+	}
+
+	// Walk in original order so unrelated schemas keep their declared order.
+	for _, s := range schemas {
+		visit(s.Name)
+	}
+	return out
 }

--- a/zod_test.go
+++ b/zod_test.go
@@ -189,6 +189,83 @@ func TestZodGeneration_Integration(t *testing.T) {
 	}
 }
 
+func TestZodGeneration_LeafSchemasEmittedBeforeReferences(t *testing.T) {
+	// Regression for the v0.37.2 bug introduced by #169: a parent schema
+	// that referenced a leaf schema (e.g. Links: z.array(EventTagSchema))
+	// could be emitted *before* the leaf's `const`, causing a TDZ
+	// ReferenceError at module load. Fix is topological sort in
+	// buildZodSchemas. This test asserts the order constraint directly on
+	// the generated file.
+	registry := NewRegistry()
+	registry.Register(&SliceElemHandlers{})
+
+	gen := NewGenerator(registry).WithOptions(GeneratorOptions{
+		Mode: OutputVanilla,
+		Zod:  true,
+	})
+
+	results, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	var schemaFile string
+	for name, content := range results {
+		if strings.HasSuffix(name, ".schema.ts") {
+			schemaFile = content
+			break
+		}
+	}
+	if schemaFile == "" {
+		t.Fatal("expected a .schema.ts file to be generated")
+	}
+
+	leafIdx := strings.Index(schemaFile, "EventTagSchema = z.object")
+	parentIdx := strings.Index(schemaFile, "SliceElemRequestSchema = z.object")
+	if leafIdx < 0 {
+		t.Fatalf("EventTagSchema declaration not found in generated file:\n%s", schemaFile)
+	}
+	if parentIdx < 0 {
+		t.Fatalf("SliceElemRequestSchema declaration not found in generated file:\n%s", schemaFile)
+	}
+	if leafIdx > parentIdx {
+		t.Errorf("EventTagSchema must be declared before SliceElemRequestSchema (leafIdx=%d, parentIdx=%d)\n---\n%s", leafIdx, parentIdx, schemaFile)
+	}
+}
+
+func TestTopoSortSchemas(t *testing.T) {
+	// Direct unit test for the sort: leaf must come before parent.
+	schemas := []zodSchemaData{
+		{Name: "Parent"},
+		{Name: "Leaf"},
+		{Name: "Unrelated"},
+	}
+	deps := map[string][]string{
+		"Parent":    {"Leaf"},
+		"Leaf":      nil,
+		"Unrelated": nil,
+	}
+	got := topoSortSchemas(schemas, deps)
+	pos := make(map[string]int)
+	for i, s := range got {
+		pos[s.Name] = i
+	}
+	if pos["Leaf"] >= pos["Parent"] {
+		t.Errorf("Leaf must come before Parent: got positions Leaf=%d Parent=%d", pos["Leaf"], pos["Parent"])
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 schemas, got %d", len(got))
+	}
+
+	// Cycle: A -> B -> A. Should not infinite-loop, both should appear.
+	cyclicSchemas := []zodSchemaData{{Name: "A"}, {Name: "B"}}
+	cyclicDeps := map[string][]string{"A": {"B"}, "B": {"A"}}
+	cyclicGot := topoSortSchemas(cyclicSchemas, cyclicDeps)
+	if len(cyclicGot) != 2 {
+		t.Errorf("cycle: expected 2 schemas, got %d", len(cyclicGot))
+	}
+}
+
 func TestZodGeneration_SliceAndMapElements(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&SliceElemHandlers{})


### PR DESCRIPTION
Regression introduced by PR #171 (closing #169) and shipped in v0.37.2.

## The bug

When PR #171 added element-schema substitution, \`buildZodSchemas\` emitted schemas in source order. If the parent struct appeared before the leaf in the source file, the generated \`.schema.ts\` ended up like:

\`\`\`ts
// events.schema.ts (broken in v0.37.2)
export const CreateEventParamsSchema = z.object({
    // ...
    Links: z.array(EventLinkInputSchema),  // ← reference to leaf
})
export const EventLinkInputSchema = z.object({  // ← leaf declared after
    URL: z.union([z.literal(''), z.string().url().max(500)]).optional(),
    Label: z.string().max(100),
})
\`\`\`

Top-level \`const\` declarations in a module are NOT hoisted (TDZ). Loading the module crashes:

\`\`\`
ReferenceError: Cannot access 'EventLinkInputSchema' before initialization
    at events.schema.ts:17:18
\`\`\`

Caught immediately when bumping a downstream consumer (tgtr) to v0.37.2 and trying to import \`CreateEventParamsSchema\`. The downstream's \`tsc --noEmit\` still passed because TypeScript doesn't run the code at type-check time — this is a pure runtime failure.

## The fix

Topologically sort \`buildZodSchemas\`'s output so every schema appears after its dependencies.

- New \`topoSortSchemas\` helper uses iterative DFS with three-color marking. Walks the original schema list in order so unrelated (independent) schemas keep their declared order.
- Dependencies are computed by scanning each interface's \`fieldData.ElemTypeName\` for slice/map fields whose element type produces a schema. This is exactly the set of references that PR #171 substitutes, so the dep graph captures every TDZ-causing edge.
- Cycles fall back to source order — cycles can only happen via \`z.any()\` under #169's out-of-scope recursion rules, so the runtime doesn't actually dereference the cyclic name. The DFS won't infinite-loop.

## Tests

\`zod_test.go\`:

- **\`TestZodGeneration_LeafSchemasEmittedBeforeReferences\`** — regression test using the existing \`SliceElemRequest\` fixture (which has \`Tags []EventTag\`). Asserts \`EventTagSchema\` is declared before \`SliceElemRequestSchema\` in the generated file. Without the fix, this fails because \`SliceElemRequest\` is registered first in the source.
- **\`TestTopoSortSchemas\`** — direct unit test:
  - Simple \`Leaf -> Parent\` ordering: leaf must come before parent.
  - Cycle case (\`A -> B -> A\`): must not infinite-loop, both schemas should still be emitted.

Existing \`TestZodGeneration_SliceAndMapElements\` and \`TestFieldToZod\` are unchanged.

## Verification

- \`go test ./...\` clean
- Example regen produces no diff (none of the example types have nested struct slices, so the fix is internal-only for them)
- \`example/react/client && npx tsc --noEmit\` clean

## v0.37.2 status

v0.37.2 is broken for any consumer with substituted slice/map element references. Recommend cutting v0.37.3 immediately after this lands. Downstream tgtr is currently pinned to v0.37.2 and blocked on this.