### PR TITLE
Fix unnamed []byte codegen and honor json v2 format tag (#174)

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1089,18 +1089,34 @@ func (g *Generator) collectInterfaceFields(t reflect.Type) []fieldData {
 		}
 		elemGoKind, elemTypeName := elemTypeInfo(field.Type)
 		goType := goKindString(field.Type)
-		if isUnnamedByteSlice(field.Type) {
-			// Unnamed []byte is encoded as a base64 string on the wire (issue
-			// #174). Report it as a string kind so Zod codegen emits
-			// z.string() instead of z.array(z.number().int()), and clear the
-			// element info that would otherwise drive z.array(...).
-			goType = "string"
-			elemGoKind = ""
-			elemTypeName = ""
+		tsType := g.goTypeToTS(field.Type)
+		if isByteSlice(field.Type) {
+			// go-json-experiment/json v2 per-field `format:` tag (issue
+			// #174). A tag value wins over the issue #174 default — it can
+			// force an unnamed []byte to serialize as a number array, or
+			// force a named byte slice to serialize as a base-N string.
+			// Unrecognized tag values fall through so the default shape
+			// still applies.
+			if format := jsonFormatOption(field); format != "" {
+				if ts, gk, ek, ok := byteSliceFormatShape(format); ok {
+					tsType = ts
+					goType = gk
+					elemGoKind = ek
+					elemTypeName = ""
+				}
+			} else if isUnnamedByteSlice(field.Type) {
+				// Unnamed []byte with no format tag is encoded as a base64
+				// string on the wire. Report it as a string kind so Zod
+				// codegen emits z.string() instead of z.array(z.number()),
+				// and clear the element info that would drive z.array(...).
+				goType = "string"
+				elemGoKind = ""
+				elemTypeName = ""
+			}
 		}
 		fields = append(fields, fieldData{
 			Name:         g.getJSONName(field),
-			Type:         g.goTypeToTS(field.Type),
+			Type:         tsType,
 			Optional:     g.isOptional(field),
 			GoType:       goType,
 			ValidateTag:  field.Tag.Get("validate"),
@@ -1276,6 +1292,50 @@ func elemTypeInfo(t reflect.Type) (goKind string, typeName string) {
 // fall through to the default slice path.
 func isUnnamedByteSlice(t reflect.Type) bool {
 	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8 && t.Name() == ""
+}
+
+// isByteSlice reports whether t is any byte slice — named or unnamed. Used
+// to gate the go-json-experiment/json v2 `format:` tag override, which
+// applies to every []byte / `type Foo []byte` regardless of naming.
+func isByteSlice(t reflect.Type) bool {
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8
+}
+
+// jsonFormatOption parses the `format:X` option from a go-json-experiment
+// json struct tag and returns X, or "" if the tag has no format option.
+// The tag grammar is `name,opt1,opt2,...` where each option is a bare word
+// or `key:value`. Only the first format: option is honored.
+func jsonFormatOption(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return ""
+	}
+	parts := strings.Split(tag, ",")
+	for _, p := range parts[1:] { // skip the name
+		if strings.HasPrefix(p, "format:") {
+			return strings.TrimPrefix(p, "format:")
+		}
+	}
+	return ""
+}
+
+// byteSliceFormatShape returns the TS / Go-kind / element-kind tuple that a
+// byte slice should use under a given v2 json format tag value. Returns
+// ok=false for an empty or unrecognized format (caller falls through to the
+// default behavior). Supported formats per the v2 package docs:
+//
+//   - "array": JSON array of per-byte numbers → TS number[]
+//   - "base64" (default for unnamed []byte), "base64url", "base32",
+//     "base32hex", "base16", "hex": base-N string → TS string
+func byteSliceFormatShape(format string) (tsType string, goKind string, elemGoKind string, ok bool) {
+	switch format {
+	case "array":
+		return "number[]", "slice", "uint", true
+	case "base64", "base64url", "base32", "base32hex", "base16", "hex":
+		return "string", "string", "", true
+	default:
+		return "", "", "", false
+	}
 }
 
 // goKindString returns a simplified Go kind string for type mapping in Zod/OpenAPI.

--- a/generate.go
+++ b/generate.go
@@ -1088,11 +1088,21 @@ func (g *Generator) collectInterfaceFields(t reflect.Type) []fieldData {
 			}
 		}
 		elemGoKind, elemTypeName := elemTypeInfo(field.Type)
+		goType := goKindString(field.Type)
+		if isUnnamedByteSlice(field.Type) {
+			// Unnamed []byte is encoded as a base64 string on the wire (issue
+			// #174). Report it as a string kind so Zod codegen emits
+			// z.string() instead of z.array(z.number().int()), and clear the
+			// element info that would otherwise drive z.array(...).
+			goType = "string"
+			elemGoKind = ""
+			elemTypeName = ""
+		}
 		fields = append(fields, fieldData{
 			Name:         g.getJSONName(field),
 			Type:         g.goTypeToTS(field.Type),
 			Optional:     g.isOptional(field),
-			GoType:       goKindString(field.Type),
+			GoType:       goType,
 			ValidateTag:  field.Tag.Get("validate"),
 			SQLNullKind:  SQLNullGoKind(field.Type, goKindString),
 			ElemGoKind:   elemGoKind,
@@ -1258,6 +1268,16 @@ func elemTypeInfo(t reflect.Type) (goKind string, typeName string) {
 	return kind, ""
 }
 
+// isUnnamedByteSlice reports whether t is the unnamed type []byte. Under
+// both encoding/json v1 and go-json-experiment/json v2, unnamed byte slices
+// marshal as base64 strings, not number arrays — so TS/Zod/OpenAPI codegen
+// must emit a string shape. Named byte slices (`type Foo []byte`) are
+// treated as number arrays by v2 per Go issue #24746, so those intentionally
+// fall through to the default slice path.
+func isUnnamedByteSlice(t reflect.Type) bool {
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8 && t.Name() == ""
+}
+
 // goKindString returns a simplified Go kind string for type mapping in Zod/OpenAPI.
 // Resolves through pointers and named types to the underlying kind.
 func goKindString(t reflect.Type) string {
@@ -1332,6 +1352,9 @@ func (g *Generator) goTypeToTS(t reflect.Type) string {
 	case reflect.Bool:
 		return "boolean"
 	case reflect.Slice:
+		if isUnnamedByteSlice(t) {
+			return "string"
+		}
 		elemType := g.goTypeToTS(t.Elem())
 		if strings.Contains(elemType, " | ") {
 			return "(" + elemType + ")[]"

--- a/generate_test.go
+++ b/generate_test.go
@@ -2121,6 +2121,8 @@ func TestGoTypeToTSCustomMarshalers(t *testing.T) {
 		{"plain struct unchanged", reflect.TypeOf(CreateUserRequest{}), "CreateUserRequest"},
 		{"int unchanged", reflect.TypeOf(0), "number"},
 		{"string unchanged", reflect.TypeOf(""), "string"},
+		{"unnamed []byte is base64 string", reflect.TypeOf([]byte(nil)), "string"},
+		{"unnamed []uint8 is base64 string", reflect.TypeOf([]uint8(nil)), "string"},
 	}
 
 	for _, tc := range tests {
@@ -2130,6 +2132,72 @@ func TestGoTypeToTSCustomMarshalers(t *testing.T) {
 				t.Errorf("goTypeToTS(%v) = %q, want %q", tc.typ, got, tc.want)
 			}
 		})
+	}
+}
+
+// namedByteSlice documents that named byte slices keep the number[] mapping:
+// go-json-experiment/json (v2) encodes `type Foo []byte` as an array of
+// numbers per Go issue #24746, only unnamed []byte stays base64.
+type namedByteSlice []byte
+
+// ByteSliceFieldStruct covers both shapes side-by-side so the collectInterfaceFields
+// regression test can assert that unnamed []byte gets special-cased but named
+// byte slices fall through to the existing slice-of-number path.
+type ByteSliceFieldStruct struct {
+	Data  []byte         `json:"data"  validate:"required"`
+	Named namedByteSlice `json:"named"`
+}
+
+func TestGoTypeToTSNamedByteSliceUnchanged(t *testing.T) {
+	registry := NewRegistry()
+	g := NewGenerator(registry)
+
+	got := g.goTypeToTS(reflect.TypeOf(namedByteSlice(nil)))
+	if got != "number[]" {
+		t.Errorf("named byte slice should still map to number[] (v2 semantics), got %q", got)
+	}
+}
+
+func TestCollectInterfaceFieldsByteSlice(t *testing.T) {
+	registry := NewRegistry()
+	g := NewGenerator(registry)
+
+	fields := g.collectInterfaceFields(reflect.TypeOf(ByteSliceFieldStruct{}))
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(fields))
+	}
+
+	byName := make(map[string]fieldData, len(fields))
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+
+	data, ok := byName["data"]
+	if !ok {
+		t.Fatalf("missing `data` field: %+v", fields)
+	}
+	if data.Type != "string" {
+		t.Errorf("unnamed []byte Type = %q, want %q", data.Type, "string")
+	}
+	if data.GoType != "string" {
+		t.Errorf("unnamed []byte GoType = %q, want %q (drives Zod z.string())", data.GoType, "string")
+	}
+	if data.ElemGoKind != "" {
+		t.Errorf("unnamed []byte ElemGoKind = %q, want empty string", data.ElemGoKind)
+	}
+	if data.ElemTypeName != "" {
+		t.Errorf("unnamed []byte ElemTypeName = %q, want empty string", data.ElemTypeName)
+	}
+
+	named, ok := byName["named"]
+	if !ok {
+		t.Fatalf("missing `named` field: %+v", fields)
+	}
+	if named.Type != "number[]" {
+		t.Errorf("named byte slice Type = %q, want %q (v2 encodes as number array)", named.Type, "number[]")
+	}
+	if named.GoType != "slice" {
+		t.Errorf("named byte slice GoType = %q, want %q", named.GoType, "slice")
 	}
 }
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -2201,6 +2201,97 @@ func TestCollectInterfaceFieldsByteSlice(t *testing.T) {
 	}
 }
 
+// ByteSliceFormatTagStruct covers the per-field go-json-experiment/json v2
+// `format:` tag. The generator should respect the tag so TS/Zod/OpenAPI
+// match the real wire shape: `format:array` forces a number array for
+// unnamed []byte, and `format:base64` (plus the other string-encoding
+// formats) forces a string shape for named byte slices — the inverse
+// defaults from issue #174.
+type ByteSliceFormatTagStruct struct {
+	ArrayFromUnnamed   []byte         `json:"arrayFromUnnamed,format:array"`
+	Base64FromNamed    namedByteSlice `json:"base64FromNamed,format:base64"`
+	Base64URLFromNamed namedByteSlice `json:"base64urlFromNamed,format:base64url"`
+	Base32FromNamed    namedByteSlice `json:"base32FromNamed,format:base32"`
+	Base32HexFromNamed namedByteSlice `json:"base32hexFromNamed,format:base32hex"`
+	Base16FromNamed    namedByteSlice `json:"base16FromNamed,format:base16"`
+	HexFromNamed       namedByteSlice `json:"hexFromNamed,format:hex"`
+	ArrayFromNamed     namedByteSlice `json:"arrayFromNamed,format:array"`
+	Default            []byte         `json:"default"`
+	UnknownFormat      []byte         `json:"unknownFormat,format:weird"`
+}
+
+func TestCollectInterfaceFieldsByteSliceFormatTag(t *testing.T) {
+	registry := NewRegistry()
+	g := NewGenerator(registry)
+
+	fields := g.collectInterfaceFields(reflect.TypeOf(ByteSliceFormatTagStruct{}))
+	byName := make(map[string]fieldData, len(fields))
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+
+	// format:array forces a number array, even on unnamed []byte
+	// (inverting the issue #174 default).
+	arrayCases := []string{"arrayFromUnnamed", "arrayFromNamed"}
+	for _, name := range arrayCases {
+		f, ok := byName[name]
+		if !ok {
+			t.Fatalf("missing field %q: %+v", name, fields)
+		}
+		if f.Type != "number[]" {
+			t.Errorf("%s Type = %q, want %q", name, f.Type, "number[]")
+		}
+		if f.GoType != "slice" {
+			t.Errorf("%s GoType = %q, want %q", name, f.GoType, "slice")
+		}
+		if f.ElemGoKind != "uint" {
+			t.Errorf("%s ElemGoKind = %q, want %q", name, f.ElemGoKind, "uint")
+		}
+	}
+
+	// All string-encoding formats force `string` — even on a named byte
+	// slice which would otherwise default to number[] under v2.
+	stringCases := []string{
+		"base64FromNamed", "base64urlFromNamed", "base32FromNamed",
+		"base32hexFromNamed", "base16FromNamed", "hexFromNamed",
+	}
+	for _, name := range stringCases {
+		f, ok := byName[name]
+		if !ok {
+			t.Fatalf("missing field %q: %+v", name, fields)
+		}
+		if f.Type != "string" {
+			t.Errorf("%s Type = %q, want %q", name, f.Type, "string")
+		}
+		if f.GoType != "string" {
+			t.Errorf("%s GoType = %q, want %q", name, f.GoType, "string")
+		}
+		if f.ElemGoKind != "" {
+			t.Errorf("%s ElemGoKind = %q, want empty", name, f.ElemGoKind)
+		}
+	}
+
+	// No tag → issue #174 default: unnamed []byte is a base64 string.
+	def, ok := byName["default"]
+	if !ok {
+		t.Fatalf("missing `default` field: %+v", fields)
+	}
+	if def.Type != "string" || def.GoType != "string" {
+		t.Errorf("default unnamed []byte should still be string, got Type=%q GoType=%q", def.Type, def.GoType)
+	}
+
+	// An unknown format value falls through to the default — the codegen
+	// should not guess at it, and v2 would raise a marshal error at
+	// runtime anyway if it genuinely didn't understand the tag.
+	unk, ok := byName["unknownFormat"]
+	if !ok {
+		t.Fatalf("missing `unknownFormat` field: %+v", fields)
+	}
+	if unk.Type != "string" {
+		t.Errorf("unknown format should fall through to default (string), got Type=%q", unk.Type)
+	}
+}
+
 // Types for TestGenerateCustomMarshalerTypes
 
 type MarshalerRequest struct {

--- a/openapi.go
+++ b/openapi.go
@@ -327,6 +327,13 @@ func (g *OpenAPIGenerator) goTypeToJSONSchema(t reflect.Type) *JSONSchema {
 	case reflect.Bool:
 		return &JSONSchema{Type: "boolean"}
 	case reflect.Slice:
+		if isUnnamedByteSlice(t) {
+			// Unnamed []byte is base64-encoded as a string on the wire under
+			// both encoding/json v1 and go-json-experiment/json v2 (issue
+			// #174). OpenAPI 3.0 represents this as {type: string, format:
+			// byte}.
+			return &JSONSchema{Type: "string", Format: "byte"}
+		}
 		return &JSONSchema{
 			Type:  "array",
 			Items: g.goTypeToJSONSchema(t.Elem()),

--- a/openapi.go
+++ b/openapi.go
@@ -359,6 +359,31 @@ func (g *OpenAPIGenerator) goTypeToJSONSchema(t reflect.Type) *JSONSchema {
 	}
 }
 
+// byteSliceFieldSchema returns the JSON Schema for a byte-slice field,
+// honoring the go-json-experiment/json v2 `format:` tag (issue #174).
+// Returns nil if the field type is not a byte slice — caller should fall
+// through to the default goTypeToJSONSchema path.
+func byteSliceFieldSchema(field reflect.StructField) *JSONSchema {
+	if !isByteSlice(field.Type) {
+		return nil
+	}
+	format := jsonFormatOption(field)
+	if format != "" {
+		if _, _, _, ok := byteSliceFormatShape(format); ok {
+			if format == "array" {
+				return &JSONSchema{Type: "array", Items: &JSONSchema{Type: "integer"}}
+			}
+			return &JSONSchema{Type: "string", Format: "byte"}
+		}
+		// Unrecognized format tag: fall through to the default shape.
+	}
+	if isUnnamedByteSlice(field.Type) {
+		return &JSONSchema{Type: "string", Format: "byte"}
+	}
+	// Named byte slice with no tag keeps the v2 number-array default.
+	return &JSONSchema{Type: "array", Items: &JSONSchema{Type: "integer"}}
+}
+
 // buildStructSchema builds a JSON Schema for a struct type and registers it.
 func (g *OpenAPIGenerator) buildStructSchema(t reflect.Type) {
 	schema := &JSONSchema{
@@ -400,7 +425,12 @@ func (g *OpenAPIGenerator) buildStructSchema(t reflect.Type) {
 		}
 
 		jsonName := jsonFieldName(field)
-		fieldSchema := g.goTypeToJSONSchema(field.Type)
+		var fieldSchema *JSONSchema
+		if s := byteSliceFieldSchema(field); s != nil {
+			fieldSchema = s
+		} else {
+			fieldSchema = g.goTypeToJSONSchema(field.Type)
+		}
 
 		// Apply validate constraints
 		validateTag := field.Tag.Get("validate")
@@ -434,7 +464,12 @@ func (g *OpenAPIGenerator) buildFieldsInto(t reflect.Type, schema *JSONSchema) {
 			continue
 		}
 		jsonName := jsonFieldName(field)
-		fieldSchema := g.goTypeToJSONSchema(field.Type)
+		var fieldSchema *JSONSchema
+		if s := byteSliceFieldSchema(field); s != nil {
+			fieldSchema = s
+		} else {
+			fieldSchema = g.goTypeToJSONSchema(field.Type)
+		}
 
 		validateTag := field.Tag.Get("validate")
 		if validateTag != "" {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -312,3 +312,41 @@ func TestApplyValidateConstraints(t *testing.T) {
 		})
 	}
 }
+
+// TestOpenAPIGoTypeToJSONSchema_ByteSlice is a regression test for issue #174:
+// unnamed []byte must map to {type: string, format: byte} because it is
+// serialized as a base64 string by both encoding/json v1 and
+// go-json-experiment/json v2, not as an array of integers. Named byte slices
+// are left on the existing array path to match v2's per-element encoding.
+func TestOpenAPIGoTypeToJSONSchema_ByteSlice(t *testing.T) {
+	gen := NewOpenAPIGenerator(NewRegistry(), "Test", "1.0.0")
+
+	t.Run("unnamed []byte is string/byte", func(t *testing.T) {
+		schema := gen.goTypeToJSONSchema(reflect.TypeOf([]byte(nil)))
+		if schema == nil {
+			t.Fatal("schema is nil")
+		}
+		if schema.Type != "string" {
+			t.Errorf("Type = %q, want %q", schema.Type, "string")
+		}
+		if schema.Format != "byte" {
+			t.Errorf("Format = %q, want %q", schema.Format, "byte")
+		}
+		if schema.Items != nil {
+			t.Errorf("Items should be nil for string/byte, got %+v", schema.Items)
+		}
+	})
+
+	t.Run("named byte slice still array", func(t *testing.T) {
+		schema := gen.goTypeToJSONSchema(reflect.TypeOf(namedByteSlice(nil)))
+		if schema == nil {
+			t.Fatal("schema is nil")
+		}
+		if schema.Type != "array" {
+			t.Errorf("Type = %q, want %q", schema.Type, "array")
+		}
+		if schema.Items == nil || schema.Items.Type != "integer" {
+			t.Errorf("Items = %+v, want integer element", schema.Items)
+		}
+	})
+}

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -350,3 +350,46 @@ func TestOpenAPIGoTypeToJSONSchema_ByteSlice(t *testing.T) {
 		}
 	})
 }
+
+// TestOpenAPIByteSliceFormatTag covers the v2 json `format:` tag end-to-end
+// through the struct schema builder: the emitted JSON Schema for each field
+// must match the on-the-wire shape driven by the tag, inverting the #174
+// defaults where the tag says so.
+func TestOpenAPIByteSliceFormatTag(t *testing.T) {
+	gen := NewOpenAPIGenerator(NewRegistry(), "Test", "1.0.0")
+
+	gen.buildStructSchema(reflect.TypeOf(ByteSliceFormatTagStruct{}))
+
+	schema := gen.schemas[reflect.TypeOf(ByteSliceFormatTagStruct{})]
+	if schema == nil {
+		t.Fatal("ByteSliceFormatTagStruct schema not registered")
+	}
+
+	arrayFields := []string{"arrayFromUnnamed", "arrayFromNamed"}
+	for _, name := range arrayFields {
+		prop := schema.Properties[name]
+		if prop == nil {
+			t.Fatalf("property %q missing", name)
+		}
+		if prop.Type != "array" {
+			t.Errorf("%s Type = %q, want %q", name, prop.Type, "array")
+		}
+		if prop.Items == nil || prop.Items.Type != "integer" {
+			t.Errorf("%s Items = %+v, want integer", name, prop.Items)
+		}
+	}
+
+	stringFields := []string{
+		"base64FromNamed", "base64urlFromNamed", "base32FromNamed",
+		"base32hexFromNamed", "base16FromNamed", "hexFromNamed",
+	}
+	for _, name := range stringFields {
+		prop := schema.Properties[name]
+		if prop == nil {
+			t.Fatalf("property %q missing", name)
+		}
+		if prop.Type != "string" || prop.Format != "byte" {
+			t.Errorf("%s = {Type: %q, Format: %q}, want {string, byte}", name, prop.Type, prop.Format)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #174.

Two commits, both scoped to issue #174:

1. **Emit unnamed `[]byte` as base64 string in generated clients** — the primary bug fix.
2. **Honor json v2 `format:` tag on byte-slice fields** — the follow-up the issue flagged as open question 2.

## Why

`go-json-experiment/json` (and `encoding/json` v1) serialize an **unnamed** `[]byte` as a base64 string on the wire. The generator previously mapped it to `number[]`, so a TypeScript caller doing `Uint8Array.from(await Download(...))` iterated the base64 text character-by-character — producing an unrecoverable blob (the original report reproduces this against an xlsx payload).

Under v2 only *named* byte slices (`type Foo []byte`) are encoded as number arrays per Go issue #24746, so those stay on the existing slice path by default.

The v2 json package also supports a per-field `format:` tag on byte slices that overrides the default encoding: `format:array` forces a number array (the v1-emulation shape), and `format:base64` / `base64url` / `base32` / `base32hex` / `base16` / `hex` force a base-N string. The generator now parses this tag and flips TS / Zod / OpenAPI accordingly, so the generated types stay aligned with the wire format regardless of which shape the handler author picked.

## Summary of changes

- `isUnnamedByteSlice`, `isByteSlice`, `jsonFormatOption`, and `byteSliceFormatShape` helpers in `generate.go`.
- `goTypeToTS`: unnamed `[]byte` → TypeScript `string`.
- `collectInterfaceFields`: per-field format tag wins; else unnamed `[]byte` falls to the `string` default. Overrides propagate through `fieldData` (`Type` / `GoType` / `ElemGoKind` / `ElemTypeName`) so Zod codegen emits the matching shape without any changes to `zod.go`.
- `goTypeToJSONSchema`: unnamed `[]byte` → `{type: string, format: byte}`.
- `byteSliceFieldSchema` in `openapi.go` + integration into `buildStructSchema` / `buildFieldsInto` so the OpenAPI field shape respects the format tag.

## Out of scope

- Typed client decode helper (`base64ToUint8Array`) — deferred, called out in #174 as open question 1.
- `[N]byte` fixed-size byte arrays — currently emit `any` via `reflect.Array` fallback; separate bug, not part of this PR.

## Test plan

Full TDD loop (red → green) for every change:

- [x] Primary fix
  - `TestGoTypeToTSCustomMarshalers` — two new cases: `[]byte`, `[]uint8` → `string`
  - `TestGoTypeToTSNamedByteSliceUnchanged` — `type Foo []byte` still `number[]`
  - `TestCollectInterfaceFieldsByteSlice` — named vs. unnamed side-by-side
  - `TestOpenAPIGoTypeToJSONSchema_ByteSlice` — both shapes
- [x] Format tag
  - `TestCollectInterfaceFieldsByteSliceFormatTag` — `format:array` on unnamed flips to `number[]`, all string-formats on named flip to `string`, unknown format falls through, no-tag default preserved
  - `TestOpenAPIByteSliceFormatTag` — same matrix through the struct schema builder
- [x] `go test ./...` green
- [x] Regenerated `example/vanilla` and `example/react` TypeScript clients — no drift
- [x] `npx tsc --noEmit` in `example/react/client` — clean
- [x] `gofmt -w` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)