### PR TITLE
Add OnStreamComplete hook for streaming handler middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,55 @@ Cancellation works exactly like any other request: break out of the `for await` 
 
 Streaming handlers are WebSocket/SSE only. Registering one via `RegisterREST` panics at registration time since REST cannot deliver multi-message responses over a single HTTP request.
 
+### Middleware and streaming handlers
+
+Middleware sees a streaming handler return as soon as the iterator value is in hand — *not* after every row has been streamed. For unary handlers that's the normal post-handler hook point; for streams, the duration and success you see at that moment reflect the time it took to produce the iterator, not the time to drain it. To observe the real end of a stream (duration, item count, cancellation cause, panic), register a callback via `aprot.OnStreamComplete(ctx, fn)`:
+
+```go
+func Logging(next aprot.Handler) aprot.Handler {
+    return func(ctx context.Context, req *aprot.Request) (any, error) {
+        start := time.Now()
+        aprot.OnStreamComplete(ctx, func(err error, items int) {
+            slog.Info("stream done",
+                "method", req.Method,
+                "dur", time.Since(start),
+                "items", items,
+                "err", err)
+        })
+        result, err := next(ctx, req)
+        if info := aprot.HandlerInfoFromContext(ctx); info != nil &&
+            info.Kind != aprot.HandlerKindUnary {
+            // Streaming handler: the hook above will fire when iteration
+            // finishes. Preflight errors (handler returned (nil, err)) never
+            // invoke the hook — log them here instead.
+            if err != nil {
+                slog.Error("stream preflight error",
+                    "method", req.Method, "dur", time.Since(start), "err", err)
+            }
+            return result, err
+        }
+        slog.Info("unary done",
+            "method", req.Method, "dur", time.Since(start), "err", err)
+        return result, err
+    }
+}
+```
+
+The `err` passed to the hook distinguishes every termination path:
+
+| Termination | `err` value |
+|---|---|
+| Clean completion (iterator returned normally) | `nil` |
+| Client canceled (`break`, `AbortSignal`, `cancel()`) | `aprot.ErrClientCanceled` |
+| Client disconnected mid-stream | `aprot.ErrConnectionClosed` |
+| Server shutdown | `aprot.ErrServerShutdown` |
+| Handler panicked mid-stream | wrapped recover value |
+| Transport send failure | underlying transport error |
+
+Use `errors.Is(err, aprot.ErrClientCanceled)` etc. to distinguish. The hook also receives `items int` — the number of elements successfully yielded to the client (for `iter.Seq2`, each `(key, value)` pair counts as one).
+
+`OnStreamComplete` is a no-op on a unary handler's context — the hooks slot is only populated when the dispatcher sees a streaming return type. Middleware that calls it on every request (as in the example above) works uniformly across both.
+
 ## Validation
 
 Add `validate` struct tags to request structs and enable validation on the registry. Validation is opt-in — nothing changes unless you call `SetValidator`.

--- a/connection.go
+++ b/connection.go
@@ -331,6 +331,15 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 	rq := &refreshQueue{server: c.server}
 	ctx = withRefreshQueue(ctx, rq)
 
+	// For streaming handlers, attach a hooks container so middleware can
+	// register post-iteration callbacks via OnStreamComplete. Unary
+	// handlers never populate the slot; OnStreamComplete is a no-op for
+	// them.
+	var sHooks *streamHooks
+	if info.Kind != HandlerKindUnary {
+		ctx, sHooks = withStreamCompleteHooks(ctx)
+	}
+
 	// Build and execute middleware chain
 	handler := c.server.buildHandler(info)
 	result, err := handler(ctx, req)
@@ -356,7 +365,7 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 	// iter.Seq / iter.Seq2. Drive iteration now that middleware has returned.
 	if info.Kind == HandlerKindStream || info.Kind == HandlerKindStream2 {
 		seqVal, _ := result.(reflect.Value)
-		c.streamIterator(ctx, msg.ID, seqVal, info)
+		c.streamIterator(ctx, msg.ID, seqVal, info, sHooks)
 		c.server.processRefreshQueue(rq)
 		return
 	}
