### PR TITLE
Keep previous data across useQuery param changes

### DIFF
--- a/e2e/tests/keep-previous-data.test.ts
+++ b/e2e/tests/keep-previous-data.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// The `selectWithPreviousData` helper lives inside the generated React client
+// (templates/_client-common.ts.tmpl) and is called from `useQuery`. It's the
+// core of the `keepPreviousData` option: given a ref holding the previous
+// snapshot and the current cached snapshot, it decides whether to surface the
+// kept data or the fresh one.
+//
+// We replicate it here so we can test its behaviour with plain vitest, the
+// same way query-cache.test.ts replicates subscribeCached. No React runtime,
+// no running server, just the pure selector logic.
+// ---------------------------------------------------------------------------
+
+interface Snapshot<T = unknown> {
+    data: T | null;
+    error: Error | null;
+    isLoading: boolean;
+}
+
+function selectWithPreviousData<T>(
+    previousRef: { current: Snapshot<T> | null },
+    snapshot: Snapshot<T>,
+): Snapshot<T> {
+    if (snapshot.data !== null) {
+        previousRef.current = snapshot;
+        return snapshot;
+    }
+    if (previousRef.current && previousRef.current.data !== null) {
+        return {
+            data: previousRef.current.data,
+            error: snapshot.error,
+            isLoading: snapshot.isLoading,
+        };
+    }
+    return snapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('selectWithPreviousData', () => {
+    test('first mount with no previous data returns the snapshot unchanged', () => {
+        const ref: { current: Snapshot<string> | null } = { current: null };
+        const snap: Snapshot<string> = { data: null, error: null, isLoading: true };
+
+        const effective = selectWithPreviousData(ref, snap);
+
+        expect(effective).toBe(snap);
+        expect(ref.current).toBeNull();
+    });
+
+    test('fresh data updates the ref and returns the snapshot as-is', () => {
+        const ref: { current: Snapshot<string> | null } = { current: null };
+        const snap: Snapshot<string> = { data: 'alpha', error: null, isLoading: false };
+
+        const effective = selectWithPreviousData(ref, snap);
+
+        expect(effective).toBe(snap);
+        expect(ref.current).toBe(snap);
+    });
+
+    test('param change with cache miss surfaces the kept data while loading', () => {
+        // Simulates the zeit "Logs by day" arrow click: the hook has been
+        // showing data for week N, the user clicks forward to week N+1, and
+        // the new cache entry starts empty. The previous week's data should
+        // remain on screen until the new week's data arrives.
+        const ref: { current: Snapshot<string> | null } = { current: null };
+
+        // Week N data arrives.
+        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        selectWithPreviousData(ref, weekN);
+
+        // Param change — the new cache entry is empty.
+        const weekNPlus1Loading: Snapshot<string> = { data: null, error: null, isLoading: true };
+        const duringTransition = selectWithPreviousData(ref, weekNPlus1Loading);
+
+        expect(duringTransition.data).toBe('week-N');
+        expect(duringTransition.isLoading).toBe(true);
+        expect(duringTransition.error).toBeNull();
+        // Ref is not overwritten until real data lands.
+        expect(ref.current).toBe(weekN);
+    });
+
+    test('kept data is replaced as soon as new data lands', () => {
+        const ref: { current: Snapshot<string> | null } = { current: null };
+
+        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        selectWithPreviousData(ref, weekN);
+
+        const weekNPlus1Loading: Snapshot<string> = { data: null, error: null, isLoading: true };
+        selectWithPreviousData(ref, weekNPlus1Loading);
+
+        const weekNPlus1Loaded: Snapshot<string> = { data: 'week-N+1', error: null, isLoading: false };
+        const effective = selectWithPreviousData(ref, weekNPlus1Loaded);
+
+        expect(effective.data).toBe('week-N+1');
+        expect(effective.isLoading).toBe(false);
+        expect(ref.current).toBe(weekNPlus1Loaded);
+    });
+
+    test('error on the new cache entry surfaces alongside the kept data', () => {
+        // The user switches params and the new fetch fails. We want to keep
+        // the previous data on screen AND surface the error so QueryErrors
+        // can render an Alert. Losing either half is a regression.
+        const ref: { current: Snapshot<string> | null } = { current: null };
+
+        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        selectWithPreviousData(ref, weekN);
+
+        const weekNPlus1Failed: Snapshot<string> = {
+            data: null,
+            error: new Error('upstream 500'),
+            isLoading: false,
+        };
+        const effective = selectWithPreviousData(ref, weekNPlus1Failed);
+
+        expect(effective.data).toBe('week-N');
+        expect(effective.error).toEqual(new Error('upstream 500'));
+        expect(effective.isLoading).toBe(false);
+    });
+
+    test('transition back to a still-cached param returns its data immediately', () => {
+        // User clicks forward then back. Week N is still in the shared cache,
+        // so useSyncExternalStore hands us its snapshot directly — we want to
+        // return that, not the ref which currently holds week N+1.
+        const ref: { current: Snapshot<string> | null } = { current: null };
+
+        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        selectWithPreviousData(ref, weekN);
+
+        const weekNPlus1: Snapshot<string> = { data: 'week-N+1', error: null, isLoading: false };
+        selectWithPreviousData(ref, weekNPlus1);
+
+        // Click back — cached snapshot for week N returns instantly.
+        const backToWeekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        const effective = selectWithPreviousData(ref, backToWeekN);
+
+        expect(effective.data).toBe('week-N');
+        expect(ref.current?.data).toBe('week-N');
+    });
+
+    test('does not flash null on a subsequent empty-snapshot render', () => {
+        // Regression guard: after an initial data load, any subsequent render
+        // that for whatever reason sees data: null (cache miss, unmount race,
+        // strict-mode double-render) should still surface the kept data.
+        const ref: { current: Snapshot<string> | null } = { current: null };
+
+        const initial: Snapshot<string> = { data: 'alpha', error: null, isLoading: false };
+        selectWithPreviousData(ref, initial);
+
+        for (let i = 0; i < 5; i++) {
+            const empty: Snapshot<string> = { data: null, error: null, isLoading: true };
+            const effective = selectWithPreviousData(ref, empty);
+            expect(effective.data).toBe('alpha');
+        }
+    });
+});

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -836,6 +836,29 @@ export interface UseQueryOptions {
      * Override the global default with {@link setQueryCacheEnabled}.
      */
     cache?: boolean;
+    /**
+     * When `true` (default), the hook keeps rendering the previously fetched
+     * `data` while a parameter change is in flight, instead of flashing
+     * `data: null` between the old and new cache entries.
+     *
+     * Cached subscriptions are keyed by the JSON of their params, so changing
+     * params (e.g. clicking a date-picker arrow) switches the hook to a fresh
+     * cache entry whose initial snapshot has `data: null, isLoading: true`.
+     * Without this option, every param-driven component would flash an empty
+     * state for a few frames on every change.
+     *
+     * The kept-data is held in a per-hook-instance ref, not in the shared
+     * cache, so it never leaks across components. `isLoading` and `error`
+     * always reflect the CURRENT cache entry, so you can still tell whether
+     * a refresh is in flight or has failed.
+     *
+     * Set to `false` to opt back into the old "flash null while transitioning"
+     * behaviour — for instance if a consumer reads structural fields off
+     * `data` that would no longer match the current params.
+     *
+     * Only applies in subscription mode with caching enabled.
+     */
+    keepPreviousData?: boolean;
     /** @internal Subscription metadata for auto-refresh. */
     _subscribe?: { method: string; params: unknown[] };
 }
@@ -1076,6 +1099,47 @@ function subscribeCached<T>(
 }
 
 /**
+ * Given the current cached snapshot and a ref holding the last snapshot this
+ * hook instance saw that had non-null data, return an "effective" snapshot
+ * that keeps the previous data visible while a new subscription loads. This
+ * is the core of {@link UseQueryOptions.keepPreviousData}.
+ *
+ * Subscriptions are keyed by method + JSON-encoded params in the shared
+ * cache. When a hook's params change, `useSyncExternalStore` switches to a
+ * fresh cache entry whose initial snapshot has `data: null, isLoading: true`.
+ * Without this selector, param-driven components flash an empty state for a
+ * few frames on every change — see issue #181 and the zeit "Logs by day"
+ * flash that triggered this fix.
+ *
+ * The selector is split out so it's unit-testable without React or a running
+ * aprot server. The only mutation is to the passed-in ref, which represents
+ * per-hook-instance state.
+ */
+function selectWithPreviousData<T>(
+    previousRef: { current: SubscriptionSnapshot<T> | null },
+    snapshot: SubscriptionSnapshot<T>,
+): SubscriptionSnapshot<T> {
+    if (snapshot.data !== null) {
+        // Fresh data landed — update the ref and return the snapshot as-is.
+        previousRef.current = snapshot;
+        return snapshot;
+    }
+    if (previousRef.current && previousRef.current.data !== null) {
+        // No current data yet, but we have a previous snapshot. Present the
+        // kept data with the CURRENT snapshot's isLoading and error so the
+        // consumer can still tell whether a refresh is in flight or has
+        // failed, and surface the error via QueryErrors / Alert.
+        return {
+            data: previousRef.current.data,
+            error: snapshot.error,
+            isLoading: snapshot.isLoading,
+        };
+    }
+    // First mount, no previous data to fall back on.
+    return snapshot;
+}
+
+/**
  * Push a new snapshot into a shared subscription cache entry and notify all
  * listeners. Used by `useQuery.refetch()` in cached mode to publish manually
  * fetched data so every subscriber across components sees the update --
@@ -1155,6 +1219,19 @@ export function useQuery<TArgs extends unknown[], TRes>(
         cacheStore ? cacheStore.subscribe : noopSubscribe,
         cacheStore ? cacheStore.getSnapshot : () => defaultSnapshot.current,
     );
+
+    // Stale-while-revalidate across cache-key transitions. Holds the most
+    // recent snapshot this hook instance has seen that had non-null data.
+    // When params change, the new cache entry starts empty (data: null,
+    // isLoading: true); without this fallback the consumer would see data
+    // flash to null for a few frames. Per-hook-instance (useRef), so it
+    // never leaks between components. Computed on every render so the
+    // returned snapshot always reflects the current cache state.
+    const previousSnapshotRef = useRef<SubscriptionSnapshot<TRes> | null>(null);
+    const keepPreviousData = options?.keepPreviousData ?? true;
+    const effectiveSnapshot = (shouldCache && keepPreviousData)
+        ? selectWithPreviousData<TRes>(previousSnapshotRef, cachedSnapshot)
+        : cachedSnapshot;
 
     // Local state for mutate/refetch — per-component, never shared via cache.
     const [localLoading, setLocalLoading] = useState(false);
@@ -1276,9 +1353,9 @@ export function useQuery<TArgs extends unknown[], TRes>(
 
     if (shouldCache) {
         return {
-            data: cachedSnapshot.data,
-            error: localError ?? cachedSnapshot.error,
-            isLoading: localLoading || cachedSnapshot.isLoading,
+            data: effectiveSnapshot.data,
+            error: localError ?? effectiveSnapshot.error,
+            isLoading: localLoading || effectiveSnapshot.isLoading,
             refetch,
             mutate,
         };


### PR DESCRIPTION
## Summary

- New `keepPreviousData?: boolean` option on `UseQueryOptions`, default `true`.
- New internal `selectWithPreviousData<T>(previousRef, snapshot)` helper that holds a per-hook-instance `useRef` of the last snapshot with non-null data and substitutes it in when the current cached snapshot has `data: null`.
- `useQuery` calls the selector on every render and reads from the effective snapshot in its return block.
- Seven unit tests in `e2e/tests/keep-previous-data.test.ts` replicate the selector inline and cover first mount, fresh data, the param-change-with-cache-miss happy path, error-during-transition, round-trip back to a still-cached param, the replacement-on-new-data edge, and a regression guard for multiple consecutive empty-snapshot renders.

## Why

Cached subscriptions are keyed by method + `JSON.stringify(params)`, so a param change switches the hook to a fresh cache entry that initializes to `{ data: null, error: null, isLoading: true }`. Consumers reading `timeLogsQuery.data?.TimeLogs ?? []` then see the UI flash empty for a few frames before the new subscription resolves. A zeit user reported it on a `<DatePicker>` arrow button advancing a week in a "Logs by day" table, but the same pattern affects every param-driven query in every downstream project — invoice filters, report filters, pagination, anywhere a generated `useXxx(params)` hook's dependency object changes.

The non-cached subscription path (`cache: false`) doesn't flash because it reads from component-local `useState` that persists across param changes. The two paths having different semantics for a subtle reason nobody should have to understand is the real diagnosis here.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| First mount, no data yet | `data: null, isLoading: true` | unchanged |
| Fresh data arrives | `data: X, isLoading: false` | unchanged |
| Param change, new entry loading | `data: null, isLoading: true` ← **flash** | `data: previousX, isLoading: true` |
| Param change, new data arrives | `data: Y, isLoading: false` | unchanged |
| Param change, new fetch fails | `data: null, error: E, isLoading: false` | `data: previousX, error: E, isLoading: false` |
| Round-trip back to cached param | `data: X, isLoading: false` | unchanged |
| Opt-out with `{ keepPreviousData: false }` | n/a | restores the old behaviour |

The kept data lives in a per-hook-instance `useRef`, not in the shared cache, so it never leaks across components subscribing with different params. `isLoading` and `error` always reflect the CURRENT cache entry, so consumers can still distinguish \"refreshing\" from \"failed\" and `<QueryErrors>` / antd Alert renders an error banner over the previous data rather than replacing it with an empty state.

**Breaking for consumers** that rely on `data === null` to detect \"params just changed.\" They should be using `isLoading` for that anyway, but the PR adds `keepPreviousData: false` as an explicit escape hatch for anything that can't be migrated quickly.

## Default of true

Default `true` is deliberate:

1. The flash is a UX bug in practice. Every downstream project has been paying the cost.
2. The kept data is per-hook-instance — no cross-component leakage is possible.
3. React Query, SWR, and TanStack Query all offer stale-while-revalidate semantics; it's the ambient expectation for hooks of this shape.
4. Making it opt-in means every callsite has to remember to pass the option, which is the same pattern that made nobody notice the flash originally.

The opt-out exists for consumers that read structural fields off `data` expecting them to match current params (e.g. `if (data.filter.fromDate !== props.fromDate) ...`) — that's a legitimate but rare shape.

## Test plan

- [x] `go test ./...` passes
- [x] `npm test -- tests/keep-previous-data.test.ts` — all 7 cases pass
- [x] `npm test -- tests/query-cache.test.ts` — all 9 cases still pass, no regression on the adjacent code path
- [ ] CI — the pre-existing SSE test flakiness (see #180) may or may not fire; none of my changes touch SSE or the vanilla-mode client. Confirmed locally that `tests/sse.test.ts` fails identically on master with my branch stashed.
- [ ] Downstream: once this tags, zeit can bump aprot and verify the \"Logs by day\" arrow buttons no longer flash.

Fixes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)