### PR TITLE
Add transform struct tags for input normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,4 @@ cd example/react/client && npm run dev
 - **Never force push.** Always create new commits instead of amending.
 - **Always update PRs and issues** when pushing changes — keep descriptions current.
 - **Always update `README.md`** when adding or changing user-facing features.
+- **Always update `doc.go`** when adding or changing user-facing features. `doc.go` is the package-level overview that renders on pkg.go.dev as the aprot landing page — new public APIs, struct tags, and behavioral rules belong alongside the existing section headers (Handlers, Registry, Middleware, …). Public funcs and types also need their own doc comments, but a reader who lands on the overview should be able to discover the feature without browsing the function index.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
 - **Automatic reconnection** — page visibility + network-aware, with exponential backoff; supports dynamic URL functions for token refresh on reconnect
 - **Struct validation** — opt-in server-side validation via `go-playground/validator` struct tags, automatically enforced before handler dispatch
+- **Input transformation** — declarative `transform` struct tags (`trim`, `trimleft`, `trimright`, `uppercase`, `lowercase`, `removeempty`) normalize fields before validation runs
 - **Zod schema generation** — opt-in generation of Zod validation schemas alongside TypeScript interfaces
 - **REST adapter** — serve handlers as REST/HTTP endpoints alongside WebSocket, with convention-based HTTP method detection and path parameter mapping
 - **OpenAPI generation** — opt-in OpenAPI 3.0 spec generation from handler metadata, including validation constraints from struct tags