@@ -373,14 +382,25 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 // StreamEndMessage always terminates the stream, carrying an error code
 // only on abnormal termination (handler panic, marshal/send error). Clean
 // client-side cancellation produces an empty StreamEndMessage.
-func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Value, info *HandlerInfo) {
+//
+// After iteration ends — for any reason — any callbacks registered via
+// OnStreamComplete on the request context are invoked with the final
+// cause and the number of items yielded. Cancellation causes surface
+// as the sentinel the context carries (ErrClientCanceled,
+// ErrConnectionClosed, or ErrServerShutdown), so logging middleware
+// can distinguish client disconnect from server shutdown.
+func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Value, info *HandlerInfo, hooks *streamHooks) {
 	if !seq.IsValid() || seq.Kind() == reflect.Func && seq.IsNil() {
 		c.sendStreamEnd(reqID, nil)
+		if hooks != nil {
+			hooks.run(nil, 0)
+		}
 		return
 	}
 
 	yieldType := seq.Type().In(0)
 	var streamErr error
+	itemCount := 0
 	yieldFn := reflect.MakeFunc(yieldType, func(args []reflect.Value) []reflect.Value {
 		if ctx.Err() != nil {
 			return []reflect.Value{reflect.ValueOf(false)}
@@ -399,6 +419,7 @@ func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Val
 			streamErr = err
 			return []reflect.Value{reflect.ValueOf(false)}
 		}
+		itemCount++
 		return []reflect.Value{reflect.ValueOf(true)}
 	})
 
@@ -410,6 +431,25 @@ func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Val
 		}()
 		seq.Call([]reflect.Value{yieldFn})
 	}()
+
+	// Compute the final cause for the completion hooks. Cancellation
+	// wins over a late transport error because the cancel is the root
+	// reason the handler stopped; we surface the specific CancelReason
+	// (ErrClientCanceled / ErrConnectionClosed / ErrServerShutdown)
+	// rather than a downstream send error caused by the same shutdown.
+	var finalErr error
+	if ctx.Err() != nil {
+		finalErr = context.Cause(ctx)
+	} else if streamErr != nil {
+		finalErr = streamErr
+	}
+
+	// Run hooks before sending the terminal message. Running first
+	// guarantees the log entry reflects the real outcome even if the
+	// transport is already torn down by the time sendStreamEnd fires.
+	if hooks != nil {
+		hooks.run(finalErr, itemCount)
+	}
 
 	// Context cancellation or transport close are clean terminations from
 	// the client's point of view — no error payload on the end message.

--- a/context.go
+++ b/context.go
@@ -1,6 +1,9 @@
 package aprot
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type contextKey int
 
@@ -11,6 +14,7 @@ const (
 	requestKey
 	triggerCollectorKey
 	refreshQueueKey
+	streamCompleteHooksKey
 )
 
 // Progress returns the ProgressReporter from the context.
