### PR TITLE
Emit z.enum/z.union for enum fields in Zod schemas

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -379,6 +379,17 @@ type fieldData struct {
 	// is a named struct (e.g., "EventLinkInput"). Used by Zod codegen to look up
 	// the element's generated schema. Empty for primitive elements.
 	ElemTypeName string
+	// Enum is non-nil when the field's type is a registered enum. Zod codegen
+	// uses it to emit z.enum([...]) (string enums) or z.union([z.literal(...),
+	// ...]) (int enums), matching the branded enum type the TS interface
+	// generator emits. Without this, enum fields would fall through to plain
+	// z.string() / z.number().int() and the inferred Zod type would not be
+	// assignable to the generated params type (aprot issue #176).
+	Enum *EnumInfo
+	// ElemEnum is non-nil when the field is a slice or map whose element type
+	// is a registered enum. Zod codegen uses it to emit the enum expression
+	// inside z.array(...) / z.record(...).
+	ElemEnum *EnumInfo
 }
 
 type paramData struct {
@@ -1123,6 +1134,8 @@ func (g *Generator) collectInterfaceFields(t reflect.Type) []fieldData {
 			SQLNullKind:  SQLNullGoKind(field.Type, goKindString),
 			ElemGoKind:   elemGoKind,
 			ElemTypeName: elemTypeName,
+			Enum:         g.lookupEnum(field.Type),
+			ElemEnum:     g.lookupElemEnum(field.Type),
 		})
 	}
 	return fields
