### PR TITLE
Isolate e2e servers per test file to eliminate cross-file pollution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,6 @@ dist/
 example/vanilla/client/static/app.js
 example/react/client/dist/
 e2e/api/
-e2e/.test-server-addr
+
+# e2e server binary built by tests/setup.ts globalSetup (issue #180)
+e2e/server/server

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,17 +1,22 @@
-import { readFileSync } from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
 import { WebSocket } from 'ws';
 import { EventSource } from 'eventsource';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Polyfill browser APIs for Node.js test environment
 (globalThis as unknown as Record<string, unknown>).WebSocket = WebSocket;
 (globalThis as unknown as Record<string, unknown>).EventSource = EventSource;
 
+// Per-worker server address, populated by setup-per-file.ts's beforeAll
+// hook (issue #180). Reading from a worker-local global keeps every test
+// file pointed at its own server, so TriggerRefresh calls in one file
+// never leak into active subscriptions in another file.
 export function getServerAddr(): string {
-    return readFileSync(join(__dirname, '..', '.test-server-addr'), 'utf-8').trim();
+    const addr = globalThis.__APROT_E2E_SERVER_ADDR__;
+    if (!addr) {
+        throw new Error(
+            'Test server address not set — ensure ./tests/setup-per-file.ts is listed in vitest.setupFiles',
+        );
+    }
+    return addr;
 }
 
 export function wsUrl(): string {

--- a/e2e/tests/setup-per-file.ts
+++ b/e2e/tests/setup-per-file.ts
@@ -1,0 +1,81 @@
+import { type ChildProcess, spawn, execFileSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { beforeAll, afterAll } from 'vitest';
+
+// Per-worker server lifecycle. Vitest runs this file once per test file
+// under pool: 'forks', so the beforeAll/afterAll hooks below apply to the
+// whole test file and each file gets its own Go server process — no
+// cross-file TriggerRefresh pollution (issue #180).
+//
+// The server binary itself is built once in setup.ts (globalSetup) so each
+// worker pays process-spawn cost only, not go-build cost.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const binaryPath = join(
+    __dirname,
+    '..',
+    'server',
+    process.platform === 'win32' ? 'server.exe' : 'server',
+);
+
+declare global {
+    // Worker-local because each vitest fork has its own globalThis. Reading
+    // from helpers.ts instead of the filesystem keeps the address scoped to
+    // the current test file's server.
+    // eslint-disable-next-line no-var
+    var __APROT_E2E_SERVER_ADDR__: string | undefined;
+}
+
+let serverProcess: ChildProcess | undefined;
+
+beforeAll(async () => {
+    serverProcess = spawn(binaryPath, [], {
+        cwd: join(__dirname, '..'),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Detached on Unix so we can kill the whole process group on
+        // teardown; the pre-built binary is a single process today, but
+        // staying consistent with the prior setup is safer against future
+        // wrapper scripts.
+        detached: process.platform !== 'win32',
+    });
+
+    const addr = await new Promise<string>((resolve, reject) => {
+        let data = '';
+        serverProcess!.stdout!.on('data', (chunk: Buffer) => {
+            data += chunk.toString();
+            const newline = data.indexOf('\n');
+            if (newline !== -1) {
+                resolve(data.substring(0, newline).trim());
+            }
+        });
+        serverProcess!.stderr!.on('data', (chunk: Buffer) => {
+            process.stderr.write(chunk);
+        });
+        serverProcess!.on('error', reject);
+        setTimeout(() => reject(new Error('Server startup timeout')), 30000);
+    });
+
+    globalThis.__APROT_E2E_SERVER_ADDR__ = addr;
+}, 30000);
+
+afterAll(() => {
+    if (serverProcess?.pid) {
+        if (process.platform === 'win32') {
+            try {
+                execFileSync('taskkill', ['/f', '/t', '/pid', String(serverProcess.pid)], {
+                    stdio: 'ignore',
+                });
+            } catch {
+                // Process may already be gone
+            }
+        } else {
+            try {
+                process.kill(-serverProcess.pid, 'SIGKILL');
+            } catch {
+                serverProcess.kill('SIGKILL');
+            }
+        }
+    }
+    globalThis.__APROT_E2E_SERVER_ADDR__ = undefined;
+});

--- a/e2e/tests/setup.ts
+++ b/e2e/tests/setup.ts
@@ -1,59 +1,39 @@
-import { type ChildProcess, spawn, execSync } from 'child_process';
-import { writeFileSync, unlinkSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { existsSync, unlinkSync } from 'fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ADDR_FILE = join(__dirname, '..', '.test-server-addr');
 
-let serverProcess: ChildProcess;
+// Pre-build the Go e2e server once before any test file runs. Each test
+// file then spawns its own copy of this binary via setup-per-file.ts so
+// every vitest worker gets an isolated server — see issue #180 for the
+// cross-file TriggerRefresh pollution that broke query-cache.test.ts when
+// all workers shared a single server via globalSetup.
+const binaryPath = join(
+    __dirname,
+    '..',
+    'server',
+    process.platform === 'win32' ? 'server.exe' : 'server',
+);
 
 export async function setup() {
-    serverProcess = spawn('go', ['run', './server'], {
-        cwd: join(__dirname, '..'),
-        stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    const addr = await new Promise<string>((resolve, reject) => {
-        let data = '';
-        serverProcess.stdout!.on('data', (chunk: Buffer) => {
-            data += chunk.toString();
-            const newline = data.indexOf('\n');
-            if (newline !== -1) {
-                resolve(data.substring(0, newline).trim());
-            }
-        });
-        serverProcess.stderr!.on('data', (chunk: Buffer) => {
-            process.stderr.write(chunk);
-        });
-        serverProcess.on('error', reject);
-        setTimeout(() => reject(new Error('Server startup timeout')), 60000);
-    });
-
-    writeFileSync(ADDR_FILE, addr);
+    execFileSync(
+        'go',
+        ['build', '-o', binaryPath, './server'],
+        {
+            cwd: join(__dirname, '..'),
+            stdio: 'inherit',
+        },
+    );
 }
 
 export async function teardown() {
-    if (serverProcess?.pid) {
-        // go run spawns a child process; kill the entire tree
-        if (process.platform === 'win32') {
-            try {
-                execSync(`taskkill /f /t /pid ${serverProcess.pid}`, { stdio: 'ignore' });
-            } catch {
-                // Process may already be gone
-            }
-        } else {
-            // Negative PID kills the process group on Unix
-            try {
-                process.kill(-serverProcess.pid, 'SIGKILL');
-            } catch {
-                serverProcess.kill('SIGKILL');
-            }
+    if (existsSync(binaryPath)) {
+        try {
+            unlinkSync(binaryPath);
+        } catch {
+            // Ignore if already cleaned up
         }
-    }
-    try {
-        unlinkSync(ADDR_FILE);
-    } catch {
-        // Ignore if already cleaned up
     }
 }

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -2,10 +2,16 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
+        // globalSetup builds the Go server binary once before any test file.
+        // setupFiles then runs per-worker (once per test file under
+        // pool: 'forks') and spawns an isolated server process for that
+        // file — issue #180 eliminates cross-file TriggerRefresh pollution
+        // that caused flakes in query-cache.test.ts.
         globalSetup: './tests/setup.ts',
+        setupFiles: ['./tests/setup-per-file.ts'],
         testTimeout: 30000,
-        hookTimeout: 15000,
-        teardownTimeout: 1000,
+        hookTimeout: 30000,
+        teardownTimeout: 5000,
         pool: 'forks',
     },
 });


### PR DESCRIPTION
## Summary

- `globalSetup` now only builds the Go server binary once (`go build -o e2e/server/server ./server`). No more shared server process.
- New `setupFiles` entry `tests/setup-per-file.ts` runs per vitest worker, spawns the pre-built binary in `beforeAll`, reads the listen address from stdout, stashes it on a worker-local `globalThis.__APROT_E2E_SERVER_ADDR__`, and kills the process in `afterAll`.
- `helpers.ts` reads the address from the worker-local global instead of the shared `.test-server-addr` file. Public API (`wsUrl()`, `sseUrl()`, `wsRejectUrl()`, `getServerAddr()`) is unchanged — every existing test file keeps compiling and running without modification.
- `.gitignore` now ignores the newly-built `e2e/server/server` binary; the obsolete `e2e/.test-server-addr` entry is removed.
- `hookTimeout` bumped from 15s to 30s (per-file server spawn runs inside `beforeAll`) and `teardownTimeout` from 1s to 5s (kill + stream cleanup).

## Why

Every vitest worker used to point at a single Go server spawned in `globalSetup`, and with `pool: 'forks'` that meant parallel test files shared the same server. Four test files (`ws.test.ts`, `sse.test.ts`, `subscription.test.ts`, `query-cache.test.ts`) call `createUser`, which fires `aprot.TriggerRefresh(ctx, \"users\")` at `example/vanilla/api/handlers.go:85`. That trigger re-executes every active `ListUsers` subscription registered via `aprot.RegisterRefreshTrigger(ctx, \"users\")` at `example/vanilla/api/handlers.go:134` — including the one `query-cache.test.ts:315` was using to count notifications.

When another file created a user in the window between

```ts
const notifyCountABefore = notifyCountA;
// ...
const fresh = await listUsers(client);
updateCachedSnapshot(client, key, { data: fresh, ... });
expect(notifyCountA).toBe(notifyCountABefore + 1);
```

the server pushed an extra refresh to the query-cache subscription and the assertion saw `notifyCountABefore + 2` instead of `+ 1`, failing with `expected 3 to be 2`. This surfaced as a CI failure on the post-merge master run for #179 while the exact same merge SHA passed the e2e job on the PR's own CI run, and a manual rerun of the failed job then passed too — classic race signature.

Per-worker isolation kills the race at the root: every test file gets its own Go server, its own user store, and its own `TriggerRefresh` fanout. Nothing one file does can reach another.

## Alternatives considered

1. **`singleFork: true`** — serialize test files to a single worker. One-line config change but doubles wall-clock test time and hides the real isolation bug.
2. **Per-test unique trigger keys** — rewrite the test handlers to use a per-test-file trigger key so `TriggerRefresh` from one file can't reach another. Intrusive and fragile.
3. **`test.retry()` on the flaky assertion** — hides the symptom, lets the race linger.

Per-file isolation is the only fix that preserves parallelism, matches how the Go ecosystem isolates e2e state (one server per test binary), and doesn't require touching handler code.

## Cost

Pre-building the binary once in `globalSetup` keeps per-file cost to a process spawn. Locally on Windows, five consecutive runs of the four WebSocket-backed files produce 30 tests passing each run at ~2.3s, vs ~2.5s on the old shared-server run. Memory: ~10-20 MB per concurrent worker process. Linux CI should be comparable or faster (pre-built binary avoids the `go run` compile tax that the old setup paid on every cold start).

Fixes #180

## Test plan

- [x] Five consecutive local runs of `query-cache.test.ts`, `subscription.test.ts`, `ws.test.ts`, `auth.test.ts` — all 30 tests pass every run, including the previously-flaky `updateCachedSnapshot notifies all subscribers with fresh data`
- [x] All previously-passing e2e test files still compile and run without modification
- [ ] CI e2e job passes on this PR
- [ ] CI e2e job passes on the post-merge master run (the condition that caught the flake last time)

SSE tests fail locally on Windows for unrelated pre-existing reasons — the same failures reproduce on master without any of these changes — but pass on Linux CI. Calling this out because the local test runs exclude `sse.test.ts` for that reason; nothing about this PR regresses SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)