@@ -75,4 +79,115 @@ func withRequest(ctx context.Context, req *Request) context.Context {
 // or ErrServerShutdown.
 func CancelCause(ctx context.Context) error {
 	return context.Cause(ctx)
+}
+
+// StreamCompleteHook is invoked once per streaming request after the
+// handler's iterator has finished executing — whether through clean
+// completion, client cancellation, connection loss, server shutdown, a
+// mid-stream panic, or a transport send failure.
+//
+// Parameters:
+//
+//   - err is nil for clean completion, or the cause of termination
+//     otherwise. For cancellation-driven termination, err is the
+//     context cause sentinel: one of [ErrClientCanceled],
+//     [ErrConnectionClosed], or [ErrServerShutdown] — use [errors.Is]
+//     to distinguish. For panics it is a wrapped recover value. For
+//     transport failures it is the underlying transport error.
+//   - items is the number of elements successfully yielded to the
+//     client. For [iter.Seq2], each (key, value) pair counts as one.
+//
+// Preflight errors — i.e. handlers that return (nil, err) before any
+// iterator is produced — do NOT invoke the hook. They travel as the
+// regular error return from the middleware chain and should be logged
+// there, the same way unary handler errors are today.
+type StreamCompleteHook func(err error, items int)
+
+// streamHooks holds the ordered list of StreamCompleteHook callbacks
+// registered against a single streaming request's context.
+type streamHooks struct {
+	mu    sync.Mutex
+	hooks []StreamCompleteHook
+}
+
+func (h *streamHooks) add(hook StreamCompleteHook) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.hooks = append(h.hooks, hook)
+}
+
+// run invokes every registered callback with the final outcome. Called
+// by the dispatcher after streamIterator has returned. Hooks fire in
+// registration order; a panic in one hook does not prevent later hooks
+// from running.
+func (h *streamHooks) run(err error, items int) {
+	h.mu.Lock()
+	hooks := make([]StreamCompleteHook, len(h.hooks))
+	copy(hooks, h.hooks)
+	h.mu.Unlock()
+	for _, hook := range hooks {
+		func() {
+			defer func() { _ = recover() }()
+			hook(err, items)
+		}()
+	}
+}
+
+// OnStreamComplete registers a callback that fires after a streaming
+// handler's iterator has finished. Typically called from middleware
+// before dispatching to the next handler, so the callback closure can
+// capture the start time and emit a log entry once iteration finishes.
+//
+// Example logging middleware that logs duration and item count for
+// both unary and streaming handlers:
+//
+//	func Logging(next aprot.Handler) aprot.Handler {
+//	    return func(ctx context.Context, req *aprot.Request) (any, error) {
+//	        start := time.Now()
+//	        aprot.OnStreamComplete(ctx, func(err error, items int) {
+//	            slog.Info("stream done",
+//	                "method", req.Method,
+//	                "dur", time.Since(start),
+//	                "items", items,
+//	                "err", err)
+//	        })
+//	        result, err := next(ctx, req)
+//	        if info := aprot.HandlerInfoFromContext(ctx); info != nil &&
+//	            info.Kind != aprot.HandlerKindUnary {
+//	            // Streaming handler: hook will fire later (unless this is
+//	            // a preflight error, in which case log it here).
+//	            if err != nil {
+//	                slog.Error("stream preflight error",
+//	                    "method", req.Method,
+//	                    "dur", time.Since(start),
+//	                    "err", err)
+//	            }
+//	            return result, err
+//	        }
+//	        slog.Info("unary done",
+//	            "method", req.Method, "dur", time.Since(start), "err", err)
+//	        return result, err
+//	    }
+//	}
+//
+// Calling OnStreamComplete on a unary handler's context is a no-op —
+// the hooks slot is only populated for requests whose handler returns
+// an iter.Seq shape.
+func OnStreamComplete(ctx context.Context, hook StreamCompleteHook) {
+	if hook == nil {
+		return
+	}
+	h, ok := ctx.Value(streamCompleteHooksKey).(*streamHooks)
+	if !ok || h == nil {
+		return
+	}
+	h.add(hook)
+}
+
+// withStreamCompleteHooks attaches a streamHooks container to ctx and
+// returns both the new ctx and the container. Called by the dispatcher
+// only for streaming handler invocations.
+func withStreamCompleteHooks(ctx context.Context) (context.Context, *streamHooks) {
+	h := &streamHooks{}
+	return context.WithValue(ctx, streamCompleteHooksKey, h), h
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -60,7 +60,7 @@ func TestStreamIterator_SeqHappyPath(t *testing.T) {
 		ResponseType: reflect.TypeOf(int(0)),
 	}
 
-	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info, nil)
 
 	msgs := drainMessages(t, rt)
 	if len(msgs) != 6 {
@@ -91,7 +91,7 @@ func TestStreamIterator_EmptySeq(t *testing.T) {
 	seq := iter.Seq[int](func(yield func(int) bool) {})
 	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
 
-	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
 
 	msgs := drainMessages(t, rt)
 	if len(msgs) != 1 || msgs[0]["type"] != "stream_end" {
@@ -104,7 +104,7 @@ func TestStreamIterator_NilSeq(t *testing.T) {
 	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
 
 	var seq iter.Seq[int] // nil
-	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
 
 	msgs := drainMessages(t, rt)
 	if len(msgs) != 1 || msgs[0]["type"] != "stream_end" {
@@ -122,7 +122,7 @@ func TestStreamIterator_PanicMidStream(t *testing.T) {
 		panic("boom")
 	})
 
-	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
 
 	msgs := drainMessages(t, rt)
 	if len(msgs) != 3 {
@@ -161,7 +161,7 @@ func TestStreamIterator_ContextCancelStopsYield(t *testing.T) {
 		}
 	})
 
-	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info, nil)
 
 	if emitted >= 10 {
 		t.Fatalf("expected iteration to stop early after cancel, emitted = %d", emitted)
@@ -197,7 +197,7 @@ func TestStreamIterator_Seq2HappyPath(t *testing.T) {
 		}
 	})
 
-	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
 
 	msgs := drainMessages(t, rt)
 	if len(msgs) != 4 {
@@ -330,7 +330,7 @@ func TestStreamIterator_TransportCloseDuringSend(t *testing.T) {
 		}
 	})
 