@@ -1242,6 +1255,35 @@ func (g *Generator) inferTypeFromMarshalCached(t reflect.Type) *MarshalTSType {
 // struct-field recursion for types whose wire format differs from their Go fields.
 func (g *Generator) hasMarshalOverride(t reflect.Type) bool {
 	return g.inferTypeFromMarshalCached(t) != nil || SQLNullTSType(t, g.goTypeToTS) != ""
+}
+
+// lookupEnum returns the registered EnumInfo for t (unwrapping a pointer),
+// or nil if t is not a registered enum. Used by collectInterfaceFields to
+// populate fieldData.Enum so Zod codegen can emit z.enum(...) instead of
+// falling through to z.string() / z.number().int() on the underlying kind
+// (aprot issue #176).
+func (g *Generator) lookupEnum(t reflect.Type) *EnumInfo {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return g.registry.GetEnum(t)
+}
+
+// lookupElemEnum returns the registered EnumInfo for the element type of a
+// slice or map (unwrapping pointers), or nil otherwise. Used by
+// collectInterfaceFields to populate fieldData.ElemEnum.
+func (g *Generator) lookupElemEnum(t reflect.Type) *EnumInfo {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Slice && t.Kind() != reflect.Map {
+		return nil
+	}
+	elem := t.Elem()
+	if elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	return g.registry.GetEnum(elem)
 }
 
 // elemTypeInfo inspects a slice or map type and returns the element's Go kind

--- a/zod.go
+++ b/zod.go
@@ -53,6 +53,25 @@ func fieldToZod(f fieldData, knownSchemas map[string]bool) string {
 		optional = true
 	}
 
+	// Issue #176: registered enum fields emit z.enum([...]) (string) or
+	// z.union([z.literal(...), ...]) (int) so z.infer matches the branded
+	// enum type the TS interface generator emits. Validate constraints like
+	// min/max/email don't apply to enum literals, so we skip them and only
+	// honor nullability, optionality, and the omitempty empty-string wrap.
+	if f.Enum != nil {
+		body := "z." + zodEnumBase(f.Enum)
+		if isNullable {
+			body += ".nullable()"
+		}
+		if hasValidateOmitempty && f.Enum.IsString {
+			body = `z.union([z.literal(""), ` + body + `])`
+		}
+		if optional {
+			body += ".optional()"
+		}
+		return body
+	}
+
 	// Issue 2 (#163): if an explicit min rule is present on a string, skip
 	// the implicit required -> min(1) so we don't emit .min(1).min(N).
 	hasExplicitMin := false
@@ -64,7 +83,7 @@ func fieldToZod(f fieldData, knownSchemas map[string]bool) string {
 	}
 
 	var chain []string
-	chain = append(chain, zodBaseType(effectiveKind, f.Type, f.ElemGoKind, f.ElemTypeName, knownSchemas))
+	chain = append(chain, zodBaseType(effectiveKind, f.Type, f.ElemGoKind, f.ElemTypeName, f.ElemEnum, knownSchemas))
 
 	for _, r := range rules {
 		if r.Tag == "omitempty" {
@@ -98,8 +117,10 @@ func fieldToZod(f fieldData, knownSchemas map[string]bool) string {
 // zodBaseType returns the base Zod type for a Go kind. For slice and map
 // kinds, elemGoKind/elemTypeName provide the element's type info so the array
 // or record can substitute the element schema (#169) instead of falling
-// through to z.any().
-func zodBaseType(goKind string, tsType string, elemGoKind string, elemTypeName string, knownSchemas map[string]bool) string {
+// through to z.any(). elemEnum is non-nil when the slice/map element is a
+// registered enum; in that case zodElemExpr emits z.enum(...) / z.union(...)
+// for the element (#176).
+func zodBaseType(goKind string, tsType string, elemGoKind string, elemTypeName string, elemEnum *EnumInfo, knownSchemas map[string]bool) string {
 	switch goKind {
 	case "string":
 		return "string()"
@@ -110,9 +131,9 @@ func zodBaseType(goKind string, tsType string, elemGoKind string, elemTypeName s
 	case "bool":
 		return "boolean()"
 	case "slice":
-		return "array(" + zodElemExpr(elemGoKind, elemTypeName, knownSchemas) + ")"
+		return "array(" + zodElemExpr(elemGoKind, elemTypeName, elemEnum, knownSchemas) + ")"
 	case "map":
-		return "record(z.string(), " + zodElemExpr(elemGoKind, elemTypeName, knownSchemas) + ")"
+		return "record(z.string(), " + zodElemExpr(elemGoKind, elemTypeName, elemEnum, knownSchemas) + ")"
 	default:
 		// Struct or unknown — use any()
 		return "any()"
@@ -122,7 +143,12 @@ func zodBaseType(goKind string, tsType string, elemGoKind string, elemTypeName s
 // zodElemExpr builds a Zod expression for a slice or map element. Returns
 // "z.any()" when the element type is unknown or unsupported (recursive types,
 // anonymous structs, slices of slices) so callers can wrap it directly.
-func zodElemExpr(elemGoKind string, elemTypeName string, knownSchemas map[string]bool) string {
+// When elemEnum is non-nil, the element is a registered enum and is emitted
+// as z.enum([...]) / z.union([...]) (#176).
+func zodElemExpr(elemGoKind string, elemTypeName string, elemEnum *EnumInfo, knownSchemas map[string]bool) string {
+	if elemEnum != nil {
+		return "z." + zodEnumBase(elemEnum)
+	}
 	switch elemGoKind {
 	case "string":
 		return "z.string()"
@@ -140,6 +166,27 @@ func zodElemExpr(elemGoKind string, elemTypeName string, knownSchemas map[string
 	default:
 		return "z.any()"
 	}
+}
+
+// zodEnumBase returns the Zod expression body (without the leading "z.") for
+// a registered enum. String enums become enum(["a", "b", ...]) so z.infer
+// produces the matching string literal union; int enums become
+// union([z.literal(0), z.literal(1), ...]) so z.infer produces the matching
+// number literal union. (#176)
+func zodEnumBase(info *EnumInfo) string {
+	if info.IsString {
+		parts := make([]string, 0, len(info.Values))
+		for _, v := range info.Values {
+			s, _ := v.Value.(string)
+			parts = append(parts, `"`+s+`"`)
+		}
+		return "enum([" + strings.Join(parts, ", ") + "])"
+	}
+	parts := make([]string, 0, len(info.Values))
+	for _, v := range info.Values {
+		parts = append(parts, fmt.Sprintf("z.literal(%d)", v.Value))
+	}
+	return "union([" + strings.Join(parts, ", ") + "])"
 }
 
 // zodConstraint maps a single validate rule to a Zod chain method.

--- a/zod_test.go
+++ b/zod_test.go
@@ -3,9 +3,30 @@ package aprot
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 )
+
+// stringEnumFixture builds an EnumInfo for unit tests that exercise enum
+// Zod codegen without going through reflect-based registration. Type is
+// left nil — fieldToZod doesn't consult it.
+func stringEnumFixture(name string, values ...string) *EnumInfo {
+	info := &EnumInfo{Name: name, IsString: true}
+	for _, v := range values {
+		info.Values = append(info.Values, EnumValueInfo{Name: v, Value: v})
+	}
+	return info
+}
+
+// intEnumFixture builds an int-based EnumInfo for unit tests.
+func intEnumFixture(name string, values ...int64) *EnumInfo {
+	info := &EnumInfo{Name: name, IsString: false}
+	for i, v := range values {
+		info.Values = append(info.Values, EnumValueInfo{Name: fmt.Sprintf("V%d", i), Value: v})
+	}
+	return info
+}
 
 // PilotQuirksRequest exercises the three Zod codegen fixes from issue #163:
 // Issue 1 (validate omitempty), Issue 2 (required+min dedup), Issue 3 (sql.Null*).
@@ -109,6 +130,55 @@ func TestFieldToZod(t *testing.T) {
 		{"map of int", fieldData{GoType: "map", Type: "Record<string, number>", ElemGoKind: "int"}, "z.record(z.string(), z.number().int())"},
 		{"map of known struct", fieldData{GoType: "map", Type: "Record<string, NestedItem>", ElemGoKind: "struct", ElemTypeName: "NestedItem"}, "z.record(z.string(), NestedItemSchema)"},
 		{"map no elem info", fieldData{GoType: "map", Type: "Record<string, any>"}, "z.record(z.string(), z.any())"},
+
+		// Issue #176: registered enum fields emit z.enum / z.union instead of
+		// plain z.string() / z.number().int() so z.infer matches the branded
+		// TS enum type.
+		{
+			"string enum",
+			fieldData{GoType: "string", Type: "TargetTypeType", Enum: stringEnumFixture("TargetType", "event", "post", "comment")},
+			`z.enum(["event", "post", "comment"])`,
+		},
+		{
+			"string enum required (no redundant min(1))",
+			fieldData{GoType: "string", Type: "TargetTypeType", ValidateTag: "required", Enum: stringEnumFixture("TargetType", "event", "post")},
+			`z.enum(["event", "post"])`,
+		},
+		{
+			"string enum optional",
+			fieldData{GoType: "string", Type: "TargetTypeType", Optional: true, Enum: stringEnumFixture("TargetType", "event", "post")},
+			`z.enum(["event", "post"]).optional()`,
+		},
+		{
+			"string enum with omitempty",
+			fieldData{GoType: "string", Type: "TargetTypeType", ValidateTag: "omitempty", Enum: stringEnumFixture("TargetType", "event", "post")},
+			`z.union([z.literal(""), z.enum(["event", "post"])]).optional()`,
+		},
+		{
+			"string enum nullable via sql.Null",
+			fieldData{GoType: "struct", Type: "TargetTypeType | null", SQLNullKind: "string", Enum: stringEnumFixture("TargetType", "event", "post")},
+			`z.enum(["event", "post"]).nullable()`,
+		},
+		{
+			"int enum",
+			fieldData{GoType: "int", Type: "StatusType", Enum: intEnumFixture("Status", 0, 1, 2)},
+			`z.union([z.literal(0), z.literal(1), z.literal(2)])`,
+		},
+		{
+			"int enum optional",
+			fieldData{GoType: "int", Type: "StatusType", Optional: true, Enum: intEnumFixture("Status", 0, 1)},
+			`z.union([z.literal(0), z.literal(1)]).optional()`,
+		},
+		{
+			"slice of string enum",
+			fieldData{GoType: "slice", Type: "TargetTypeType[]", ElemGoKind: "string", ElemEnum: stringEnumFixture("TargetType", "event", "post")},
+			`z.array(z.enum(["event", "post"]))`,
+		},
+		{
+			"map of int enum",
+			fieldData{GoType: "map", Type: "Record<string, StatusType>", ElemGoKind: "int", ElemEnum: intEnumFixture("Status", 0, 1)},
+			`z.record(z.string(), z.union([z.literal(0), z.literal(1)]))`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -372,5 +442,115 @@ func TestZodGeneration_PilotQuirks(t *testing.T) {
 	// Regression: no .any() fallthrough for sql.Null fields (Issue 3 fix applies)
 	if strings.Contains(schemaFile, "parentId: z.any()") || strings.Contains(schemaFile, "bio: z.any()") {
 		t.Error("sql.Null* fields should not fall through to z.any()")
+	}
+}
+
+// --- Issue #176: enum-aware Zod codegen ---
+
+// EnumTarget is a string-based enum used by the integration test below.
+type EnumTarget string
+
+const (
+	EnumTargetEvent   EnumTarget = "event"
+	EnumTargetPost    EnumTarget = "post"
+	EnumTargetComment EnumTarget = "comment"
+)
+
+func EnumTargetValues() []EnumTarget {
+	return []EnumTarget{EnumTargetEvent, EnumTargetPost, EnumTargetComment}
+}
+
+// EnumPriority is an int-based enum to exercise the z.union([z.literal(N),
+// ...]) output path.
+type EnumPriority int
+
+const (
+	EnumPriorityLow  EnumPriority = 0
+	EnumPriorityMed  EnumPriority = 1
+	EnumPriorityHigh EnumPriority = 2
+)
+
+func EnumPriorityValues() []EnumPriority {
+	return []EnumPriority{EnumPriorityLow, EnumPriorityMed, EnumPriorityHigh}
+}
+
+// EnumParamsRequest combines every enum field shape covered by the Zod fix
+// so the integration test can assert each emission in one Generate() run.
+type EnumParamsRequest struct {
+	Title   string       `json:"title"   validate:"required,min=1"`
+	Target  EnumTarget   `json:"target"  validate:"required"`
+	Opt     EnumTarget   `json:"opt"     validate:"omitempty"`
+	Related []EnumTarget `json:"related"`
+	Level   EnumPriority `json:"level"   validate:"required"`
+}
+
+type EnumParamsHandlers struct{}
+
+func (h *EnumParamsHandlers) Submit(ctx context.Context, req *EnumParamsRequest) error {
+	return nil
+}
+
+func TestZodGeneration_EnumFields(t *testing.T) {
+	// Integration regression for issue #176: generated Zod schemas must use
+	// z.enum([...]) for string enums and z.union([z.literal(N), ...]) for
+	// int enums so z.infer<> is assignable to the branded TS enum types the
+	// interface generator emits. Before this fix both fell through to
+	// z.string() / z.number().int().
+	registry := NewRegistry()
+	registry.Register(&EnumParamsHandlers{})
+	registry.RegisterEnum(EnumTargetValues())
+	registry.RegisterEnum(EnumPriorityValues())
+
+	gen := NewGenerator(registry).WithOptions(GeneratorOptions{
+		Mode: OutputVanilla,
+		Zod:  true,
+	})
+
+	results, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	var schemaFile string
+	for name, content := range results {
+		if strings.HasSuffix(name, ".schema.ts") {
+			schemaFile = content
+			break
+		}
+	}
+	if schemaFile == "" {
+		t.Fatal("expected a .schema.ts file to be generated")
+	}
+
+	expectations := []struct {
+		substr string
+		desc   string
+	}{
+		// Required string enum: plain z.enum([...]) literal, no .min(1) noise.
+		{`target: z.enum(["event", "post", "comment"])`, "Target: string enum"},
+		// Optional+omitempty string enum: empty-literal union wrap + .optional().
+		{`opt: z.union([z.literal(""), z.enum(["event", "post", "comment"])]).optional()`, "Opt: string enum with omitempty wrap"},
+		// Slice of string enum → z.array(z.enum([...])).
+		{`related: z.array(z.enum(["event", "post", "comment"]))`, "Related: slice of string enum"},
+		// Int enum → z.union of literals.
+		{`level: z.union([z.literal(0), z.literal(1), z.literal(2)])`, "Level: int enum"},
+	}
+	for _, exp := range expectations {
+		if !strings.Contains(schemaFile, exp.substr) {
+			t.Errorf("%s — expected schema to contain %q\n---\n%s", exp.desc, exp.substr, schemaFile)
+		}
+	}
+
+	// Regressions: enum fields must not fall through to the primitive base
+	// types. Before #176 these were the output.
+	forbidden := []string{
+		"target: z.string()",
+		"related: z.array(z.string())",
+		"level: z.number().int()",
+	}
+	for _, bad := range forbidden {
+		if strings.Contains(schemaFile, bad) {
+			t.Errorf("schema should not contain %q (pre-#176 regression)\n---\n%s", bad, schemaFile)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Thread registered `*EnumInfo` through `fieldData` (both for the field itself and for slice/map element types), populated from `registry.GetEnum` in `collectInterfaceFields`.
- `fieldToZod` short-circuits enum fields to a literal-typed Zod expression — string enums emit `z.enum(["a", "b"])`, int enums emit `z.union([z.literal(0), z.literal(1), ...])`. `zodElemExpr` does the same for slice/map element types.
- Validate constraints like `min`/`max`/`email` are skipped on enum fields (they don't apply to enum literals). Optional, nullable (`sql.Null*`), and the existing omitempty empty-literal wrap for string enums all still apply.
- Tests cover string enum, int enum, optional/omitempty/nullable string enum, slice-of-string-enum, map-of-int-enum, plus a full `Generate()` integration run.

## Why

The TS interface generator emits registered enums as branded types, e.g.

```ts
export type TargetTypeType = (typeof TargetType)[keyof typeof TargetType]
```

but the Zod schema generator fell through to the underlying kind and emitted `z.string()` / `z.number().int()`. `z.infer<typeof Schema>` then produced `string` / `number` and was not assignable to the generated params interface, so any form that piped a Zod-validated payload into a generated mutation broke under `tsc`:

```
src/components/comment-section.tsx:52:27 - error TS2345: Argument of type
  '{ TargetType: string; ... }' is not assignable to parameter of type 'CreateCommentParams'.
    Types of property 'TargetType' are incompatible.
      Type 'string' is not assignable to type 'TargetTypeType'.
```

After this change, `z.infer` produces the same string/number literal union the TS interface generator emits, so validated payloads pass through to generated mutations without casts.

Fixes #176

## Test plan

- [x] `go test ./...` passes
- [x] New `TestFieldToZod` cases cover every enum shape (string / int / optional / omitempty / nullable / slice / map element)
- [x] New `TestZodGeneration_EnumFields` integration test registers a real enum, runs `Generate()`, and asserts the emitted schema for all shapes
- [ ] Downstream verification in tgtr (regenerate `frontend/src/api/` and confirm `tsc -b` is green) will happen once a release is tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)