### PR TITLE
Quote non-identifier enum keys in generated TypeScript

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
@@ -926,7 +927,7 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, meta *sourceMeta) tem
 				val = fmt.Sprintf("%d", v.Value)
 			}
 			ed.Values = append(ed.Values, enumValueTemplateData{
-				Name:  v.Name,
+				Name:  tsObjectKey(v.Name),
 				Value: val,
 			})
 		}
@@ -980,7 +981,7 @@ func (g *Generator) buildEnums() []enumTemplateData {
 				val = fmt.Sprintf("%d", v.Value)
 			}
 			ed.Values = append(ed.Values, enumValueTemplateData{
-				Name:  v.Name,
+				Name:  tsObjectKey(v.Name),
 				Value: val,
 			})
 		}
@@ -992,6 +993,38 @@ func (g *Generator) buildEnums() []enumTemplateData {
 // isIdentChar reports whether c is a valid Go/TypeScript identifier character.
 func isIdentChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+// isValidJSIdent reports whether name is a valid (ASCII) JavaScript
+// identifier, safe to use as an unquoted object-literal key. Deliberately
+// ASCII-only: any name that falls outside this set is emitted as a quoted
+// string key instead, which is always syntactically valid.
+func isValidJSIdent(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		ok := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '$'
+		if i > 0 {
+			ok = ok || (c >= '0' && c <= '9')
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// tsObjectKey renders s as a TypeScript object-literal key. Valid JS
+// identifiers are returned bare; anything else — including the empty
+// string, hyphens, leading digits, spaces — is returned as a double-quoted
+// string literal.
+func tsObjectKey(s string) string {
+	if isValidJSIdent(s) {
+		return s
+	}
+	return strconv.Quote(s)
 }
 
 // containsTypeName checks whether name appears as a complete identifier in typeStr,

--- a/generate_test.go
+++ b/generate_test.go
@@ -3136,3 +3136,72 @@ func TestGenerateSharedFileCrossPackageImports(t *testing.T) {
 		t.Errorf("gentestpkg.ts must not import from itself, got:\n%s", gentestpkgShared)
 	}
 }
+
+// TrickyStatus exercises enum values whose capitalized forms are not valid
+// TypeScript identifiers: empty string, a hyphenated value, and a
+// leading-digit value. The codegen must still produce syntactically valid TS.
+type TrickyStatus string
+
+const (
+	TrickyStatusNone      TrickyStatus = ""
+	TrickyStatusActive    TrickyStatus = "active"
+	TrickyStatusKebabCase TrickyStatus = "kebab-case"
+	TrickyStatusLeadDigit TrickyStatus = "123abc"
+)
+
+func TrickyStatusValues() []TrickyStatus {
+	return []TrickyStatus{
+		TrickyStatusNone,
+		TrickyStatusActive,
+		TrickyStatusKebabCase,
+		TrickyStatusLeadDigit,
+	}
+}
+
+type TrickyEnumHandlers struct{}
+
+func (h *TrickyEnumHandlers) Ping(ctx context.Context) error { return nil }
+
+// TestGenerateEnum_NonIdentifierKeys is a regression for the codegen producing
+// invalid TypeScript when an enum value's derived name is not a valid JS
+// identifier. The empty-string case renders literally as `: "",` (missing key,
+// TS1005 syntax error); hyphens and leading digits share the same failure
+// mode. Fix: quoted-string keys for any derived name that is not a valid
+// identifier.
+func TestGenerateEnum_NonIdentifierKeys(t *testing.T) {
+	registry := NewRegistry()
+	handler := &TrickyEnumHandlers{}
+	registry.Register(handler)
+	registry.RegisterEnumFor(handler, TrickyStatusValues())
+
+	gen := NewGenerator(registry)
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	output := buf.String()
+
+	// The bare `\n    : "",` form (no key before the colon) is a TS syntax
+	// error. Match it on its own line so the check doesn't false-positive on
+	// the valid `    "": "",` form, which contains `: ""` as a substring.
+	if strings.Contains(output, "\n    : \"\",") {
+		t.Errorf("generated TS has bare-colon entry (missing key), output:\n%s", output)
+	}
+
+	// Valid identifiers still render unquoted.
+	if !strings.Contains(output, `Active: "active"`) {
+		t.Errorf("expected valid identifier to render bare, got:\n%s", output)
+	}
+
+	// Non-identifier names render as quoted string keys.
+	wantQuoted := []string{
+		`"": ""`,
+		`"Kebab-case": "kebab-case"`,
+		`"123abc": "123abc"`,
+	}
+	for _, want := range wantQuoted {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %s in generated TS, got:\n%s", want, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Enum values whose derived key name is not a valid JavaScript identifier — empty string, hyphens, leading digits, whitespace — now render as quoted-string object keys instead of bare keys. Previously these produced syntactically invalid TypeScript (TS1005 "',' expected" on the generated file).
- The fix is one small helper (`tsObjectKey`) plus a three-branch call at the two `enumValueTemplateData` construction sites in `generate.go`. Templates are untouched. Valid identifiers still render bare, so the common path is byte-identical — regenerating the example clients produced zero diffs outside of what was already committed.
- Chosen fix is Option 1 from the issue (quote non-identifier keys), because it covers every invalid-identifier case in one place and preserves the original value in the generated union type. The alternatives (renaming empty to "Empty", skipping empty) either leave hyphens/digits broken or silently drop a legitimate enum variant.

Fixes #187

## Test plan

- [x] `go test ./...` — full suite green
- [x] New regression test `TestGenerateEnum_NonIdentifierKeys` with a `TrickyStatus` enum covering empty string, `"kebab-case"`, and `"123abc"` — asserts quoted rendering for all three and bare rendering for `"active"`
- [x] `gofmt -l` clean
- [x] Regenerated `example/vanilla` and `example/react` TS clients — zero file changes (no example exercises non-identifier enums)
- [x] `npx tsc --noEmit` in `example/react/client` — clean

## Implementation notes

`tsObjectKey` is ASCII-only on purpose. JavaScript identifiers technically allow Unicode `ID_Start` / `ID_Continue` codepoints, but restricting to ASCII is a conservative-but-correct choice: every ASCII name either passes the check and is always valid as a bare key, or fails it and falls through to `strconv.Quote`, which is always valid as a quoted key. No edge case is silently mishandled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)