-	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info)
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
 
 	// ErrConnectionClosed is a clean termination from the stream's point of
 	// view — we still send an end message, but it carries no code.
@@ -359,7 +359,7 @@ func TestStreamIterator_NoGoroutineLeakOnCancel(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			c.streamIterator(ctx, "r", reflect.ValueOf(seq), info)
+			c.streamIterator(ctx, "r", reflect.ValueOf(seq), info, nil)
 		}()
 		time.Sleep(5 * time.Millisecond)
 		cancel()
@@ -421,3 +421,222 @@ func TestErrConnectionClosedIsError(t *testing.T) {
 		t.Errorf("ErrConnectionClosed is not itself")
 	}
 }
+
+// Stream completion hook tests: verify that OnStreamComplete's callback
+// receives the correct err cause and item count across every termination
+// path the framework supports.
+
+func runStreamWithHook(t *testing.T, ctx context.Context, seq any, info *HandlerInfo) (hookErr error, hookItems int, hookCount int) {
+	t.Helper()
+	c, _ := streamTestServer(t)
+	ctx, hooks := withStreamCompleteHooks(ctx)
+	OnStreamComplete(ctx, func(err error, items int) {
+		hookErr, hookItems = err, items
+		hookCount++
+	})
+	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info, hooks)
+	return
+}
+
+func TestStreamCompleteHook_HappyPath(t *testing.T) {
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		for i := 1; i <= 4; i++ {
+			if !yield(i) {
+				return
+			}
+		}
+	})
+
+	err, items, count := runStreamWithHook(t, context.Background(), seq, info)
+	if count != 1 {
+		t.Fatalf("expected hook to fire once, got %d", count)
+	}
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if items != 4 {
+		t.Errorf("expected 4 items, got %d", items)
+	}
+}
+
+func TestStreamCompleteHook_ClientCancel(t *testing.T) {
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		for i := 1; i <= 1000; i++ {
+			if i == 3 {
+				cancel(ErrClientCanceled)
+			}
+			if !yield(i) {
+				return
+			}
+		}
+	})
+
+	err, items, count := runStreamWithHook(t, ctx, seq, info)
+	if count != 1 {
+		t.Fatalf("expected hook to fire once, got %d", count)
+	}
+	if !errors.Is(err, ErrClientCanceled) {
+		t.Errorf("expected ErrClientCanceled, got %v", err)
+	}
+	if items < 1 || items > 5 {
+		t.Errorf("expected a small positive item count around 2, got %d", items)
+	}
+}
+
+func TestStreamCompleteHook_ServerShutdown(t *testing.T) {
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		yield(1)
+		cancel(ErrServerShutdown)
+		yield(2) // yield returns false because ctx is canceled
+	})
+
+	err, items, count := runStreamWithHook(t, ctx, seq, info)
+	if count != 1 {
+		t.Fatalf("expected hook to fire once, got %d", count)
+	}
+	if !errors.Is(err, ErrServerShutdown) {
+		t.Errorf("expected ErrServerShutdown, got %v", err)
+	}
+	if items != 1 {
+		t.Errorf("expected 1 item, got %d", items)
+	}
+}
+
+func TestStreamCompleteHook_Panic(t *testing.T) {
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		yield(1)
+		yield(2)
+		panic("boom")
+	})
+
+	err, items, count := runStreamWithHook(t, context.Background(), seq, info)
+	if count != 1 {
+		t.Fatalf("expected hook to fire once, got %d", count)
+	}
+	if err == nil {
+		t.Fatal("expected non-nil err on panic")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected panic text in err, got %q", err.Error())
+	}
+	if items != 2 {
+		t.Errorf("expected 2 items before panic, got %d", items)
+	}
+}
+
+func TestStreamCompleteHook_EmptySeq(t *testing.T) {
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	seq := iter.Seq[int](func(yield func(int) bool) {})
+
+	err, items, count := runStreamWithHook(t, context.Background(), seq, info)
+	if count != 1 {
+		t.Fatalf("expected hook to fire once, got %d", count)
+	}
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if items != 0 {
+		t.Errorf("expected 0 items, got %d", items)
+	}
+}
+
+func TestStreamCompleteHook_NilSeq(t *testing.T) {
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	var seq iter.Seq[int]
+
+	err, items, count := runStreamWithHook(t, context.Background(), seq, info)
+	if count != 1 {
+		t.Fatalf("expected hook to fire once, got %d", count)
+	}
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if items != 0 {
+		t.Errorf("expected 0 items, got %d", items)
+	}
+}
+
+func TestStreamCompleteHook_MultipleHooks(t *testing.T) {
+	c, _ := streamTestServer(t)
+	ctx, hooks := withStreamCompleteHooks(context.Background())
+
+	var order []string
+	OnStreamComplete(ctx, func(err error, items int) { order = append(order, "first") })
+	OnStreamComplete(ctx, func(err error, items int) { order = append(order, "second") })
+	OnStreamComplete(ctx, func(err error, items int) { order = append(order, "third") })
+
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	seq := iter.Seq[int](func(yield func(int) bool) { yield(1) })
+	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info, hooks)
+
+	if len(order) != 3 {
+		t.Fatalf("expected 3 hook invocations, got %d: %v", len(order), order)
+	}
+	if order[0] != "first" || order[1] != "second" || order[2] != "third" {
+		t.Errorf("expected registration-order invocation, got %v", order)
+	}
+}
+
+func TestStreamCompleteHook_PanicInHookDoesNotBreakOthers(t *testing.T) {
+	c, _ := streamTestServer(t)
+	ctx, hooks := withStreamCompleteHooks(context.Background())
+
+	var reached bool
+	OnStreamComplete(ctx, func(err error, items int) { panic("hook boom") })
+	OnStreamComplete(ctx, func(err error, items int) { reached = true })
+
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+	seq := iter.Seq[int](func(yield func(int) bool) {})
+	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info, hooks)
+
+	if !reached {
+		t.Error("second hook did not run after first hook panicked")
+	}
+}
+
+func TestOnStreamComplete_NoHooksSlotIsNoOp(t *testing.T) {
+	// Registering on a context without withStreamCompleteHooks attached
+	// (e.g. a unary handler's context) should silently do nothing rather
+	// than panic or mis-register against some other request.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("OnStreamComplete panicked on unary ctx: %v", r)
+		}
+	}()
+	OnStreamComplete(context.Background(), func(err error, items int) {
+		t.Error("hook should never fire when no hooks slot is attached")
+	})
+	// No assertion needed beyond the deferred panic check; the hook
+	// simply has nowhere to be stored.
+}
+
+func TestStreamCompleteHook_Seq2CountsPairs(t *testing.T) {
+	info := &HandlerInfo{
+		Kind:          HandlerKindStream2,
+		ResponseType:  reflect.TypeOf(int(0)),
+		StreamKeyType: reflect.TypeOf(""),
+	}
+	seq := iter.Seq2[string, int](func(yield func(string, int) bool) {
+		yield("a", 1)
+		yield("b", 2)
+		yield("c", 3)
+	})
+
+	err, items, count := runStreamWithHook(t, context.Background(), seq, info)
+	if count != 1 || err != nil || items != 3 {
+		t.Errorf("Seq2 hook: count=%d err=%v items=%d (want 1, nil, 3)", count, err, items)
+	}
+}
+
+// Suppress an unused-variable warning from time.Duration usage in unrelated
+// tests above — the hook tests don't need time, but the import was pulled
+// in by earlier cases. This comment exists to prevent go vet noise.
+var _ = time.Second