@@ -473,6 +474,30 @@ try {
 ```
 
 `getValidationErrors` returns `null` for any error that isn't a `CodeValidationFailed` response, so the same form-submit catch block can handle both validation failures and other errors with a single check. The `FieldError` interface mirrors the Go `FieldError` struct in `validate.go`.
+
+### Input transformation
+
+Normalize incoming fields with `transform` struct tags. Transforms run **after** JSON decoding and **before** validation, so rules like `required,min=1` see the cleaned value. No registry setup required — a field is transformed iff it carries a `transform:""` tag.
+
+```go
+type SignupRequest struct {
+    Email    string   `json:"email"    transform:"trim,lowercase" validate:"required,email"`
+    Username string   `json:"username" transform:"trim"            validate:"required,min=3"`
+    Slug     string   `json:"slug"     transform:"trimleft=/,lowercase"`
+    Tags     []string `json:"tags"     transform:"trim,removeempty"`
+}
+```
+
+Supported ops, applied in the order listed:
+
+| Op                       | Type         | Behavior                                          |
+|--------------------------|--------------|---------------------------------------------------|
+| `trim`                   | string       | `strings.TrimSpace`                               |
+| `trimleft` / `trimright` | string       | `TrimLeft` / `TrimRight`; optional `=cutset` (defaults to whitespace) |
+| `uppercase` / `lowercase`| string       | `strings.ToUpper` / `strings.ToLower`             |
+| `removeempty`            | `[]string`   | drop empty elements (apply after `trim` to also drop whitespace-only) |
+
+Transforms recurse into nested structs and slices of structs, and they handle `*string` fields (nil pointers are left alone).
 
 ### Zod Schemas
 

--- a/doc.go
+++ b/doc.go
@@ -34,6 +34,42 @@
 // parsing, so the names you choose in Go are the names your TypeScript client
 // uses.
 //
+// # Input Transformation
+//
+// Request struct fields can be normalized before handler dispatch using
+// "transform" struct tags. Transforms run after JSON decoding and before
+// struct validation, so validator rules see the cleaned value:
+//
+//	type SignupRequest struct {
+//	    Email    string   `json:"email"    transform:"trim,lowercase" validate:"required,email"`
+//	    Username string   `json:"username" transform:"trim"            validate:"required,min=3"`
+//	    Slug     string   `json:"slug"     transform:"trimleft=/,lowercase"`
+//	    Tags     []string `json:"tags"     transform:"trim,removeempty"`
+//	}
+//
+// Supported ops (applied in the order listed in the tag):
+//
+//   - trim                   strings.TrimSpace
+//   - trimleft[=cutset]      TrimLeft; optional cutset (defaults to whitespace)
+//   - trimright[=cutset]     TrimRight; optional cutset (defaults to whitespace)
+//   - uppercase              strings.ToUpper
+//   - lowercase              strings.ToLower
+//   - removeempty            []string only — drop empty elements
+//
+// Ops apply to string, *string (nil-safe), and []string fields, and the
+// walker recurses into nested structs, *struct, and []struct so nested
+// tags are picked up automatically. There is no registry opt-in — a
+// field is transformed if and only if it carries a "transform" tag.
+//
+// Every "transform" tag reachable from a handler's param types is
+// statically checked at registration time via [ValidateTransformTags].
+// Unknown ops, "removeempty" on a non-[]string field, or a "transform"
+// tag on an unsupported field type (int, bool, time.Time, …) cause
+// [Registry.Register] to panic when the server boots, rather than
+// turning every request into a [CodeInvalidParams] response at runtime.
+// [ApplyTransforms] is also exposed so the same walker can be invoked
+// on ad-hoc values outside the handler flow.
+//
 // # Registry
 //
 // A [Registry] collects handler groups, push events, enums, and custom errors

--- a/example/react/api/types.go
+++ b/example/react/api/types.go
@@ -135,9 +135,9 @@ type GetDashboardResponse struct {
 // CreateUserRequest is the payload accepted by the CreateUser endpoint.
 type CreateUserRequest struct {
 	// Name is the user's display name (2–100 characters).
-	Name string `json:"name"  validate:"required,min=2,max=100"`
+	Name string `json:"name"  transform:"trim"            validate:"required,min=2,max=100"`
 	// Email is the user's primary contact address; must be a valid email.
-	Email string `json:"email" validate:"required,email"`
+	Email string `json:"email" transform:"trim,lowercase" validate:"required,email"`
 }
 
 // UpdateUserRequest is the payload accepted by the UpdateUser endpoint.

--- a/handler.go
+++ b/handler.go
@@ -292,6 +292,14 @@ func (r *Registry) register(handler any, addToWSDispatch bool, middleware ...Mid
 		method := t.Method(i)
 		if info := validateMethod(method, v, structName); info != nil {
 			wireMethod := structName + "." + info.Name
+			// Statically verify every `transform:""` tag on the handler's
+			// struct params — catches bad tags at registration time rather
+			// than turning each request into a CodeInvalidParams response.
+			for _, p := range info.Params {
+				if err := ValidateTransformTags(p.Type); err != nil {
+					panic(fmt.Sprintf("aprot: %s.%s: %s", structName, info.Name, err.Error()))
+				}
+			}
 			info.registry = r
 			if addToWSDispatch {
 				if existing, exists := r.handlers[wireMethod]; exists {

--- a/handler.go
+++ b/handler.go
@@ -818,6 +818,31 @@ func (info *HandlerInfo) buildArgs(ctx context.Context, params jsontext.Value) (
 		}
 	}
 
+	// Apply struct-tag transformations (`transform:""`) before validation
+	// so rules like `required,min=1` see the normalized value.
+	for i, p := range info.Params {
+		pt := p.Type
+		if pt.Kind() == reflect.Ptr {
+			pt = pt.Elem()
+		}
+		if pt.Kind() != reflect.Struct {
+			continue
+		}
+		target := args[i+1] // +1 because args[0] is ctx
+		if target.Kind() == reflect.Ptr {
+			if target.IsNil() {
+				continue
+			}
+			target = target.Elem()
+		}
+		if !target.CanAddr() {
+			continue
+		}
+		if err := applyTransformsValue(target); err != nil {
+			return nil, err
+		}
+	}
+
 	// Validate struct parameters if a validator is set
 	if info.registry != nil && info.registry.validator != nil {
 		for i, p := range info.Params {

--- a/transform.go
+++ b/transform.go
@@ -7,6 +7,99 @@ import (
 	"unicode"
 )
 
+// ValidateTransformTags statically checks every `transform:""` tag
+// reachable from t (a struct type or pointer to one). It catches
+// unknown op names, ops used on unsupported field kinds, and
+// `removeempty` on anything other than `[]string` — all at registration
+// time, so the problem surfaces when the server boots rather than on
+// the first request that happens to hit the handler.
+//
+// Non-struct types are a no-op; caller is responsible for passing the
+// param type. Recursion into nested structs, *struct, and slices/arrays
+// of struct (or *struct) elements mirrors the runtime walker. Cycles
+// are broken by tracking visited types.
+func ValidateTransformTags(t reflect.Type) error {
+	if t == nil {
+		return nil
+	}
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	return validateTransformTagsType(t, map[reflect.Type]bool{})
+}
+
+func validateTransformTagsType(t reflect.Type, seen map[reflect.Type]bool) error {
+	if seen[t] {
+		return nil
+	}
+	seen[t] = true
+
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		tag := sf.Tag.Get("transform")
+		if tag != "" {
+			if err := validateTransformTagOnField(sf, ParseValidateTag(tag)); err != nil {
+				return err
+			}
+		}
+		if err := validateTransformTagsChildren(sf.Type, seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTransformTagsChildren(ft reflect.Type, seen map[reflect.Type]bool) error {
+	switch ft.Kind() {
+	case reflect.Struct:
+		return validateTransformTagsType(ft, seen)
+	case reflect.Ptr:
+		if ft.Elem().Kind() == reflect.Struct {
+			return validateTransformTagsType(ft.Elem(), seen)
+		}
+	case reflect.Slice, reflect.Array:
+		et := ft.Elem()
+		if et.Kind() == reflect.Struct {
+			return validateTransformTagsType(et, seen)
+		}
+		if et.Kind() == reflect.Ptr && et.Elem().Kind() == reflect.Struct {
+			return validateTransformTagsType(et.Elem(), seen)
+		}
+	}
+	return nil
+}
+
+func validateTransformTagOnField(sf reflect.StructField, rules []ValidateRule) error {
+	ft := sf.Type
+	isStringField := ft.Kind() == reflect.String ||
+		(ft.Kind() == reflect.Ptr && ft.Elem().Kind() == reflect.String)
+	isStringSlice := ft.Kind() == reflect.Slice && ft.Elem().Kind() == reflect.String
+
+	if !isStringField && !isStringSlice {
+		return fmt.Errorf("aprot: transform tag on field %q has unsupported type %s (only string, *string, and []string are supported)", sf.Name, ft)
+	}
+
+	for _, r := range rules {
+		switch r.Tag {
+		case "trim", "trimleft", "trimright", "uppercase", "lowercase":
+			// valid on string, *string, and []string (per-element)
+		case "removeempty":
+			if !isStringSlice {
+				return fmt.Errorf("aprot: transform tag on field %q uses removeempty on non-[]string type %s", sf.Name, ft)
+			}
+		default:
+			return fmt.Errorf("aprot: transform tag on field %q has unknown op %q", sf.Name, r.Tag)
+		}
+	}
+	return nil
+}
+
 // ApplyTransforms walks v (a struct or pointer to struct) and applies the
 // operations declared in `transform:""` tags on its exported fields. It
 // mutates the value in place.

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,223 @@
+package aprot
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+// ApplyTransforms walks v (a struct or pointer to struct) and applies the
+// operations declared in `transform:""` tags on its exported fields. It
+// mutates the value in place.
+//
+// Supported ops:
+//   - trim                  strings.TrimSpace
+//   - trimleft[=cutset]     TrimLeft (default cutset: whitespace)
+//   - trimright[=cutset]    TrimRight (default cutset: whitespace)
+//   - uppercase             strings.ToUpper
+//   - lowercase             strings.ToLower
+//   - removeempty           ([]string only) drop empty elements
+//
+// Ops apply in the order listed in the tag, so `transform:"trim,removeempty"`
+// on a []string first trims each element and then drops the empties.
+//
+// Non-struct inputs are a no-op. Unknown op names or type mismatches
+// (e.g. removeempty on a non-slice field) return an *ProtocolError with
+// CodeInvalidParams.
+func ApplyTransforms(v any) error {
+	if v == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil
+	}
+	return applyTransformsValue(rv)
+}
+
+// applyTransformsValue recursively walks a struct value. rv must be a
+// struct (not a pointer) and addressable so that fields can be mutated.
+func applyTransformsValue(rv reflect.Value) error {
+	t := rv.Type()
+	for i := 0; i < rv.NumField(); i++ {
+		sf := t.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		fv := rv.Field(i)
+		tag := sf.Tag.Get("transform")
+		rules := ParseValidateTag(tag)
+
+		if len(rules) > 0 {
+			if err := applyFieldRules(sf, fv, rules); err != nil {
+				return err
+			}
+		}
+
+		// Always recurse into nested structs / struct containers so
+		// nested `transform` tags are discovered even when the parent
+		// field has no tag of its own.
+		if err := recurseIntoField(fv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recurseIntoField(fv reflect.Value) error {
+	switch fv.Kind() {
+	case reflect.Struct:
+		return applyTransformsValue(fv)
+	case reflect.Ptr:
+		if fv.IsNil() {
+			return nil
+		}
+		if fv.Elem().Kind() == reflect.Struct {
+			return applyTransformsValue(fv.Elem())
+		}
+	case reflect.Slice, reflect.Array:
+		et := fv.Type().Elem()
+		if et.Kind() == reflect.Struct {
+			for i := 0; i < fv.Len(); i++ {
+				if err := applyTransformsValue(fv.Index(i)); err != nil {
+					return err
+				}
+			}
+		} else if et.Kind() == reflect.Ptr && et.Elem().Kind() == reflect.Struct {
+			for i := 0; i < fv.Len(); i++ {
+				el := fv.Index(i)
+				if el.IsNil() {
+					continue
+				}
+				if err := applyTransformsValue(el.Elem()); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func applyFieldRules(sf reflect.StructField, fv reflect.Value, rules []ValidateRule) error {
+	switch fv.Kind() {
+	case reflect.String:
+		s, err := applyStringOps(sf.Name, fv.String(), rules, false)
+		if err != nil {
+			return err
+		}
+		fv.SetString(s)
+		return nil
+
+	case reflect.Ptr:
+		if fv.Type().Elem().Kind() != reflect.String {
+			return nil
+		}
+		if fv.IsNil() {
+			return nil
+		}
+		s, err := applyStringOps(sf.Name, fv.Elem().String(), rules, false)
+		if err != nil {
+			return err
+		}
+		fv.Elem().SetString(s)
+		return nil
+
+	case reflect.Slice:
+		if fv.Type().Elem().Kind() != reflect.String {
+			// removeempty is only valid on []string; bail with a helpful
+			// error if the user put transform ops on a non-string slice.
+			return ErrInvalidParams(fmt.Sprintf("transform: field %q has slice type %s, only []string is supported", sf.Name, fv.Type()))
+		}
+		return applySliceStringOps(sf.Name, fv, rules)
+
+	default:
+		return ErrInvalidParams(fmt.Sprintf("transform: field %q has unsupported type %s", sf.Name, fv.Type()))
+	}
+}
+
+func applyStringOps(field, s string, rules []ValidateRule, inSlice bool) (string, error) {
+	for _, r := range rules {
+		switch r.Tag {
+		case "trim":
+			s = strings.TrimSpace(s)
+		case "trimleft":
+			if r.Param == "" {
+				s = strings.TrimLeftFunc(s, unicode.IsSpace)
+			} else {
+				s = strings.TrimLeft(s, r.Param)
+			}
+		case "trimright":
+			if r.Param == "" {
+				s = strings.TrimRightFunc(s, unicode.IsSpace)
+			} else {
+				s = strings.TrimRight(s, r.Param)
+			}
+		case "uppercase":
+			s = strings.ToUpper(s)
+		case "lowercase":
+			s = strings.ToLower(s)
+		case "removeempty":
+			if !inSlice {
+				return "", ErrInvalidParams(fmt.Sprintf("transform: field %q uses removeempty on non-slice type", field))
+			}
+			// handled by caller
+		default:
+			return "", ErrInvalidParams(fmt.Sprintf("transform: field %q has unknown op %q", field, r.Tag))
+		}
+	}
+	return s, nil
+}
+
+func applySliceStringOps(field string, fv reflect.Value, rules []ValidateRule) error {
+	// Walk rules once, applying per-element string ops and filtering
+	// empties in place when `removeempty` appears. Order matters: ops
+	// before `removeempty` run on every element; ops after it run only
+	// on the surviving elements.
+	n := fv.Len()
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, fv.Index(i).String())
+	}
+
+	for _, r := range rules {
+		if r.Tag == "removeempty" {
+			filtered := out[:0]
+			for _, s := range out {
+				if s != "" {
+					filtered = append(filtered, s)
+				}
+			}
+			out = filtered
+			continue
+		}
+		// Apply this single op to each element via applyStringOps with a
+		// one-rule slice so param handling stays centralized.
+		one := []ValidateRule{r}
+		for i, s := range out {
+			ns, err := applyStringOps(field, s, one, true)
+			if err != nil {
+				return err
+			}
+			out[i] = ns
+		}
+	}
+
+	// Write back. If the input slice was nil and no elements survive,
+	// leave it nil to avoid surprising the caller.
+	if fv.IsNil() && len(out) == 0 {
+		return nil
+	}
+	result := reflect.MakeSlice(fv.Type(), len(out), len(out))
+	for i, s := range out {
+		result.Index(i).SetString(s)
+	}
+	fv.Set(result)
+	return nil
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,0 +1,252 @@
+package aprot
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestApplyTransforms_StringBasics(t *testing.T) {
+	type req struct {
+		Trim  string `transform:"trim"`
+		Upper string `transform:"uppercase"`
+		Lower string `transform:"lowercase"`
+		Combo string `transform:"trim,lowercase"`
+		Untag string
+		unexp string `transform:"trim"` //nolint:unused // tag on unexported field must be ignored
+	}
+	r := &req{
+		Trim:  "  hello  ",
+		Upper: "hello",
+		Lower: "HELLO",
+		Combo: "  HELLO  ",
+		Untag: "  keep  ",
+		unexp: "  skip  ",
+	}
+	if err := ApplyTransforms(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Trim != "hello" {
+		t.Errorf("Trim = %q", r.Trim)
+	}
+	if r.Upper != "HELLO" {
+		t.Errorf("Upper = %q", r.Upper)
+	}
+	if r.Lower != "hello" {
+		t.Errorf("Lower = %q", r.Lower)
+	}
+	if r.Combo != "hello" {
+		t.Errorf("Combo = %q", r.Combo)
+	}
+	if r.Untag != "  keep  " {
+		t.Errorf("Untag = %q (should be unchanged)", r.Untag)
+	}
+	if r.unexp != "  skip  " {
+		t.Errorf("unexp = %q (should be unchanged)", r.unexp)
+	}
+}
+
+func TestApplyTransforms_TrimLeftRight(t *testing.T) {
+	type req struct {
+		DefaultLeft  string `transform:"trimleft"`
+		DefaultRight string `transform:"trimright"`
+		CutsetLeft   string `transform:"trimleft=/"`
+		CutsetRight  string `transform:"trimright=/"`
+		CutsetBoth   string `transform:"trimleft=/,trimright=/"`
+	}
+	r := &req{
+		DefaultLeft:  "  keep me  ",
+		DefaultRight: "  keep me  ",
+		CutsetLeft:   "///path",
+		CutsetRight:  "path///",
+		CutsetBoth:   "///path///",
+	}
+	if err := ApplyTransforms(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.DefaultLeft != "keep me  " {
+		t.Errorf("DefaultLeft = %q", r.DefaultLeft)
+	}
+	if r.DefaultRight != "  keep me" {
+		t.Errorf("DefaultRight = %q", r.DefaultRight)
+	}
+	if r.CutsetLeft != "path" {
+		t.Errorf("CutsetLeft = %q", r.CutsetLeft)
+	}
+	if r.CutsetRight != "path" {
+		t.Errorf("CutsetRight = %q", r.CutsetRight)
+	}
+	if r.CutsetBoth != "path" {
+		t.Errorf("CutsetBoth = %q", r.CutsetBoth)
+	}
+}
+
+func TestApplyTransforms_StringPointer(t *testing.T) {
+	type req struct {
+		Name *string `transform:"trim,lowercase"`
+		Nil  *string `transform:"trim"`
+	}
+	val := "  HELLO  "
+	r := &req{Name: &val}
+	if err := ApplyTransforms(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *r.Name != "hello" {
+		t.Errorf("Name = %q", *r.Name)
+	}
+	if r.Nil != nil {
+		t.Errorf("Nil should remain nil, got %v", r.Nil)
+	}
+}
+
+func TestApplyTransforms_StringSliceRemoveEmpty(t *testing.T) {
+	type req struct {
+		Tags    []string `transform:"trim,removeempty"`
+		Upper   []string `transform:"uppercase"`
+		Empty   []string `transform:"removeempty"`
+		NilTags []string `transform:"trim,removeempty"`
+	}
+	r := &req{
+		Tags:  []string{"  go ", "", "  rust  ", "   "},
+		Upper: []string{"a", "b"},
+		Empty: []string{"", "x", ""},
+	}
+	if err := ApplyTransforms(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := r.Tags, []string{"go", "rust"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Tags = %v, want %v", got, want)
+	}
+	if got, want := r.Upper, []string{"A", "B"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Upper = %v, want %v", got, want)
+	}
+	if got, want := r.Empty, []string{"x"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Empty = %v, want %v", got, want)
+	}
+	if r.NilTags != nil {
+		t.Errorf("NilTags should stay nil, got %v", r.NilTags)
+	}
+}
+
+func TestApplyTransforms_NestedStruct(t *testing.T) {
+	type Inner struct {
+		Name string `transform:"trim,lowercase"`
+	}
+	type Outer struct {
+		Title string `transform:"trim"`
+		Inner Inner
+		Ptr   *Inner
+	}
+	r := &Outer{
+		Title: "  T  ",
+		Inner: Inner{Name: "  ALICE  "},
+		Ptr:   &Inner{Name: "  BOB  "},
+	}
+	if err := ApplyTransforms(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Title != "T" {
+		t.Errorf("Title = %q", r.Title)
+	}
+	if r.Inner.Name != "alice" {
+		t.Errorf("Inner.Name = %q", r.Inner.Name)
+	}
+	if r.Ptr.Name != "bob" {
+		t.Errorf("Ptr.Name = %q", r.Ptr.Name)
+	}
+}
+
+func TestApplyTransforms_SliceOfStructs(t *testing.T) {
+	type Item struct {
+		Label string `transform:"trim,uppercase"`
+	}
+	type req struct {
+		Items []Item
+	}
+	r := &req{Items: []Item{{Label: "  a  "}, {Label: " b "}}}
+	if err := ApplyTransforms(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Items[0].Label != "A" || r.Items[1].Label != "B" {
+		t.Errorf("Items = %+v", r.Items)
+	}
+}
+
+func TestApplyTransforms_UnknownOp(t *testing.T) {
+	type req struct {
+		X string `transform:"trim,frobnicate"`
+	}
+	err := ApplyTransforms(&req{X: " hi "})
+	if err == nil {
+		t.Fatal("expected error for unknown op")
+	}
+	if !strings.Contains(err.Error(), "frobnicate") {
+		t.Errorf("error should mention unknown op name: %v", err)
+	}
+}
+
+func TestApplyTransforms_RemoveEmptyOnNonSlice(t *testing.T) {
+	type req struct {
+		X string `transform:"removeempty"`
+	}
+	err := ApplyTransforms(&req{X: "hi"})
+	if err == nil {
+		t.Fatal("expected error for removeempty on string")
+	}
+}
+
+func TestApplyTransforms_NonStructInput(t *testing.T) {
+	// Non-struct inputs are a no-op (matches validator leniency).
+	if err := ApplyTransforms("just a string"); err != nil {
+		t.Errorf("unexpected error on non-struct: %v", err)
+	}
+	if err := ApplyTransforms(nil); err != nil {
+		t.Errorf("unexpected error on nil: %v", err)
+	}
+}
+
+// --- Integration test: transforms run before validation in buildArgs() ---
+
+type TransformValidated struct {
+	Name string `json:"name" transform:"trim" validate:"required,min=1"`
+}
+
+type TransformHandlers struct{}
+
+func (h *TransformHandlers) Submit(ctx context.Context, req *TransformValidated) error {
+	if req.Name != strings.TrimSpace(req.Name) {
+		return errors.New("handler saw untrimmed value")
+	}
+	return nil
+}
+
+func TestTransform_RunsBeforeValidation(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&TransformHandlers{})
+	registry.SetValidator(NewPlaygroundValidator())
+
+	info, ok := registry.Get("TransformHandlers.Submit")
+	if !ok {
+		t.Fatal("handler not found")
+	}
+
+	// Whitespace-only input should trim to empty, then fail validation.
+	_, err := info.Call(context.Background(), []byte(`[{"name":"   "}]`))
+	if err == nil {
+		t.Fatal("expected validation error after trim, got nil")
+	}
+	var perr *ProtocolError
+	if !errors.As(err, &perr) {
+		t.Fatalf("expected *ProtocolError, got %T: %v", err, err)
+	}
+	if perr.Code != CodeValidationFailed {
+		t.Errorf("expected code %d, got %d", CodeValidationFailed, perr.Code)
+	}
+
+	// Padded valid input should trim and pass.
+	if _, err := info.Call(context.Background(), []byte(`[{"name":"  alice  "}]`)); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -207,6 +207,98 @@ func TestApplyTransforms_NonStructInput(t *testing.T) {
 	}
 }
 
+// --- Static tag validation: caught at registration time ---
+
+func TestValidateTransformTags_UnknownOp(t *testing.T) {
+	type req struct {
+		Name string `transform:"trim,frobnicate"`
+	}
+	err := ValidateTransformTags(reflect.TypeOf(req{}))
+	if err == nil {
+		t.Fatal("expected error for unknown op")
+	}
+	if !strings.Contains(err.Error(), "frobnicate") {
+		t.Errorf("error should mention op name: %v", err)
+	}
+}
+
+func TestValidateTransformTags_WrongFieldType(t *testing.T) {
+	type req struct {
+		Age int `transform:"trim"`
+	}
+	err := ValidateTransformTags(reflect.TypeOf(req{}))
+	if err == nil {
+		t.Fatal("expected error for transform on int")
+	}
+	if !strings.Contains(err.Error(), "Age") {
+		t.Errorf("error should mention field name: %v", err)
+	}
+}
+
+func TestValidateTransformTags_RemoveEmptyOnNonSlice(t *testing.T) {
+	type req struct {
+		Name string `transform:"removeempty"`
+	}
+	err := ValidateTransformTags(reflect.TypeOf(req{}))
+	if err == nil {
+		t.Fatal("expected error for removeempty on string")
+	}
+}
+
+func TestValidateTransformTags_NestedStruct(t *testing.T) {
+	type inner struct {
+		Age int `transform:"trim"`
+	}
+	type outer struct {
+		Inner inner
+	}
+	err := ValidateTransformTags(reflect.TypeOf(outer{}))
+	if err == nil {
+		t.Fatal("expected error from nested struct")
+	}
+}
+
+func TestValidateTransformTags_ValidTags(t *testing.T) {
+	type inner struct {
+		Label string `transform:"trim,uppercase"`
+	}
+	type req struct {
+		Email string   `transform:"trim,lowercase"`
+		Name  *string  `transform:"trim"`
+		Tags  []string `transform:"trim,removeempty"`
+		Items []inner
+	}
+	if err := ValidateTransformTags(reflect.TypeOf(req{})); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+type BadTransformHandlers struct{}
+
+type BadReq struct {
+	Age int `transform:"trim"`
+}
+
+func (h *BadTransformHandlers) Submit(ctx context.Context, req *BadReq) error { return nil }
+
+func TestRegister_PanicsOnBadTransformTag(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on registration with invalid transform tag")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+		if !strings.Contains(msg, "transform") || !strings.Contains(msg, "Age") {
+			t.Errorf("panic message should mention transform and field name: %q", msg)
+		}
+	}()
+	registry := NewRegistry()
+	registry.Register(&BadTransformHandlers{})
+}
+
 // --- Integration test: transforms run before validation in buildArgs() ---
 
 type TransformValidated struct {


### PR DESCRIPTION
Closes #191

## Summary

- New `transform:""` struct tag runs between JSON decode and validation in `handler.go:buildArgs`, so rules like `required,min=1` finally reject whitespace-only input.
- Supports `trim`, `trimleft[=cutset]`, `trimright[=cutset]`, `uppercase`, `lowercase` on strings / `*string` / `[]string`, plus `removeempty` for `[]string`. Ops apply in the listed order.
- Recurses into nested structs, `*struct`, and `[]struct`. Reuses `ParseValidateTag` so the tag format matches `validate`. No registry opt-in — tag presence is the opt-in.
- **Tags are statically validated at registration time** via `ValidateTransformTags`. Unknown ops, `transform` on unsupported field types (int, bool, …), and `removeempty` on non-`[]string` slices panic from `Registry.Register` when the server boots, instead of turning every request into a `CodeInvalidParams` response at runtime.
- README gets an "Input transformation" subsection; React example `CreateUserRequest` demonstrates `trim` / `trim,lowercase`.

## Example

```go
type SignupRequest struct {
    Email    string   `json:"email"    transform:"trim,lowercase" validate:"required,email"`
    Username string   `json:"username" transform:"trim"            validate:"required,min=3"`
    Slug     string   `json:"slug"     transform:"trimleft=/,lowercase"`
    Tags     []string `json:"tags"     transform:"trim,removeempty"`
}
```

## Test plan

- [x] `go test ./...` — full suite green, including new `transform_test.go`
- [x] Unit tests cover each op, nesting, slice recursion, nil-pointer safety, unknown-op error, `removeempty` on non-slice error
- [x] Static-validation tests cover unknown op, wrong field type, `removeempty` on non-slice, nested struct, and a full valid struct
- [x] `TestRegister_PanicsOnBadTransformTag` asserts `Registry.Register` panics when a handler's param struct has `transform:"trim"` on an `int` field
- [x] Integration test `TestTransform_RunsBeforeValidation` sends `{"name":"   "}` and asserts the handler returns `CodeValidationFailed` — proving transforms run before validation
- [x] Regenerated both vanilla and React TS clients; `npx tsc --noEmit` clean in React client
- [x] `gofmt -w` on all touched Go files

🤖 Generated with [Claude Code](https://claude.com/claude-code)