### PR TITLE
Fix strict-ESLint findings in generated TS client (#195)

### DIFF
--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -802,9 +802,12 @@ export class ApiClient {
      * rejected with an error and are NOT auto-resumed on reconnect.
      */
     requestStream<T>(method: string, params: unknown[], options?: RequestOptions): AsyncIterable<T> {
-        const client = this;
+        // Arrow factory captures `this` lexically — avoids aliasing `this` to a
+        // local variable (which trips @typescript-eslint/no-this-alias under
+        // strict presets). All inner closures are also arrows, so they inherit
+        // the same `this` (the ApiClient instance).
         return {
-            [Symbol.asyncIterator](): AsyncIterator<T> {
+            [Symbol.asyncIterator]: (): AsyncIterator<T> => {
                 let id = '';
                 let started = false;
                 const buffer: T[] = [];
@@ -840,9 +843,9 @@ export class ApiClient {
 
                 const cancelAtServer = () => {
                     if (id && !ended) {
-                        client.streams.delete(id);
-                        if (client.transport.isConnected()) {
-                            client.transport.send({ type: 'cancel', id });
+                        this.streams.delete(id);
+                        if (this.transport.isConnected()) {
+                            this.transport.send({ type: 'cancel', id });
                         }
                     }
                 };
@@ -850,13 +853,13 @@ export class ApiClient {
                 const ensureStarted = () => {
                     if (started) return;
                     started = true;
-                    if (!client.transport.isConnected()) {
+                    if (!this.transport.isConnected()) {
                         end(new Error('Not connected'));
                         return;
                     }
-                    id = String(++client.requestId);
-                    client.streams.set(id, { push, end });
-                    client.notifyLoadingChange();
+                    id = String(++this.requestId);
+                    this.streams.set(id, { push, end });
+                    this.notifyLoadingChange();
                     if (options?.signal) {
                         if (options.signal.aborted) {
                             cancelAtServer();
@@ -868,7 +871,7 @@ export class ApiClient {
                             end(new Error('Request aborted'));
                         }, { once: true });
                     }
-                    client.transport.send({ type: 'request', id, method, params });
+                    this.transport.send({ type: 'request', id, method, params });
                 };
 
                 return {
@@ -1392,10 +1395,12 @@ export function useQuery<TArgs extends unknown[], TRes>(
     // These hooks are always called to satisfy Rules of Hooks.
     // When caching is off they receive no-op values and are inert.
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const cacheStore = useMemo(() => {
         if (!shouldCache) return null;
         return subscribeCached<TRes>(client, cacheKey, subscribeMethod!, subscribeOpts!.params);
+    // subscribeMethod / subscribeOpts.params are already encoded into cacheKey,
+    // so listing them again would force the memo to re-run on identity changes
+    // even when the resolved key is unchanged.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, cacheKey, shouldCache]);
 
@@ -1703,6 +1708,11 @@ export function useStream<TRes>(
     useEffect(() => {
         start();
         return () => {
+            // Intentionally mutates the LIVE ref instead of a captured local —
+            // that's how cleanup invalidates the in-flight async loop on
+            // unmount/restart. Copying `tickRef.current` to a local first (the
+            // rule's literal advice) would defeat the invalidation.
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             tickRef.current++;
             abortRef.current?.abort();
             abortRef.current = null;

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -800,9 +800,12 @@ export class ApiClient {
      * rejected with an error and are NOT auto-resumed on reconnect.
      */
     requestStream<T>(method: string, params: unknown[], options?: RequestOptions): AsyncIterable<T> {
-        const client = this;
+        // Arrow factory captures `this` lexically — avoids aliasing `this` to a
+        // local variable (which trips @typescript-eslint/no-this-alias under
+        // strict presets). All inner closures are also arrows, so they inherit
+        // the same `this` (the ApiClient instance).
         return {
-            [Symbol.asyncIterator](): AsyncIterator<T> {
+            [Symbol.asyncIterator]: (): AsyncIterator<T> => {
                 let id = '';
                 let started = false;
                 const buffer: T[] = [];
@@ -838,9 +841,9 @@ export class ApiClient {
 
                 const cancelAtServer = () => {
                     if (id && !ended) {
-                        client.streams.delete(id);
-                        if (client.transport.isConnected()) {
-                            client.transport.send({ type: 'cancel', id });
+                        this.streams.delete(id);
+                        if (this.transport.isConnected()) {
+                            this.transport.send({ type: 'cancel', id });
                         }
                     }
                 };
@@ -848,13 +851,13 @@ export class ApiClient {
                 const ensureStarted = () => {
                     if (started) return;
                     started = true;
-                    if (!client.transport.isConnected()) {
+                    if (!this.transport.isConnected()) {
                         end(new Error('Not connected'));
                         return;
                     }
-                    id = String(++client.requestId);
-                    client.streams.set(id, { push, end });
-                    client.notifyLoadingChange();
+                    id = String(++this.requestId);
+                    this.streams.set(id, { push, end });
+                    this.notifyLoadingChange();
                     if (options?.signal) {
                         if (options.signal.aborted) {
                             cancelAtServer();
@@ -866,7 +869,7 @@ export class ApiClient {
                             end(new Error('Request aborted'));
                         }, { once: true });
                     }
-                    client.transport.send({ type: 'request', id, method, params });
+                    this.transport.send({ type: 'request', id, method, params });
                 };
 
                 return {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -806,9 +806,12 @@ export class ApiClient {
      * rejected with an error and are NOT auto-resumed on reconnect.
      */
     requestStream<T>(method: string, params: unknown[], options?: RequestOptions): AsyncIterable<T> {
-        const client = this;
+        // Arrow factory captures `this` lexically — avoids aliasing `this` to a
+        // local variable (which trips @typescript-eslint/no-this-alias under
+        // strict presets). All inner closures are also arrows, so they inherit
+        // the same `this` (the ApiClient instance).
         return {
-            [Symbol.asyncIterator](): AsyncIterator<T> {
+            [Symbol.asyncIterator]: (): AsyncIterator<T> => {
                 let id = '';
                 let started = false;
                 const buffer: T[] = [];
@@ -844,9 +847,9 @@ export class ApiClient {
 
                 const cancelAtServer = () => {
                     if (id && !ended) {
-                        client.streams.delete(id);
-                        if (client.transport.isConnected()) {
-                            client.transport.send({ type: 'cancel', id });
+                        this.streams.delete(id);
+                        if (this.transport.isConnected()) {
+                            this.transport.send({ type: 'cancel', id });
                         }
                     }
                 };
@@ -854,13 +857,13 @@ export class ApiClient {
                 const ensureStarted = () => {
                     if (started) return;
                     started = true;
-                    if (!client.transport.isConnected()) {
+                    if (!this.transport.isConnected()) {
                         end(new Error('Not connected'));
                         return;
                     }
-                    id = String(++client.requestId);
-                    client.streams.set(id, { push, end });
-                    client.notifyLoadingChange();
+                    id = String(++this.requestId);
+                    this.streams.set(id, { push, end });
+                    this.notifyLoadingChange();
                     if (options?.signal) {
                         if (options.signal.aborted) {
                             cancelAtServer();
@@ -872,7 +875,7 @@ export class ApiClient {
                             end(new Error('Request aborted'));
                         }, { once: true });
                     }
-                    client.transport.send({ type: 'request', id, method, params });
+                    this.transport.send({ type: 'request', id, method, params });
                 };
 
                 return {
@@ -1419,10 +1422,12 @@ export function useQuery<TArgs extends unknown[], TRes>(
     // These hooks are always called to satisfy Rules of Hooks.
     // When caching is off they receive no-op values and are inert.
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const cacheStore = useMemo(() => {
         if (!shouldCache) return null;
         return subscribeCached<TRes>(client, cacheKey, subscribeMethod!, subscribeOpts!.params);
+    // subscribeMethod / subscribeOpts.params are already encoded into cacheKey,
+    // so listing them again would force the memo to re-run on identity changes
+    // even when the resolved key is unchanged.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, cacheKey, shouldCache]);
 
@@ -1730,6 +1735,11 @@ export function useStream<TRes>(
     useEffect(() => {
         start();
         return () => {
+            // Intentionally mutates the LIVE ref instead of a captured local —
+            // that's how cleanup invalidates the in-flight async loop on
+            // unmount/restart. Copying `tickRef.current` to a local first (the
+            // rule's literal advice) would defeat the invalidation.
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             tickRef.current++;
             abortRef.current?.abort();
             abortRef.current = null;


### PR DESCRIPTION
## Summary

Closes #195. Patches `templates/_client-common.ts.tmpl` so the emitted TypeScript client passes the strict ESLint preset combo `@typescript-eslint/recommended` + `eslint-plugin-react-hooks/recommended` (v5) — the combo that `npm create vite@latest -- --template react-ts` scaffolds.

Three template-source fixes:

1. **`@typescript-eslint/no-this-alias` in `requestStream`** — replaced `const client = this` + `[Symbol.asyncIterator](): AsyncIterator<T>` with an arrow factory `[Symbol.asyncIterator]: () => { ... }` so `this` is captured lexically. All inner closures (`cancelAtServer`, `ensureStarted`, `push`, `end`) were already arrow functions, so they inherit the new `this` (the `ApiClient` instance). Runtime behavior unchanged.
2. **Unused `eslint-disable-next-line` above `useMemo` in `useQuery`** — only the directive immediately preceding the deps array actually suppresses the warning; the outer one was dead and was itself flagged as `Unused eslint-disable directive`. Removed it and added a short rationale above the kept directive (`subscribeMethod` / `subscribeOpts.params` are already encoded into `cacheKey`).
3. **`react-hooks/exhaustive-deps` "ref value will likely have changed" in `useStream` cleanup** — added a scoped `// eslint-disable-next-line` directly above `tickRef.current++` (the site the rule reports on, verified at column 21 in the pre-fix generated client) with a comment explaining that mutating the live ref *is* the invalidation mechanism; copying to a local (the rule's literal advice) would defeat it.

The example clients under `example/react/client/src/api/client.ts` and `example/vanilla/client/static/api/client.ts` were regenerated and are included in the diff.

## Test plan

- [x] `cd example/vanilla/tools/generate && go run main.go` — clean codegen
- [x] `cd example/react/tools/generate && go run main.go` — clean codegen
- [x] `cd example/react/client && npx tsc --noEmit` — passes (exit 0)
- [x] `go test ./...` — `aprot` and `aprot/tasks` both pass
- [x] **Reproducer verified**: ESLint v9.39.4 + `eslint-plugin-react-hooks` v5.2.0 + `typescript-eslint` v8.59.0 against the regenerated `example/react/client/src/api/client.ts`:
  - **Pre-fix:** 1 error (`no-this-alias` at 805:15) + 2 warnings (unused disable at 1395:5, ref-cleanup at 1706:21) — matches issue exactly
  - **Post-fix:** 0 problems
- [ ] Downstream consumer who reported #195 confirms `mage patchRelease` / `npx eslint .` no longer fails on the regenerated `src/api/client.ts`

## Notes

- No `.go` files changed → no `gofmt` step required.
- README / `doc.go` not updated: this is a codegen output bug fix, not a new public-facing feature or API. The hooks' signatures, return types, and runtime behavior are unchanged. Happy to add a brief "generated client is ESLint-clean against strict presets" note if you'd like an explicit guarantee documented.