### PR DESCRIPTION
## Summary

Middleware today sees a streaming handler return as soon as the `iter.Seq` value is in hand — before any items have actually been streamed — so duration/status logging middleware reports 0ms success for every stream. This PR adds `aprot.OnStreamComplete(ctx, fn)`, a middleware-friendly hook that fires once per streaming request after iteration finishes, with the real cause and item count.

## API

```go
type StreamCompleteHook func(err error, items int)
func OnStreamComplete(ctx context.Context, hook StreamCompleteHook)
```

Typically called from middleware before invoking the next handler:

```go
func Logging(next aprot.Handler) aprot.Handler {
    return func(ctx context.Context, req *aprot.Request) (any, error) {
        start := time.Now()
        aprot.OnStreamComplete(ctx, func(err error, items int) {
            slog.Info("stream done",
                "method", req.Method,
                "dur", time.Since(start),
                "items", items,
                "err", err)
        })
        // ... call next, handle preflight errors for streams, etc.
    }
}
```

## Cause distinction

The \`err\` parameter carries the specific cause, populated from \`context.Cause(ctx)\` for cancellation paths so middleware can distinguish \`ErrClientCanceled\` / \`ErrConnectionClosed\` / \`ErrServerShutdown\` with \`errors.Is\`:

| Termination | \`err\` |
|---|---|
| Clean completion | \`nil\` |
| Client canceled (\`break\`, \`AbortSignal\`, \`cancel()\`) | \`aprot.ErrClientCanceled\` |
| Client disconnected mid-stream | \`aprot.ErrConnectionClosed\` |
| Server shutdown | \`aprot.ErrServerShutdown\` |
| Handler panicked mid-stream | wrapped recover value |
| Transport send failure | underlying transport error |

Cancellation takes precedence over late transport errors — the logged cause is the root reason the handler stopped, not a downstream send-failure side effect of the same shutdown.

## Guarantees

- Hooks run **before** \`sendStreamEnd\` so the log reflects the real outcome even when the transport is already torn down.
- Hooks fire in **registration order**.
- A **panic inside a hook is recovered** and does not prevent later hooks from running.
- **Preflight errors** — handlers that return \`(nil, err)\` before any iterator — do *not* invoke the hook; they flow back through the middleware's normal error return path, same as unary handler errors.
- Calling \`OnStreamComplete\` on a unary handler's context is a **no-op** — the hooks slot is only populated when the dispatcher sees a streaming return type.

## Tests

\`stream_test.go\` gains 10 focused tests:
- Happy path, client cancel via \`context.Cause\`, server shutdown, mid-stream panic, empty seq, nil seq, multiple hooks in registration order, panic-in-hook isolation, no-op on unary context, Seq2 item counting.

## Docs

README gains a "Middleware and streaming handlers" subsection with the full logging middleware example and the termination → err mapping table.

## Test plan

- [x] \`go test ./...\` — green (all new hook tests pass + existing suite)
- [x] \`gofmt -l .\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)