### PR TITLE
Fix useIsLoading getting stuck after reconnect (regression of #160)

### DIFF
--- a/e2e/tests/ws.test.ts
+++ b/e2e/tests/ws.test.ts
@@ -140,6 +140,75 @@ describe('WebSocket Transport', () => {
         expect(client.getLoadingCount()).toBe(0);
     });
 
+    test('onLoadingChange does not flag subscriptions as loading after reconnect', async () => {
+        // Use a dedicated client with auto-reconnect enabled. The default
+        // afterEach disconnects the suite-wide client; this one is cleaned
+        // up locally.
+        const reconnectClient = new ApiClient(wsUrl(), {
+            reconnect: true,
+            reconnectInterval: 50,
+        });
+        await reconnectClient.connect();
+
+        try {
+            // Subscribe and wait for initial data to land. The active
+            // subscription must survive the reconnect so resubscribeAll()
+            // re-registers it server-side.
+            await new Promise<void>((resolve) => {
+                subscribeListUsers(reconnectClient, (_result: ListUsersResponse) => {
+                    resolve();
+                });
+            });
+            expect(reconnectClient.getLoadingCount()).toBe(0);
+
+            // Capture every onLoadingChange notification fired from this
+            // point onward. With only an active subscription pending (no
+            // user-initiated requests), no notification should report
+            // count > 0 — including the one fired by resubscribeAll() after
+            // the reconnect lands.
+            const counts: number[] = [];
+            const offLoading = reconnectClient.onLoadingChange((count) => counts.push(count));
+
+            // Force a transport-level disconnect to simulate a network drop
+            // (Spotify-foreground pause, auth-token rotation, etc.). Going
+            // through transport.disconnect() — not client.disconnect() —
+            // keeps `manualDisconnect` false, so the auto-reconnect path
+            // engages and resubscribeAll() runs.
+            const transport = (reconnectClient as unknown as {
+                transport: { disconnect: () => void };
+            }).transport;
+            transport.disconnect();
+
+            // Wait for the client to fully re-enter the connected state.
+            await new Promise<void>((resolve) => {
+                const offState = reconnectClient.onStateChange((s) => {
+                    if (s === 'connected') {
+                        offState();
+                        resolve();
+                    }
+                });
+            });
+
+            // Give resubscribe responses time to land.
+            await new Promise((r) => setTimeout(r, 200));
+
+            offLoading();
+
+            // After reconnect, getLoadingCount() must still report 0 (it
+            // already excludes subscription pending entries).
+            expect(reconnectClient.getLoadingCount()).toBe(0);
+
+            // The notification stream must agree. With the regression in
+            // notifyLoadingChange(), resubscribeAll() puts subscription IDs
+            // back in `pending` and notifies listeners with `pending.size`,
+            // so useIsLoading() flips to true and stays stuck until each
+            // initial response arrives — exactly the symptom this guards.
+            expect(counts.every((c) => c === 0)).toBe(true);
+        } finally {
+            reconnectClient.disconnect();
+        }
+    });
+
     test('unknown method throws ApiError with isNotFound', async () => {
         try {
             await client.request('NonExistent', []);

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -536,7 +536,13 @@ export class ApiClient {
     }
 
     private notifyLoadingChange(): void {
-        const count = this.pending.size + this.buffer.length + this.streams.size;
+        // Read through getLoadingCount() so the listener-facing count and the
+        // public getter cannot diverge. Subscription pending entries (added
+        // by subscribe() and re-added by resubscribeAll() on reconnect) must
+        // not flip useIsLoading() to true — otherwise reconnects after auth
+        // refresh or coming back from another app leave the global loading
+        // state stuck until every subscription's first response arrives.
+        const count = this.getLoadingCount();
         if (count !== this.lastLoadingCount) {
             this.lastLoadingCount = count;
             for (const listener of this.loadingListeners) {

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -529,7 +529,13 @@ export class ApiClient {
     }
 
     private notifyLoadingChange(): void {
-        const count = this.pending.size + this.buffer.length + this.streams.size;
+        // Read through getLoadingCount() so the listener-facing count and the
+        // public getter cannot diverge. Subscription pending entries (added
+        // by subscribe() and re-added by resubscribeAll() on reconnect) must
+        // not flip useIsLoading() to true — otherwise reconnects after auth
+        // refresh or coming back from another app leave the global loading
+        // state stuck until every subscription's first response arrives.
+        const count = this.getLoadingCount();
         if (count !== this.lastLoadingCount) {
             this.lastLoadingCount = count;
             for (const listener of this.loadingListeners) {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -535,7 +535,13 @@ export class ApiClient {
     }
 
     private notifyLoadingChange(): void {
-        const count = this.pending.size + this.buffer.length + this.streams.size;
+        // Read through getLoadingCount() so the listener-facing count and the
+        // public getter cannot diverge. Subscription pending entries (added
+        // by subscribe() and re-added by resubscribeAll() on reconnect) must
+        // not flip useIsLoading() to true — otherwise reconnects after auth
+        // refresh or coming back from another app leave the global loading
+        // state stuck until every subscription's first response arrives.
+        const count = this.getLoadingCount();
         if (count !== this.lastLoadingCount) {
             this.lastLoadingCount = count;
             for (const listener of this.loadingListeners) {


### PR DESCRIPTION
## Summary

- `notifyLoadingChange()` re-introduced the bug fixed in #160 by computing the listener-facing count with a different formula than `getLoadingCount()` — it summed `pending.size + buffer.length + streams.size` and so re-counted the subscription IDs that `resubscribeAll()` puts back into `pending` on every reconnect.
- After a transport-level disconnect (auth-token rotation, returning from a foregrounded app, network blip), `useIsLoading()` flipped to `true` and stayed stuck until *every* subscription's first response arrived. Users hit this coming back from Spotify or after re-authenticating.
- Fix: make `notifyLoadingChange()` read through `getLoadingCount()` so the two paths cannot diverge again. The previous "two formulas to keep in sync" footgun is removed.

## Test plan

- [x] Added `e2e/tests/ws.test.ts > onLoadingChange does not flag subscriptions as loading after reconnect`. The test forces a transport-level disconnect via `transport.disconnect()` (keeps `manualDisconnect: false` so auto-reconnect engages and subscriptions survive), waits for the client to re-enter `connected`, and asserts that no `onLoadingChange` notification reports `count > 0`.
- [x] Confirmed red on the fix branch (`expected false to be true`) before changing the template, then green after the template fix is applied and the example/e2e clients are regenerated.
- [x] `go test ./...` clean.
- [x] `e2e/` non-SSE suite: 62/62 passing including the new test (the 9 SSE failures reproduce on a clean stash of `master`, so they are pre-existing and unrelated).
- [x] `tsc --noEmit` clean on `example/react/client`.
- [x] `gofmt -l .` clean and ESLint clean on the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)