### PR TITLE
Add structured ConnectionError with reason classification

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -1,99 +1,321 @@
 # aprot AI Guide
 
-A high-performance Go library for type-safe real-time APIs with automatic TypeScript/React client generation.
+A high-performance Go library for type-safe real-time APIs with automatic TypeScript/React client generation. WebSocket and SSE+HTTP transports; optional REST/OpenAPI on top.
+
+This guide is a fast-reference for agents. The authoritative overview is `doc.go` (pkg.go.dev landing page).
 
 ## Core Concepts
 
-- **Registry**: Central place to register handlers, enums, and push events.
-- **Handlers**: Go struct methods that become TypeScript functions.
-- **Transports**: Supports both WebSocket (`/ws`) and SSE+HTTP (`/sse`).
-- **Middleware**: Interceptors for auth, logging, etc. (Server-level or Handler-level).
-- **Tasks**: Hierarchical progress reporting and output streaming (Request-scoped or Shared).
-- **Cancel Causes**: Inspect why a request was canceled (`ErrClientCanceled`, `ErrConnectionClosed`, `ErrServerShutdown`).
-- **Naming Plugins**: Customize generated TypeScript naming conventions.
+- **Registry** — collects handler groups, push events, enums, custom errors, and a validator.
+- **Handlers** — methods on a struct; one TypeScript file per group.
+- **Transports** — WebSocket (`/ws`), SSE+HTTP (`/sse`), and optional REST (`NewRESTAdapter`).
+- **Middleware** — `func(next) Handler` wrappers; server-level or per-handler-group.
+- **Tasks** — hierarchical progress and output streaming (request-scoped or shared).
+- **Subscription Refresh** — query handlers register trigger keys; mutations fire them to push fresh results.
+- **Streaming** — handlers can return `iter.Seq[T]` / `iter.Seq2[K,V]`; clients consume as `AsyncIterable`.
+- **Validation & Transforms** — `validate:"…"` and `transform:"…"` struct tags applied before dispatch.
+- **REST + OpenAPI + Zod** — same handlers, additional surfaces opted in per registry/handler.
 
 ## Implementation Checklist
 
 ### 1. Define API (Go)
-- Handlers MUST be methods on a struct.
-- Signature: `func (h *T) Method(ctx context.Context, [params]) ([res], error)`.
-- Use `context.Context` as the first parameter.
+- Handler methods on a struct: `func (h *T) Method(ctx context.Context, [params]) ([res], error)`.
+- Parameters are positional — each Go param becomes a separate TS argument; names come from AST.
+- Return shapes supported: `error` (void), `(T, error)`, `(iter.Seq[T], error)`, `(iter.Seq2[K,V], error)`.
 - Register with `registry.Register(handlers, [middleware...])`.
 
-### 2. TypeScript Generation
-- Create a generator script using `aprot.NewGenerator(registry)`.
-- Set `OutputDir` and `Mode` (`aprot.OutputReact` or `aprot.OutputVanilla`).
-- Run via `go run` or `go generate`.
+### 2. Server Setup
+```go
+server := aprot.NewServer(registry)
+http.Handle("/ws", server)                   // WebSocket
+http.Handle("/sse", server.HTTPTransport())  // SSE+HTTP
+http.Handle("/sse/", server.HTTPTransport())
+http.Handle("/api/", aprot.NewRESTAdapter(registry)) // optional REST
+```
 
-### 3. Server Setup
-- `server := aprot.NewServer(registry)`.
-- Mount WebSocket: `http.Handle("/ws", server)`.
-- Mount SSE: `http.Handle("/sse", server.HTTPTransport())`.
+### 3. TypeScript Generation
+```go
+gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
+    OutputDir: "./client/src/api",
+    Mode:      aprot.OutputReact,   // or aprot.OutputVanilla
+    Naming:    aprot.DefaultNaming{FixAcronyms: true},
+    Zod:       true,                // emit *.schema.ts mirrors of validate tags
+})
+gen.Generate()
+```
 
 ### 4. Progress & Tasks
-- **Simple**: `aprot.Progress(ctx).Update(current, total, message)`.
-- **Advanced**: Use `tasks.SubTask(ctx, title, fn)` for nested progress.
-- **Shared**: `tasks.StartSharedTask[Meta](ctx, title)` for server-wide jobs.
-- **Enable**: Call `tasks.Enable(registry)` to use the task system.
+- Simple: `aprot.Progress(ctx).Update(current, total, message)`.
+- Hierarchical: `tasks.SubTask(ctx, title, fn)`.
+- Server-wide: `tasks.StartSharedTask[Meta](ctx, title)`.
+- Enable: `tasks.Enable(registry)` before generation/serving.
 
-## Common Snippets
+## Handlers
 
-### Middleware
+### Signatures
+```go
+func (h *H) CreateUser(ctx context.Context, req *CreateUserRequest) (*User, error)
+func (h *H) DeleteUser(ctx context.Context, id string) error                      // void
+func (h *H) ListUsers(ctx context.Context) ([]User, error)                        // no params
+func (h *H) Add(ctx context.Context, a int, b int) (*SumResult, error)            // arbitrary params
+```
+
+### Streaming (`iter.Seq` → `AsyncIterable`)
+```go
+func (h *H) ListUsers(ctx context.Context) (iter.Seq[*User], error) {
+    return func(yield func(*User) bool) {
+        for cursor.Next(ctx) {
+            var u User
+            cursor.Scan(&u)
+            if !yield(&u) { return } // client canceled
+        }
+    }, nil
+}
+```
+Streaming handlers cannot be exposed via REST (panics at registration). For SSE/WS only. To observe real stream end from middleware, use `aprot.OnStreamComplete(ctx, fn)` — it fires once with `(err, items)`.
+
+## Input Transformation
+
+`transform:"…"` ops run after JSON decoding, before validation. Statically checked at `Register` time.
+
+```go
+type SignupRequest struct {
+    Email    string   `json:"email"    transform:"trim,lowercase" validate:"required,email"`
+    Username string   `json:"username" transform:"trim"            validate:"required,min=3"`
+    Slug     string   `json:"slug"     transform:"trimleft=/,lowercase"`
+    Tags     []string `json:"tags"     transform:"trim,removeempty"`
+}
+```
+
+Ops: `trim`, `trimleft[=cutset]`, `trimright[=cutset]`, `uppercase`, `lowercase`, `removeempty` (`[]string` only). Applies to `string`, `*string`, `[]string`, and recurses into nested structs/slices.
+
+## Request Validation
+
+Opt in per registry. Failures surface as `CodeValidationFailed` with structured `[]FieldError` payload — TS client exposes via `ApiError`.
+
+```go
+type CreateUserRequest struct {
+    Name  string `json:"name"  validate:"required,min=2,max=100"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age"   validate:"gte=13,lte=120"`
+}
+
+registry.Register(&Handlers{})
+registry.SetValidator(aprot.NewPlaygroundValidator())
+```
+
+`Zod: true` in `GeneratorOptions` mirrors these rules into a `*.schema.ts` file per group.
+
+## Middleware
+
 ```go
 func MyMiddleware() aprot.Middleware {
     return func(next aprot.Handler) aprot.Handler {
         return func(ctx context.Context, req *aprot.Request) (any, error) {
-            // Pre-process (e.g., auth check)
             res, err := next(ctx, req)
-            // Post-process
             return res, err
         }
     }
 }
+
+server.Use(MyMiddleware())                          // all handlers
+registry.Register(&AdminHandlers{}, AuthMiddleware()) // group-only
 ```
 
-### Accessing Connection/User
+For streaming handlers, `next()` returns as soon as the iterator is constructed — register a completion callback for real end-of-stream observability:
+
 ```go
-conn := aprot.Connection(ctx)
-userID := conn.UserID() // Set via conn.SetUserID("id") in auth middleware
+aprot.OnStreamComplete(ctx, func(err error, items int) {
+    log.Printf("stream done: items=%d err=%v", items, err)
+})
 ```
 
-### TypeScript Usage (React)
-Per-handler hooks are generated wrapping the generic `useQuery`/`useMutation`/`usePushEvent` hooks:
+`OnStreamComplete` is a no-op on unary contexts, so the same middleware works for both kinds.
+
+## Connection Lifecycle
+
+```go
+server.OnConnect(func(ctx context.Context, conn *aprot.Conn) error {
+    session, err := validateSession(conn.Info().Cookies)
+    if err != nil {
+        return aprot.ErrConnectionRejected("invalid session")
+    }
+    conn.SetUserID(session.UserID)
+    conn.Set(principalKey{}, session.User)
+    return nil
+})
+```
+
+`Conn` exposes:
+- `Info()` — HTTP request snapshot at connection time.
+- `Set(key, val)` / `Get(key)` / `Load(key)` — per-connection state.
+- `SetUserID(id)` / `UserID()` — push routing identity (not a security boundary; use stored principal for authz).
+
+Inside handlers: `conn := aprot.Connection(ctx)`.
+
+## Push Events
+
+```go
+registry.RegisterPushEventFor(&PublicHandlers{}, UserCreatedEvent{})
+server.Broadcast(&UserCreatedEvent{ID: "1"})
+server.PushToUser("user_123", &NotificationEvent{Message: "hello"})
+```
+
+Event name on the wire is the Go type name. Subscribed via the generated per-event hook (React) or `subscribe`/`onUserCreated` standalone (vanilla).
+
+## Subscription Refresh
+
+Push fresh query results to subscribed clients when related data changes.
+
+```go
+// Query handler — declare the trigger keys this query depends on.
+func (h *H) ListUsers(ctx context.Context) ([]User, error) {
+    aprot.RegisterRefreshTrigger(ctx, "users")
+    return h.db.ListUsers(ctx)
+}
+
+// Mutation handler — fire keys to refresh subscribed clients.
+func (h *H) CreateUser(ctx context.Context, req *CreateReq) (*User, error) {
+    user, err := h.db.CreateUser(ctx, req)
+    if err != nil { return nil, err }
+    aprot.TriggerRefresh(ctx, "users")
+    return user, nil
+}
+```
+
+- `TriggerRefresh` batches and dedupes within a request.
+- `TriggerRefreshNow` flushes immediately (use in long-running handlers between observable state transitions).
+- `Server.TriggerRefresh(keys...)` for background goroutines / cron / webhooks — flushes immediately, no request context required.
+- `RegisterRefreshTrigger` is a no-op outside subscribe; package-level `TriggerRefresh` is a no-op outside a request context.
+
+## REST + OpenAPI
+
+```go
+registry.Register(&UserHandlers{})       // WebSocket only
+registry.RegisterREST(&TodoHandlers{})   // REST only
+registry.Register(&BothHandlers{})       // WebSocket...
+registry.EnableREST(&BothHandlers{})     //   ...and also REST
+
+http.Handle("/api/", aprot.NewRESTAdapter(registry))
+
+oag := aprot.NewOpenAPIGenerator(registry, "My API", "1.0.0")
+spec, _ := oag.Generate()                // or oag.GenerateJSON()
+```
+
+HTTP method/path derive from method name (e.g. `CreateUser` → `POST /users/create-user`). Streaming handlers cannot be REST-exposed (panic at registration). Doc comments on handlers/structs/fields flow into OpenAPI `summary`/`description`/JSON Schema.
+
+## Error Handling
+
+### Server-side
+```go
+return aprot.ErrUnauthorized("invalid token")     // -32001
+return aprot.ErrForbidden("access denied")        // -32003
+return aprot.ErrInvalidParams("name required")    // -32602
+return aprot.ErrInternal(err)                     // -32603
+
+registry.RegisterError(sql.ErrNoRows, "NotFound") // → ApiError.isNotFound() in TS
+```
+
+### Client-side: `ApiError` vs `ConnectionError`
+Two distinct error types on the generated TS client:
+
+- **`ApiError`** — structured server-side error response. Has `.code`, `.message`, optional `.data`. Helpers: `err.isNotFound()`, `err.isUnauthorized()`, etc. Validation failures arrive here with `CodeValidationFailed` and `data: FieldError[]`.
+- **`ConnectionError extends Error`** — connection-level failure. Has `.reason` for switching on user-facing UI:
+
+  | reason            | meaning                                                                      |
+  | ----------------- | ---------------------------------------------------------------------------- |
+  | `offline`         | `navigator.onLine` was false at failure time                                 |
+  | `server-rejected` | server sent `ApiError` with code `ConnectionRejected`; original on `.cause`  |
+  | `server-closed`   | clean post-upgrade close; `.closeCode` and `.closeReason` carry CloseEvent   |
+  | `network-error`   | pre-upgrade failure or close code 1006 (refused/unreachable/TLS/HTTP error)  |
+  | `manual`          | caller invoked `client.disconnect()`                                         |
+
+In-flight requests reject with a `ConnectionError` when the connection drops; calls issued while disconnected reject with the most recent one. Use:
+```ts
+client.onConnectionError(err => showBanner(err.reason));
+const last = client.getLastConnectionError(); // or null
+```
+The `'server-rejected'` bucket is also surfaced via the older `onConnectionRejected` `ApiClientOption` callback (kept for backward compatibility).
+
+## TypeScript Hooks (React Output)
+
+Per-handler hooks wrap the generic primitives:
+
 ```tsx
-import { useListUsers, useCreateUserMutation, useUserCreatedEvent } from './api/handlers';
+import {
+  useListUsers, useGetUser, useCreateUserMutation,
+  useUserCreatedEvent, useStreamNumbers,
+} from './api/handlers';
 
-// Auto-fetching query hook (no params)
-const { data, isLoading, refetch } = useListUsers();
-
-// Auto-fetching query hook (with params — re-fetches when params change)
-const { data: user } = useGetUser(userId);
-
-// Imperative mutation hook
-const { mutate, isLoading } = useCreateUserMutation();
+const { data, isLoading, error, refetch, cancel } = useListUsers();
+const { data: user } = useGetUser(userId);                          // re-fetches when userId changes
+const { mutate, isLoading, cancel } = useCreateUserMutation();
 mutate('Alice', 'alice@example.com');
 
-// Server push event hook
+const { items, done, error, isLoading, restart, cancel } = useStreamNumbers(10, 100);
+
 const { lastEvent, events, clear } = useUserCreatedEvent();
 ```
 
-The generic hooks can also be used directly:
+### React 19 Suspense — `useQuerySuspense`
+Single generic hook; works with any generated query function. Opens a subscription, suspends until first response, swaps the promise on each push (no re-suspending).
 ```tsx
-import { useQuery, useMutation, usePushEvent } from './api/client';
-import { listUsers, createUser, onUserCreated } from './api/handlers';
+import { Suspense } from 'react';
+import { useQuerySuspense } from './api/client';
+import { listUsers, getUser } from './api/handlers';
+
+function UsersList() {
+  const data = useQuerySuspense(listUsers);   // no params
+  return data.users.map(u => <li key={u.id}>{u.name}</li>);
+}
+
+function UserView({ id }: { id: string }) {
+  const user = useQuerySuspense(getUser, id); // typed params
+  return <h1>{user.name}</h1>;
+}
+```
+Errors propagate to the nearest error boundary. Mutations and streams stay on `useMutation` / `useStream`.
+
+### Connection / loading hooks
+```tsx
+import { useConnection, useIsLoading } from './api/client';
+
+const { isConnected, state } = useConnection(); // 'connecting' | 'connected' | 'reconnecting' | 'disconnected'
+const isLoading = useIsLoading();               // any in-flight request anywhere
 ```
 
-## Cancel Cause Reporting
-Handlers can inspect why a request was canceled:
+### Generic primitives
+```tsx
+import { useQuery, useMutation, useStream, usePushEvent } from './api/client';
+```
+
+## Vanilla Output
+
+Per-handler standalone functions plus `subscribe`/`unsubscribe` helpers for live data:
+
+```ts
+import { listUsers, subscribeListUsers, onUserCreated } from './api/handlers';
+
+const users = await listUsers(client);
+const unsub = subscribeListUsers(client, (next) => render(next));
+const off = onUserCreated(client, (evt) => append(evt));
+```
+
+## Cancel Causes
+
+Inside a handler:
 ```go
 cause := aprot.CancelCause(ctx)
-if errors.Is(cause, aprot.ErrClientCanceled) { /* client called AbortController.abort() */ }
-if errors.Is(cause, aprot.ErrConnectionClosed) { /* client disconnected */ }
-if errors.Is(cause, aprot.ErrServerShutdown) { /* server is shutting down */ }
+switch {
+case errors.Is(cause, aprot.ErrClientCanceled):    // AbortController.abort() / unmount
+case errors.Is(cause, aprot.ErrConnectionClosed):  // client disconnected
+case errors.Is(cause, aprot.ErrServerShutdown):    // server.Stop in progress
+}
 ```
 
 ## SQL Nullable Types
-`database/sql` nullable types are automatically mapped in TypeScript generation:
+
+Auto-mapped in TS generation and unwrapped at runtime:
 - `sql.NullString` → `string | null`
 - `sql.NullInt64`, `NullInt32`, `NullInt16` → `number | null`
 - `sql.NullBool` → `boolean | null`
@@ -101,8 +323,11 @@ if errors.Is(cause, aprot.ErrServerShutdown) { /* server is shutting down */ }
 - `sql.NullTime` → `string | null`
 - `sql.Null[T]` (generic) → `T | null`
 
-## Naming Convention Plugins
-Configure how generated TypeScript names are formatted via `NamingPlugin`:
+Zod schemas mirror these as `T.nullable()`.
+
+## Naming Plugins
+
+Configure how generated TS names are formatted:
 ```go
 gen.WithOptions(aprot.GeneratorOptions{
     OutputDir: "./client/api",
@@ -110,11 +335,12 @@ gen.WithOptions(aprot.GeneratorOptions{
     Naming:    aprot.DefaultNaming{FixAcronyms: true},
 })
 ```
-Built-in plugins:
-- **`DefaultNaming`** — kebab-case files, camelCase methods (default). `FixAcronyms: true` keeps acronyms together (e.g., `BulkXML` → `bulk-xml`).
-- **`PreserveNaming`** — keeps Go PascalCase names in TypeScript.
 
-Implement `NamingPlugin` for custom conventions:
+Built-in:
+- `DefaultNaming{FixAcronyms: bool}` — kebab-case files, camelCase methods. `FixAcronyms` keeps acronym runs together (`BulkXML` → `bulk-xml`).
+- `PreserveNaming` — keeps Go PascalCase names in TS.
+
+Custom:
 ```go
 type NamingPlugin interface {
     FileName(groupName string) string
@@ -125,7 +351,28 @@ type NamingPlugin interface {
 }
 ```
 
-## Error Handling
-- Register Go errors: `registry.RegisterError(sql.ErrNoRows, "NotFound")`.
-- Built-in: `aprot.ErrUnauthorized("msg")`, `aprot.ErrInvalidParams("msg")`.
-- Client: `err instanceof ApiError`, `err.isNotFound()`.
+## Graceful Shutdown
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+server.Stop(ctx) // rejects new connections, waits for in-flight, runs OnDisconnect
+```
+
+Safe to call multiple times. In-flight handler contexts are canceled with `ErrServerShutdown`.
+
+## Enums
+
+```go
+type Status string
+const (
+    StatusActive  Status = "active"
+    StatusExpired Status = "expired"
+)
+func StatusValues() []Status { return []Status{StatusActive, StatusExpired} }
+
+registry.RegisterEnumFor(&Handlers{}, StatusValues())
+// or: registry.RegisterEnum(StatusValues()) for a shared enum
+```
+
+Struct fields with enum types generate as the TS union (not raw `string`/`number`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,4 @@ cd example/react/client && npm run dev
 - **Always update PRs and issues** when pushing changes — keep descriptions current.
 - **Always update `README.md`** when adding or changing user-facing features.
 - **Always update `doc.go`** when adding or changing user-facing features. `doc.go` is the package-level overview that renders on pkg.go.dev as the aprot landing page — new public APIs, struct tags, and behavioral rules belong alongside the existing section headers (Handlers, Registry, Middleware, …). Public funcs and types also need their own doc comments, but a reader who lands on the overview should be able to discover the feature without browsing the function index.
+- **Always update `APROT_AI.md`** when adding or changing user-facing features. It is the fast-reference guide for AI agents working in this repo — new APIs, hooks, struct tags, and patterns should land there alongside `README.md` and `doc.go` updates so agents don't act on stale snippets.

--- a/README.md
+++ b/README.md
@@ -560,6 +560,52 @@ A few validate-tag semantics worth knowing when designing your request structs:
 - **`url` and `email` are absolute-only** because that's how `go-playground/validator` defines them upstream. `validate:"url"` rejects app-internal paths like `/images/123/mobile`, and `email` is strict about the formats it accepts. Not an aprot choice — just a footgun to know about so you don't fight it for half an hour. If you need relative URLs, fall back to `validate:"max=500"` or a custom validator.
 - **Slice and map element types are substituted into parent schemas.** A field of type `[]EventLink` whose element struct has its own `validate` tags becomes `Links: z.array(EventLinkSchema)` in the parent — not `z.array(z.any())`. Combined with `validate:"dive"` on the parent slice, this means the same `dive` tag drives both server-side element validation (via `go-playground/validator`) and client-side element validation (via the substituted Zod schema). Primitive elements (`[]string`, `[]int`, `map[string]bool`) get a typed `z.array(z.string())` / `z.record(z.string(), z.boolean())` etc. Slices of slices, slices of maps, and anonymous-struct elements still fall through to `z.any()`.
 
+## Connection Errors
+
+Connection-level failures surface as a structured `ConnectionError` (separate from `ApiError`, which represents a structured server-side error response). It extends `Error`, so existing `instanceof Error` catches keep working — switch on `err.reason` to render appropriate UI:
+
+```typescript
+import { ConnectionError } from './api/client';
+
+try {
+    await addTodo(client, { title: 'Buy milk' });
+} catch (err) {
+    if (err instanceof ConnectionError) {
+        switch (err.reason) {
+            case 'offline':         return showBanner('You appear to be offline.');
+            case 'server-rejected': return showError('Session expired. Please sign in.');
+            case 'server-closed':   return showError(`Server closed: ${err.closeReason ?? err.closeCode}`);
+            case 'network-error':   return showError('Connection failed. Retrying…');
+            case 'manual':          return; // we initiated the disconnect
+        }
+    }
+    throw err;
+}
+```
+
+Reasons:
+
+| Reason | When |
+|---|---|
+| `offline` | `navigator.onLine` was `false` at failure time. |
+| `server-rejected` | The server sent an `ApiError` with code `ConnectionRejected` (e.g. invalid session) before closing. The original `ApiError` is attached as `err.cause`. |
+| `server-closed` | Transport closed cleanly after the WebSocket upgrade completed. `err.closeCode` and `err.closeReason` carry the WebSocket `CloseEvent` fields. |
+| `network-error` | Pre-upgrade failure or close code 1006 — refused, unreachable, TLS, or HTTP error during the WebSocket upgrade. Browsers deliberately collapse these into one bucket; finer classification is not achievable from JS. |
+| `manual` | The caller invoked `client.disconnect()`. |
+
+The same `ConnectionError` instance is delivered to:
+
+- **In-flight `request` / `requestStream` calls** — pending promises reject with it when the connection drops.
+- **`request()` issued while disconnected** — rejects synchronously with the most recent `ConnectionError`, falling back to `'offline'` (when `navigator.onLine === false`) or `'manual'`.
+- **`onConnectionError(listener)`** — register a listener to drive UI like an "Offline" banner. Multiple listeners supported; returns an unsubscribe function. `getLastConnectionError()` returns the most recently observed error or `null`.
+
+```typescript
+const off = client.onConnectionError((err) => {
+    if (err.isOffline()) showOfflineBanner();
+    else hideOfflineBanner();
+});
+```
+
 ## REST Adapter
 
 Serve your handlers as REST/HTTP endpoints alongside WebSocket. Use `RegisterREST` for REST-only handlers, or `EnableREST` to expose a WebSocket handler via REST as well:

--- a/doc.go
+++ b/doc.go
@@ -321,6 +321,36 @@
 //	registry.RegisterError(sql.ErrNoRows, "NotFound")
 //	// In TypeScript: err.isNotFound(), ErrorCode.NotFound
 //
+// # Connection Errors (TypeScript Client)
+//
+// Connection-level failures surface as a structured ConnectionError on the
+// generated TypeScript client — separate from ApiError, which represents a
+// structured server-side error response. ConnectionError extends Error and
+// exposes a typed `reason` field so apps can render appropriate UI:
+//
+//	'offline'         — navigator.onLine was false at failure time.
+//	'server-rejected' — server sent ApiError with code ConnectionRejected
+//	                    before closing; the original ApiError is attached as
+//	                    err.cause.
+//	'server-closed'   — transport closed cleanly after the WebSocket upgrade
+//	                    completed; err.closeCode and err.closeReason carry
+//	                    the WebSocket CloseEvent fields.
+//	'network-error'   — pre-upgrade failure or close code 1006 (refused,
+//	                    unreachable, TLS, HTTP error during upgrade).
+//	                    Browsers deliberately collapse these into one bucket.
+//	'manual'          — caller invoked client.disconnect().
+//
+// In-flight request and requestStream calls reject with a ConnectionError
+// when the connection drops. Calls issued while disconnected reject with the
+// most recent ConnectionError, falling back to 'offline' or 'manual' when
+// none is available. Use client.onConnectionError(listener) to drive UI like
+// an "Offline" banner; client.getLastConnectionError() returns the most
+// recently observed error or null.
+//
+// The 'server-rejected' bucket is also surfaced via the existing
+// onConnectionRejected ApiClientOption callback — both fire for the same
+// underlying event, kept for backward compatibility.
+//
 // # Enum Support
 //
 // Register Go enum types with [Registry.RegisterEnumFor] or

--- a/e2e/tests/connection-error.test.ts
+++ b/e2e/tests/connection-error.test.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect } from 'vitest';
+import { wsUrl, wsRejectUrl } from './helpers';
+import {
+    ApiClient,
+    ApiError,
+    ConnectionError,
+    ErrorCode,
+    type ConnectionErrorReason,
+} from '../api/client';
+
+// These tests exercise the structured ConnectionError API end-to-end. The
+// reason classification is the user-visible payoff — apps need to switch on
+// 'offline' / 'server-rejected' / 'server-closed' / 'network-error' /
+// 'manual' to render appropriate messaging.
+
+describe('ConnectionError', () => {
+    test('extends Error so legacy `instanceof Error` catches still match', () => {
+        const err = new ConnectionError('manual', 'test');
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(ConnectionError);
+        expect(err.name).toBe('ConnectionError');
+    });
+
+    test('exposes reason + helper predicates for every reason', () => {
+        const reasons: ConnectionErrorReason[] = [
+            'offline',
+            'server-rejected',
+            'server-closed',
+            'network-error',
+            'manual',
+        ];
+        for (const r of reasons) {
+            const err = new ConnectionError(r, 'm');
+            expect(err.reason).toBe(r);
+            expect(err.isOffline()).toBe(r === 'offline');
+            expect(err.isServerRejected()).toBe(r === 'server-rejected');
+            expect(err.isServerClosed()).toBe(r === 'server-closed');
+            expect(err.isNetworkError()).toBe(r === 'network-error');
+            expect(err.isManual()).toBe(r === 'manual');
+        }
+    });
+
+    test('server-rejected: pending request rejects with ConnectionError carrying ApiError as cause', async () => {
+        const client = new ApiClient(wsRejectUrl(), {
+            reconnect: false,
+        });
+
+        const errors: ConnectionError[] = [];
+        client.onConnectionError((err) => errors.push(err));
+
+        await client.connect();
+
+        // Wait for the server to send the ConnectionRejected ApiError and tear
+        // the socket down. 500ms matches the existing connection-rejected.test.ts
+        // pacing.
+        await new Promise((r) => setTimeout(r, 500));
+
+        expect(client.getState()).toBe('disconnected');
+        expect(errors.length).toBeGreaterThanOrEqual(1);
+
+        const last = client.getLastConnectionError();
+        expect(last).toBeInstanceOf(ConnectionError);
+        expect(last!.reason).toBe('server-rejected');
+        expect(last!.isServerRejected()).toBe(true);
+        // cause is the underlying ApiError so apps can inspect err.cause.code
+        // without re-running the rejection callback.
+        expect(last!.cause).toBeInstanceOf(ApiError);
+        expect((last!.cause as ApiError).code).toBe(ErrorCode.ConnectionRejected);
+        expect((last!.cause as ApiError).message).toBe('invalid session');
+
+        client.disconnect();
+    });
+
+    test('manual: request after client.disconnect() rejects with reason "manual"', async () => {
+        const client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+        client.disconnect();
+
+        await expect(client.request('PublicHandlers.GetUser', ['x']))
+            .rejects
+            .toMatchObject({
+                name: 'ConnectionError',
+                reason: 'manual',
+            });
+    });
+
+    test('manual: in-flight request rejects with ConnectionError when caller calls disconnect()', async () => {
+        const client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+
+        // Fire a request, then immediately disconnect. The server has no
+        // chance to reply before the close lands, so the in-flight call
+        // surfaces handleClose's classified error.
+        const promise = client.request('PublicHandlers.GetUser', ['x']);
+        client.disconnect();
+
+        const err: unknown = await promise.catch((e: unknown) => e);
+        expect(err).toBeInstanceOf(ConnectionError);
+        expect((err as ConnectionError).reason).toBe('manual');
+    });
+
+    test('onConnectionError fires with classified error on close', async () => {
+        const client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+
+        const captured: ConnectionError[] = [];
+        const off = client.onConnectionError((err) => captured.push(err));
+
+        // Force a close via transport.disconnect() so manualDisconnect stays
+        // false and we exercise the post-upgrade clean-close path. The
+        // server-side ws close lands as either code 1000-1015 ('server-closed')
+        // or code 1006 ('network-error') depending on the exact close
+        // sequence the runtime produces — both are valid, non-manual reasons.
+        const transport = (client as unknown as {
+            transport: { disconnect: () => void };
+        }).transport;
+        transport.disconnect();
+
+        // Wait for the close event to propagate.
+        await new Promise((r) => setTimeout(r, 200));
+
+        expect(captured.length).toBeGreaterThanOrEqual(1);
+        const err = captured[captured.length - 1];
+        expect(err).toBeInstanceOf(ConnectionError);
+        expect(err.reason).not.toBe('manual');
+
+        off();
+        client.disconnect();
+    });
+
+    test('offline: navigator.onLine === false drives the offline classification', async () => {
+        // Stub navigator.onLine for this test. The Node test environment
+        // includes a polyfilled navigator via undici; if it isn't writable
+        // we skip the assertion that depends on the stub rather than fail
+        // spuriously.
+        const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+        const writable = (() => {
+            try {
+                Object.defineProperty(globalThis, 'navigator', {
+                    value: { onLine: false },
+                    configurable: true,
+                });
+                return true;
+            } catch {
+                return false;
+            }
+        })();
+
+        try {
+            const client = new ApiClient(wsUrl(), { reconnect: false });
+            // Don't even try to connect — request() consults navigator.onLine
+            // when building the immediate-reject error.
+            const err: unknown = await client.request('PublicHandlers.GetUser', ['x']).catch((e: unknown) => e);
+            expect(err).toBeInstanceOf(ConnectionError);
+            if (writable) {
+                const ce = err as ConnectionError;
+                expect(ce.reason).toBe('offline');
+                expect(ce.isOffline()).toBe(true);
+            }
+            client.disconnect();
+        } finally {
+            // Restore navigator to whatever the runtime had originally.
+            if (originalDescriptor) {
+                Object.defineProperty(globalThis, 'navigator', originalDescriptor);
+            } else {
+                delete (globalThis as unknown as { navigator?: unknown }).navigator;
+            }
+        }
+    });
+});

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -73,6 +73,68 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+// ConnectionErrorReason classifies why a connection failed or could not be
+// used. Browsers deliberately collapse most pre-WebSocket-upgrade failures
+// (DNS, TCP refused, TLS handshake, HTTP 4xx during upgrade) into close
+// code 1006 with no diagnostic text, so finer-grained classification is
+// not achievable from JS — these all surface as 'network-error'.
+//
+//   - 'offline':         navigator.onLine was false at failure time.
+//   - 'server-rejected': server sent an ApiError with code ConnectionRejected
+//                        (e.g. invalid session) before closing. The original
+//                        ApiError is attached via ConnectionError.cause.
+//   - 'server-closed':   transport closed cleanly after the WebSocket upgrade
+//                        completed; closeCode and closeReason are populated.
+//   - 'network-error':   pre-upgrade failure or close code 1006 — refused,
+//                        unreachable, TLS or upgrade-time HTTP error.
+//   - 'manual':          the caller invoked client.disconnect().
+export type ConnectionErrorReason =
+    | 'offline'
+    | 'server-rejected'
+    | 'server-closed'
+    | 'network-error'
+    | 'manual';
+
+// ConnectionErrorInit carries the optional diagnostic fields attached to a
+// ConnectionError. closeCode/closeReason mirror the WebSocket CloseEvent
+// fields when available; cause carries the underlying ApiError for
+// 'server-rejected' so callers can read err.cause.code / err.cause.data.
+export interface ConnectionErrorInit {
+    closeCode?: number;
+    closeReason?: string;
+    cause?: unknown;
+}
+
+// ConnectionError is thrown (or attached to a rejected promise) whenever a
+// request fails because the connection itself is unhealthy — distinct from
+// ApiError, which represents a structured server-side error response. It
+// extends Error so existing `catch (err) { ... }` blocks keep working; new
+// code can switch on err.reason for user-facing messaging.
+export class ConnectionError extends Error {
+    readonly reason: ConnectionErrorReason;
+    readonly closeCode?: number;
+    readonly closeReason?: string;
+    // cause is the underlying ApiError for 'server-rejected', if any.
+    // For other reasons it is undefined. Typed `unknown` to align with the
+    // ES2022 Error.cause convention without forcing a specific shape.
+    readonly cause?: unknown;
+
+    constructor(reason: ConnectionErrorReason, message: string, init?: ConnectionErrorInit) {
+        super(message);
+        this.name = 'ConnectionError';
+        this.reason = reason;
+        this.closeCode = init?.closeCode;
+        this.closeReason = init?.closeReason;
+        this.cause = init?.cause;
+    }
+
+    isOffline(): boolean { return this.reason === 'offline'; }
+    isServerRejected(): boolean { return this.reason === 'server-rejected'; }
+    isServerClosed(): boolean { return this.reason === 'server-closed'; }
+    isNetworkError(): boolean { return this.reason === 'network-error'; }
+    isManual(): boolean { return this.reason === 'manual'; }
+}
+
 
 
 export interface RequestOptions {
@@ -136,9 +198,26 @@ export function getSSEUrl(path: string = '/sse'): string {
 
 
 
+// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+// transport up to the client's classification logic. SSE has no equivalent
+// (the EventSource error event exposes nothing structured), so the SSE
+// transport synthesizes an empty info object — it lands as 'network-error'
+// after offline/manual checks, which is the most accurate bucket browsers
+// will let us name.
+interface TransportCloseInfo {
+    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
+    code?: number;
+    /** WebSocket CloseEvent.reason, when non-empty. */
+    reason?: string;
+    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
+    wasClean?: boolean;
+    /** True when the close was already classified as a server-rejected protocol error. */
+    serverRejected?: boolean;
+}
+
 // Internal transport interface
 interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void>;
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -147,7 +226,7 @@ interface ClientTransport {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve, reject) => {
             // Detach and close previous socket so its deferred onclose
             // cannot interfere with the new connection (mobile wake race).
@@ -163,10 +242,21 @@ class WebSocketTransport implements ClientTransport {
             this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
-            this.ws.onclose = () => {
+            this.ws.onclose = (event) => {
                 this.ws = null;
+                // Surface the structured CloseEvent so the ApiClient can
+                // distinguish a clean post-upgrade close (codes 1000-1015,
+                // 4xxx) from a pre-upgrade abnormal closure (1006). The
+                // browser deliberately hides upgrade-time HTTP status for
+                // fingerprinting reasons, so 1006 is as fine-grained as
+                // we get for refused/DNS/TLS/4xx-during-upgrade failures.
+                const info: TransportCloseInfo = {
+                    code: event.code,
+                    reason: event.reason || undefined,
+                    wasClean: event.wasClean,
+                };
                 if (!opened) reject(new Error('WebSocket closed before open'));
-                onClose();
+                onClose(info);
             };
         });
     }
@@ -197,7 +287,7 @@ class SSETransport implements ClientTransport {
     private baseUrl: string = '';
     private onMessage: ((data: string) => void) | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
         this.onMessage = onMessage;
 
@@ -222,11 +312,14 @@ class SSETransport implements ClientTransport {
                 if (e.data) {
                     onMessage(e.data);
                 } else {
-                    // EventSource connection error (no data = connectivity issue)
+                    // EventSource connection error (no data = connectivity issue).
+                    // EventSource exposes nothing structured here, so the
+                    // ApiClient classifier falls through to 'network-error'
+                    // after offline/manual checks.
                     this.eventSource?.close();
                     this.eventSource = null;
                     this.connectionId = null;
-                    onClose();
+                    onClose({ wasClean: false });
                 }
             });
 
@@ -350,11 +443,22 @@ export class ApiClient {
     private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private loadingListeners = new Set<(count: number) => void>();
+    private connectionErrorListeners = new Set<(error: ConnectionError) => void>();
     private lastLoadingCount = 0;
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private manualDisconnect = false;
+    // pendingRejection is set when the server sends a ConnectionRejected
+    // ApiError just before tearing down the transport. handleClose() reads
+    // it so the resulting ConnectionError carries reason 'server-rejected'
+    // (with the original ApiError as cause) rather than the default
+    // 'manual' reading triggered by transport.disconnect().
+    private pendingRejection: ApiError | null = null;
+    // lastConnectionError is the most recently observed ConnectionError,
+    // exposed via getLastConnectionError() so a UI can render an offline
+    // banner / "server unreachable" message after the fact.
+    private lastConnectionError: ConnectionError | null = null;
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
@@ -383,33 +487,109 @@ export class ApiClient {
         return this.transport.connect(
             url,
             (data) => this.handleMessage(data),
-            () => this.handleClose(),
+            (info) => this.handleClose(info),
         ).then(() => {
             this.reconnectAttempts = 0;
             this.setState('connected');
         }).catch(() => {
-            this.handleClose();
+            // The transport's promise rejected before opening — treat as a
+            // pre-upgrade close with no diagnostic info available.
+            this.handleClose({ wasClean: false });
         });
     }
 
-    private handleClose(): void {
+    // classifyClose decides why the transport closed. Order matters:
+    //   1. Server-rejected wins because the server explicitly told us why
+    //      (we keep the ApiError as `cause`).
+    //   2. Manual disconnect comes next — the caller initiated the close.
+    //   3. Offline overrides everything else; navigator.onLine being false
+    //      means even a clean close happened during a network outage and
+    //      "offline" is the more useful message.
+    //   4. A close code outside the abnormal range (1006) and 0 means the
+    //      WebSocket upgrade succeeded and the server closed cleanly.
+    //   5. Otherwise the failure happened before/at upgrade time and the
+    //      browser collapses every cause into an indistinguishable
+    //      'network-error'.
+    private classifyClose(info?: TransportCloseInfo): ConnectionErrorReason {
+        if (this.pendingRejection || info?.serverRejected) {
+            return 'server-rejected';
+        }
+        if (this.manualDisconnect) return 'manual';
+        if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+            return 'offline';
+        }
+        if (info?.code !== undefined && info.code !== 1006 && info.code !== 0) {
+            return 'server-closed';
+        }
+        return 'network-error';
+    }
+
+    private buildConnectionError(reason: ConnectionErrorReason, info?: TransportCloseInfo): ConnectionError {
+        let message: string;
+        const init: ConnectionErrorInit = {
+            closeCode: info?.code,
+            closeReason: info?.reason,
+        };
+        switch (reason) {
+            case 'offline':
+                message = 'Offline: no network connection';
+                break;
+            case 'server-rejected': {
+                const cause = this.pendingRejection;
+                init.cause = cause ?? undefined;
+                message = cause?.message
+                    ? `Server rejected connection: ${cause.message}`
+                    : 'Server rejected connection';
+                break;
+            }
+            case 'server-closed':
+                message = info?.reason
+                    ? `Server closed connection (code ${info.code}): ${info.reason}`
+                    : `Server closed connection (code ${info?.code ?? 'unknown'})`;
+                break;
+            case 'network-error':
+                message = 'Network error: connection lost';
+                break;
+            case 'manual':
+                message = 'Disconnected';
+                break;
+        }
+        return new ConnectionError(reason, message, init);
+    }
+
+    private notifyConnectionError(error: ConnectionError): void {
+        this.lastConnectionError = error;
+        for (const listener of this.connectionErrorListeners) {
+            listener(error);
+        }
+    }
+
+    private handleClose(info?: TransportCloseInfo): void {
+        const reason = this.classifyClose(info);
+        const error = this.buildConnectionError(reason, info);
+        // Consume the pending rejection: subsequent reconnect attempts
+        // (e.g. after the auth flow refreshes) must not be misclassified.
+        this.pendingRejection = null;
+
         // Reject all pending requests (but keep subscription entries for reconnect)
         const subIds = new Set(this.subscriptions.keys());
         for (const [id, p] of this.pending) {
             if (!subIds.has(id)) {
                 p.onSettle?.();
-                p.reject(new Error('Connection closed'));
+                p.reject(error);
             }
             this.pending.delete(id);
         }
-        // End all in-flight streams with a connection-closed error. Streams
-        // are not auto-resumed on reconnect; consumers must restart them.
+        // End all in-flight streams with the structured connection error.
+        // Streams are not auto-resumed on reconnect; consumers must restart
+        // them.
         const streams = Array.from(this.streams.values());
         this.streams.clear();
         for (const s of streams) {
-            s.end(new Error('Connection closed'));
+            s.end(error);
         }
         this.notifyLoadingChange();
+        this.notifyConnectionError(error);
 
         if (this.manualDisconnect) {
             this.setState('disconnected');
@@ -468,7 +648,14 @@ export class ApiClient {
             this.flushBuffer();
             this.resubscribeAll();
         } else if (state === 'disconnected') {
-            this.rejectBuffer(new Error('Not connected'));
+            // Reuse the most recent classified error if handleClose() just
+            // ran, so a request buffered during a reconnect attempt that
+            // ultimately fails is rejected with the same reason as the
+            // close itself (e.g. 'offline'). Falls back to 'manual' when
+            // there's no prior error — that branch is hit by an idle
+            // disconnect() with no in-flight close.
+            const err = this.lastConnectionError ?? new ConnectionError('manual', 'Not connected');
+            this.rejectBuffer(err);
         }
         for (const listener of this.stateListeners) {
             listener(state);
@@ -483,6 +670,30 @@ export class ApiClient {
     onLoadingChange(listener: (count: number) => void): () => void {
         this.loadingListeners.add(listener);
         return () => this.loadingListeners.delete(listener);
+    }
+
+    /**
+     * onConnectionError registers a listener that fires every time a
+     * connection-level failure is classified (transport close, server
+     * rejection, etc.). The listener receives a structured ConnectionError
+     * carrying the reason and any close-event diagnostics the browser
+     * exposed. Use this to drive UI like an "Offline" banner.
+     *
+     * Returns an unsubscribe function. Multiple listeners are supported.
+     */
+    onConnectionError(listener: (error: ConnectionError) => void): () => void {
+        this.connectionErrorListeners.add(listener);
+        return () => this.connectionErrorListeners.delete(listener);
+    }
+
+    /**
+     * getLastConnectionError returns the most recent ConnectionError, or
+     * null if no failure has been observed (or the connection has never
+     * dropped). Useful right after `getState() === 'disconnected'` or
+     * 'reconnecting' to decide what message to show the user.
+     */
+    getLastConnectionError(): ConnectionError | null {
+        return this.lastConnectionError;
     }
 
     getLoadingCount(): number {
@@ -593,8 +804,14 @@ export class ApiClient {
                     break;
                 }
                 if (msg.code === ErrorCode.ConnectionRejected) {
+                    const apiError = new ApiError(msg.code, msg.message, msg.data);
                     this.manualDisconnect = true;
-                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message, msg.data));
+                    // Stash the rejection so the imminent transport close
+                    // is classified as 'server-rejected' rather than the
+                    // default 'manual' that manualDisconnect=true would
+                    // otherwise produce. handleClose() consumes it.
+                    this.pendingRejection = apiError;
+                    this.options.onConnectionRejected?.(apiError);
                     this.transport.disconnect();
                 } else {
                     // Server-driven subscription refresh error
@@ -690,7 +907,21 @@ export class ApiClient {
                 }
                 return;
             }
-            reject(new Error('Not connected'));
+            // Disconnected and not reconnecting. Prefer the most recent
+            // ConnectionError (set by handleClose) so callers see the same
+            // reason that classified the transport drop. If we got here
+            // without a prior failure (e.g. caller never connected, or
+            // navigator.onLine flipped between connect and request), still
+            // surface a ConnectionError with the best reason we can name.
+            let err = this.lastConnectionError;
+            if (!err) {
+                if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+                    err = new ConnectionError('offline', 'Offline: no network connection');
+                } else {
+                    err = new ConnectionError('manual', 'Not connected');
+                }
+            }
+            reject(err);
         });
     }
 
@@ -865,7 +1096,12 @@ export class ApiClient {
                     if (started) return;
                     started = true;
                     if (!this.transport.isConnected()) {
-                        end(new Error('Not connected'));
+                        const err = this.lastConnectionError ?? (
+                            typeof navigator !== 'undefined' && navigator.onLine === false
+                                ? new ConnectionError('offline', 'Offline: no network connection')
+                                : new ConnectionError('manual', 'Not connected')
+                        );
+                        end(err);
                         return;
                     }
                     id = String(++this.requestId);

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -565,6 +565,14 @@ export class ApiClient {
     }
 
     private handleClose(info?: TransportCloseInfo): void {
+        // disconnect() rejects pending requests/streams synchronously and
+        // sets state to 'disconnected'. The transport's onclose still fires
+        // afterwards to confirm the close — short-circuit so we don't
+        // re-notify listeners or rebuild the error.
+        if (this.manualDisconnect && this.state === 'disconnected') {
+            this.pendingRejection = null;
+            return;
+        }
         const reason = this.classifyClose(info);
         const error = this.buildConnectionError(reason, info);
         // Consume the pending rejection: subsequent reconnect attempts
@@ -626,6 +634,7 @@ export class ApiClient {
     }
 
     disconnect(): void {
+        if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
         if (this.reconnectTimer) {
@@ -633,6 +642,26 @@ export class ApiClient {
             this.reconnectTimer = null;
         }
         this.subscriptions.clear();
+
+        // Reject in-flight requests/streams synchronously: the server may
+        // still respond between transport.disconnect() and the close event
+        // landing, racing the rejection in handleClose() and resolving the
+        // promise instead. Doing it here means the caller's "I'm done"
+        // semantics win over a late server reply.
+        const error = this.buildConnectionError('manual', undefined);
+        for (const [, p] of this.pending) {
+            p.onSettle?.();
+            p.reject(error);
+        }
+        this.pending.clear();
+        const streams = Array.from(this.streams.values());
+        this.streams.clear();
+        for (const s of streams) {
+            s.end(error);
+        }
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+
         this.transport.disconnect();
         this.setState('disconnected');
     }

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -558,6 +558,14 @@ export class ApiClient {
     }
 
     private handleClose(info?: TransportCloseInfo): void {
+        // disconnect() rejects pending requests/streams synchronously and
+        // sets state to 'disconnected'. The transport's onclose still fires
+        // afterwards to confirm the close — short-circuit so we don't
+        // re-notify listeners or rebuild the error.
+        if (this.manualDisconnect && this.state === 'disconnected') {
+            this.pendingRejection = null;
+            return;
+        }
         const reason = this.classifyClose(info);
         const error = this.buildConnectionError(reason, info);
         // Consume the pending rejection: subsequent reconnect attempts
@@ -619,6 +627,7 @@ export class ApiClient {
     }
 
     disconnect(): void {
+        if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
         if (this.reconnectTimer) {
@@ -626,6 +635,26 @@ export class ApiClient {
             this.reconnectTimer = null;
         }
         this.subscriptions.clear();
+
+        // Reject in-flight requests/streams synchronously: the server may
+        // still respond between transport.disconnect() and the close event
+        // landing, racing the rejection in handleClose() and resolving the
+        // promise instead. Doing it here means the caller's "I'm done"
+        // semantics win over a late server reply.
+        const error = this.buildConnectionError('manual', undefined);
+        for (const [, p] of this.pending) {
+            p.onSettle?.();
+            p.reject(error);
+        }
+        this.pending.clear();
+        const streams = Array.from(this.streams.values());
+        this.streams.clear();
+        for (const s of streams) {
+            s.end(error);
+        }
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+
         this.transport.disconnect();
         this.setState('disconnected');
     }

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -66,6 +66,68 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+// ConnectionErrorReason classifies why a connection failed or could not be
+// used. Browsers deliberately collapse most pre-WebSocket-upgrade failures
+// (DNS, TCP refused, TLS handshake, HTTP 4xx during upgrade) into close
+// code 1006 with no diagnostic text, so finer-grained classification is
+// not achievable from JS — these all surface as 'network-error'.
+//
+//   - 'offline':         navigator.onLine was false at failure time.
+//   - 'server-rejected': server sent an ApiError with code ConnectionRejected
+//                        (e.g. invalid session) before closing. The original
+//                        ApiError is attached via ConnectionError.cause.
+//   - 'server-closed':   transport closed cleanly after the WebSocket upgrade
+//                        completed; closeCode and closeReason are populated.
+//   - 'network-error':   pre-upgrade failure or close code 1006 — refused,
+//                        unreachable, TLS or upgrade-time HTTP error.
+//   - 'manual':          the caller invoked client.disconnect().
+export type ConnectionErrorReason =
+    | 'offline'
+    | 'server-rejected'
+    | 'server-closed'
+    | 'network-error'
+    | 'manual';
+
+// ConnectionErrorInit carries the optional diagnostic fields attached to a
+// ConnectionError. closeCode/closeReason mirror the WebSocket CloseEvent
+// fields when available; cause carries the underlying ApiError for
+// 'server-rejected' so callers can read err.cause.code / err.cause.data.
+export interface ConnectionErrorInit {
+    closeCode?: number;
+    closeReason?: string;
+    cause?: unknown;
+}
+
+// ConnectionError is thrown (or attached to a rejected promise) whenever a
+// request fails because the connection itself is unhealthy — distinct from
+// ApiError, which represents a structured server-side error response. It
+// extends Error so existing `catch (err) { ... }` blocks keep working; new
+// code can switch on err.reason for user-facing messaging.
+export class ConnectionError extends Error {
+    readonly reason: ConnectionErrorReason;
+    readonly closeCode?: number;
+    readonly closeReason?: string;
+    // cause is the underlying ApiError for 'server-rejected', if any.
+    // For other reasons it is undefined. Typed `unknown` to align with the
+    // ES2022 Error.cause convention without forcing a specific shape.
+    readonly cause?: unknown;
+
+    constructor(reason: ConnectionErrorReason, message: string, init?: ConnectionErrorInit) {
+        super(message);
+        this.name = 'ConnectionError';
+        this.reason = reason;
+        this.closeCode = init?.closeCode;
+        this.closeReason = init?.closeReason;
+        this.cause = init?.cause;
+    }
+
+    isOffline(): boolean { return this.reason === 'offline'; }
+    isServerRejected(): boolean { return this.reason === 'server-rejected'; }
+    isServerClosed(): boolean { return this.reason === 'server-closed'; }
+    isNetworkError(): boolean { return this.reason === 'network-error'; }
+    isManual(): boolean { return this.reason === 'manual'; }
+}
+
 
 
 export interface RequestOptions {
@@ -129,9 +191,26 @@ export function getSSEUrl(path: string = '/sse'): string {
 
 
 
+// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+// transport up to the client's classification logic. SSE has no equivalent
+// (the EventSource error event exposes nothing structured), so the SSE
+// transport synthesizes an empty info object — it lands as 'network-error'
+// after offline/manual checks, which is the most accurate bucket browsers
+// will let us name.
+interface TransportCloseInfo {
+    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
+    code?: number;
+    /** WebSocket CloseEvent.reason, when non-empty. */
+    reason?: string;
+    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
+    wasClean?: boolean;
+    /** True when the close was already classified as a server-rejected protocol error. */
+    serverRejected?: boolean;
+}
+
 // Internal transport interface
 interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void>;
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -140,7 +219,7 @@ interface ClientTransport {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve, reject) => {
             // Detach and close previous socket so its deferred onclose
             // cannot interfere with the new connection (mobile wake race).
@@ -156,10 +235,21 @@ class WebSocketTransport implements ClientTransport {
             this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
-            this.ws.onclose = () => {
+            this.ws.onclose = (event) => {
                 this.ws = null;
+                // Surface the structured CloseEvent so the ApiClient can
+                // distinguish a clean post-upgrade close (codes 1000-1015,
+                // 4xxx) from a pre-upgrade abnormal closure (1006). The
+                // browser deliberately hides upgrade-time HTTP status for
+                // fingerprinting reasons, so 1006 is as fine-grained as
+                // we get for refused/DNS/TLS/4xx-during-upgrade failures.
+                const info: TransportCloseInfo = {
+                    code: event.code,
+                    reason: event.reason || undefined,
+                    wasClean: event.wasClean,
+                };
                 if (!opened) reject(new Error('WebSocket closed before open'));
-                onClose();
+                onClose(info);
             };
         });
     }
@@ -190,7 +280,7 @@ class SSETransport implements ClientTransport {
     private baseUrl: string = '';
     private onMessage: ((data: string) => void) | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
         this.onMessage = onMessage;
 
@@ -215,11 +305,14 @@ class SSETransport implements ClientTransport {
                 if (e.data) {
                     onMessage(e.data);
                 } else {
-                    // EventSource connection error (no data = connectivity issue)
+                    // EventSource connection error (no data = connectivity issue).
+                    // EventSource exposes nothing structured here, so the
+                    // ApiClient classifier falls through to 'network-error'
+                    // after offline/manual checks.
                     this.eventSource?.close();
                     this.eventSource = null;
                     this.connectionId = null;
-                    onClose();
+                    onClose({ wasClean: false });
                 }
             });
 
@@ -343,11 +436,22 @@ export class ApiClient {
     private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private loadingListeners = new Set<(count: number) => void>();
+    private connectionErrorListeners = new Set<(error: ConnectionError) => void>();
     private lastLoadingCount = 0;
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private manualDisconnect = false;
+    // pendingRejection is set when the server sends a ConnectionRejected
+    // ApiError just before tearing down the transport. handleClose() reads
+    // it so the resulting ConnectionError carries reason 'server-rejected'
+    // (with the original ApiError as cause) rather than the default
+    // 'manual' reading triggered by transport.disconnect().
+    private pendingRejection: ApiError | null = null;
+    // lastConnectionError is the most recently observed ConnectionError,
+    // exposed via getLastConnectionError() so a UI can render an offline
+    // banner / "server unreachable" message after the fact.
+    private lastConnectionError: ConnectionError | null = null;
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
@@ -376,33 +480,109 @@ export class ApiClient {
         return this.transport.connect(
             url,
             (data) => this.handleMessage(data),
-            () => this.handleClose(),
+            (info) => this.handleClose(info),
         ).then(() => {
             this.reconnectAttempts = 0;
             this.setState('connected');
         }).catch(() => {
-            this.handleClose();
+            // The transport's promise rejected before opening — treat as a
+            // pre-upgrade close with no diagnostic info available.
+            this.handleClose({ wasClean: false });
         });
     }
 
-    private handleClose(): void {
+    // classifyClose decides why the transport closed. Order matters:
+    //   1. Server-rejected wins because the server explicitly told us why
+    //      (we keep the ApiError as `cause`).
+    //   2. Manual disconnect comes next — the caller initiated the close.
+    //   3. Offline overrides everything else; navigator.onLine being false
+    //      means even a clean close happened during a network outage and
+    //      "offline" is the more useful message.
+    //   4. A close code outside the abnormal range (1006) and 0 means the
+    //      WebSocket upgrade succeeded and the server closed cleanly.
+    //   5. Otherwise the failure happened before/at upgrade time and the
+    //      browser collapses every cause into an indistinguishable
+    //      'network-error'.
+    private classifyClose(info?: TransportCloseInfo): ConnectionErrorReason {
+        if (this.pendingRejection || info?.serverRejected) {
+            return 'server-rejected';
+        }
+        if (this.manualDisconnect) return 'manual';
+        if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+            return 'offline';
+        }
+        if (info?.code !== undefined && info.code !== 1006 && info.code !== 0) {
+            return 'server-closed';
+        }
+        return 'network-error';
+    }
+
+    private buildConnectionError(reason: ConnectionErrorReason, info?: TransportCloseInfo): ConnectionError {
+        let message: string;
+        const init: ConnectionErrorInit = {
+            closeCode: info?.code,
+            closeReason: info?.reason,
+        };
+        switch (reason) {
+            case 'offline':
+                message = 'Offline: no network connection';
+                break;
+            case 'server-rejected': {
+                const cause = this.pendingRejection;
+                init.cause = cause ?? undefined;
+                message = cause?.message
+                    ? `Server rejected connection: ${cause.message}`
+                    : 'Server rejected connection';
+                break;
+            }
+            case 'server-closed':
+                message = info?.reason
+                    ? `Server closed connection (code ${info.code}): ${info.reason}`
+                    : `Server closed connection (code ${info?.code ?? 'unknown'})`;
+                break;
+            case 'network-error':
+                message = 'Network error: connection lost';
+                break;
+            case 'manual':
+                message = 'Disconnected';
+                break;
+        }
+        return new ConnectionError(reason, message, init);
+    }
+
+    private notifyConnectionError(error: ConnectionError): void {
+        this.lastConnectionError = error;
+        for (const listener of this.connectionErrorListeners) {
+            listener(error);
+        }
+    }
+
+    private handleClose(info?: TransportCloseInfo): void {
+        const reason = this.classifyClose(info);
+        const error = this.buildConnectionError(reason, info);
+        // Consume the pending rejection: subsequent reconnect attempts
+        // (e.g. after the auth flow refreshes) must not be misclassified.
+        this.pendingRejection = null;
+
         // Reject all pending requests (but keep subscription entries for reconnect)
         const subIds = new Set(this.subscriptions.keys());
         for (const [id, p] of this.pending) {
             if (!subIds.has(id)) {
                 p.onSettle?.();
-                p.reject(new Error('Connection closed'));
+                p.reject(error);
             }
             this.pending.delete(id);
         }
-        // End all in-flight streams with a connection-closed error. Streams
-        // are not auto-resumed on reconnect; consumers must restart them.
+        // End all in-flight streams with the structured connection error.
+        // Streams are not auto-resumed on reconnect; consumers must restart
+        // them.
         const streams = Array.from(this.streams.values());
         this.streams.clear();
         for (const s of streams) {
-            s.end(new Error('Connection closed'));
+            s.end(error);
         }
         this.notifyLoadingChange();
+        this.notifyConnectionError(error);
 
         if (this.manualDisconnect) {
             this.setState('disconnected');
@@ -461,7 +641,14 @@ export class ApiClient {
             this.flushBuffer();
             this.resubscribeAll();
         } else if (state === 'disconnected') {
-            this.rejectBuffer(new Error('Not connected'));
+            // Reuse the most recent classified error if handleClose() just
+            // ran, so a request buffered during a reconnect attempt that
+            // ultimately fails is rejected with the same reason as the
+            // close itself (e.g. 'offline'). Falls back to 'manual' when
+            // there's no prior error — that branch is hit by an idle
+            // disconnect() with no in-flight close.
+            const err = this.lastConnectionError ?? new ConnectionError('manual', 'Not connected');
+            this.rejectBuffer(err);
         }
         for (const listener of this.stateListeners) {
             listener(state);
@@ -476,6 +663,30 @@ export class ApiClient {
     onLoadingChange(listener: (count: number) => void): () => void {
         this.loadingListeners.add(listener);
         return () => this.loadingListeners.delete(listener);
+    }
+
+    /**
+     * onConnectionError registers a listener that fires every time a
+     * connection-level failure is classified (transport close, server
+     * rejection, etc.). The listener receives a structured ConnectionError
+     * carrying the reason and any close-event diagnostics the browser
+     * exposed. Use this to drive UI like an "Offline" banner.
+     *
+     * Returns an unsubscribe function. Multiple listeners are supported.
+     */
+    onConnectionError(listener: (error: ConnectionError) => void): () => void {
+        this.connectionErrorListeners.add(listener);
+        return () => this.connectionErrorListeners.delete(listener);
+    }
+
+    /**
+     * getLastConnectionError returns the most recent ConnectionError, or
+     * null if no failure has been observed (or the connection has never
+     * dropped). Useful right after `getState() === 'disconnected'` or
+     * 'reconnecting' to decide what message to show the user.
+     */
+    getLastConnectionError(): ConnectionError | null {
+        return this.lastConnectionError;
     }
 
     getLoadingCount(): number {
@@ -586,8 +797,14 @@ export class ApiClient {
                     break;
                 }
                 if (msg.code === ErrorCode.ConnectionRejected) {
+                    const apiError = new ApiError(msg.code, msg.message, msg.data);
                     this.manualDisconnect = true;
-                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message, msg.data));
+                    // Stash the rejection so the imminent transport close
+                    // is classified as 'server-rejected' rather than the
+                    // default 'manual' that manualDisconnect=true would
+                    // otherwise produce. handleClose() consumes it.
+                    this.pendingRejection = apiError;
+                    this.options.onConnectionRejected?.(apiError);
                     this.transport.disconnect();
                 } else {
                     // Server-driven subscription refresh error
@@ -683,7 +900,21 @@ export class ApiClient {
                 }
                 return;
             }
-            reject(new Error('Not connected'));
+            // Disconnected and not reconnecting. Prefer the most recent
+            // ConnectionError (set by handleClose) so callers see the same
+            // reason that classified the transport drop. If we got here
+            // without a prior failure (e.g. caller never connected, or
+            // navigator.onLine flipped between connect and request), still
+            // surface a ConnectionError with the best reason we can name.
+            let err = this.lastConnectionError;
+            if (!err) {
+                if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+                    err = new ConnectionError('offline', 'Offline: no network connection');
+                } else {
+                    err = new ConnectionError('manual', 'Not connected');
+                }
+            }
+            reject(err);
         });
     }
 
@@ -858,7 +1089,12 @@ export class ApiClient {
                     if (started) return;
                     started = true;
                     if (!this.transport.isConnected()) {
-                        end(new Error('Not connected'));
+                        const err = this.lastConnectionError ?? (
+                            typeof navigator !== 'undefined' && navigator.onLine === false
+                                ? new ConnectionError('offline', 'Offline: no network connection')
+                                : new ConnectionError('manual', 'Not connected')
+                        );
+                        end(err);
                         return;
                     }
                     id = String(++this.requestId);

--- a/generate_test.go
+++ b/generate_test.go
@@ -3205,3 +3205,104 @@ func TestGenerateEnum_NonIdentifierKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerateConnectionError verifies that the generated TS client exposes a
+// structured ConnectionError + ConnectionErrorReason API so applications can
+// distinguish "no network", "server closed", "rejected by server" and
+// "manual disconnect" outcomes from each other. Browsers collapse most
+// network-level failures into WebSocket close code 1006 with no diagnostic
+// info, so the four-bucket classification is the most useful split that's
+// actually achievable from JS.
+//
+// Both single-file (GenerateTo) and multi-file (Generate) clients must carry
+// the new API.
+func TestGenerateConnectionError(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&TestHandlers{})
+
+	// --- Multi-file output ------------------------------------------------
+	multi, err := NewGenerator(registry).Generate()
+	if err != nil {
+		t.Fatalf("Generate (multi-file) failed: %v", err)
+	}
+	baseContent, ok := multi["client.ts"]
+	if !ok {
+		t.Fatalf("client.ts not in multi-file output: %v", mapKeys(multi))
+	}
+
+	// --- Single-file output (GenerateTo) ----------------------------------
+	var singleBuf bytes.Buffer
+	if err := NewGenerator(registry).GenerateTo(&singleBuf); err != nil {
+		t.Fatalf("GenerateTo failed: %v", err)
+	}
+	singleContent := singleBuf.String()
+
+	// --- Single-file React output -----------------------------------------
+	var reactBuf bytes.Buffer
+	if err := NewGenerator(registry).WithOptions(GeneratorOptions{Mode: OutputReact}).GenerateTo(&reactBuf); err != nil {
+		t.Fatalf("GenerateTo (react) failed: %v", err)
+	}
+	reactContent := reactBuf.String()
+
+	wantSubstrings := []struct {
+		substr string
+		desc   string
+	}{
+		// Reason union — must list every bucket so apps can switch on it.
+		{`'offline'`, "offline reason literal"},
+		{`'server-rejected'`, "server-rejected reason literal"},
+		{`'server-closed'`, "server-closed reason literal"},
+		{`'network-error'`, "network-error reason literal"},
+		{`'manual'`, "manual reason literal"},
+		{"export type ConnectionErrorReason", "ConnectionErrorReason exported"},
+
+		// ConnectionError class — extends Error so `instanceof Error` keeps
+		// working, but adds reason + close diagnostics.
+		{"export class ConnectionError extends Error", "ConnectionError class exported and extends Error"},
+		{"readonly reason: ConnectionErrorReason", "ConnectionError.reason field"},
+		{"readonly closeCode?: number", "ConnectionError.closeCode field"},
+		{"readonly closeReason?: string", "ConnectionError.closeReason field"},
+
+		// Listener API — apps need a way to subscribe to classified errors.
+		{"onConnectionError(", "onConnectionError listener registration"},
+
+		// Classification source: navigator.onLine drives the offline bucket.
+		{"navigator", "uses navigator.onLine to classify offline failures"},
+
+		// WebSocket transport must surface the CloseEvent so the classifier
+		// can distinguish post-upgrade (clean) from pre-upgrade (1006).
+		{"event.code", "WebSocket close code captured"},
+	}
+
+	for _, c := range wantSubstrings {
+		if !strings.Contains(baseContent, c.substr) {
+			t.Errorf("multi-file client.ts: %s — expected substring %q", c.desc, c.substr)
+		}
+		if !strings.Contains(singleContent, c.substr) {
+			t.Errorf("GenerateTo client.ts: %s — expected substring %q", c.desc, c.substr)
+		}
+		if !strings.Contains(reactContent, c.substr) {
+			t.Errorf("GenerateTo react client.ts: %s — expected substring %q", c.desc, c.substr)
+		}
+	}
+
+	// The legacy bare `new Error('Connection closed')` rejections must be
+	// replaced with the structured ConnectionError so consumers can switch
+	// on .reason. Allow the old string to live on inside a ConnectionError
+	// message, but not as a bare `new Error(...)` call.
+	bannedPatterns := []string{
+		"new Error('Connection closed')",
+		`new Error("Connection closed")`,
+	}
+	for _, banned := range bannedPatterns {
+		if strings.Contains(baseContent, banned) {
+			t.Errorf("multi-file client.ts still uses bare %q — should be ConnectionError", banned)
+		}
+		if strings.Contains(singleContent, banned) {
+			t.Errorf("GenerateTo client.ts still uses bare %q — should be ConnectionError", banned)
+		}
+		if strings.Contains(reactContent, banned) {
+			t.Errorf("GenerateTo react client.ts still uses bare %q — should be ConnectionError", banned)
+		}
+	}
+}

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -71,6 +71,68 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     if (!Array.isArray(err.data)) return null;
     return err.data as FieldError[];
 }
+
+// ConnectionErrorReason classifies why a connection failed or could not be
+// used. Browsers deliberately collapse most pre-WebSocket-upgrade failures
+// (DNS, TCP refused, TLS handshake, HTTP 4xx during upgrade) into close
+// code 1006 with no diagnostic text, so finer-grained classification is
+// not achievable from JS — these all surface as 'network-error'.
+//
+//   - 'offline':         navigator.onLine was false at failure time.
+//   - 'server-rejected': server sent an ApiError with code ConnectionRejected
+//                        (e.g. invalid session) before closing. The original
+//                        ApiError is attached via ConnectionError.cause.
+//   - 'server-closed':   transport closed cleanly after the WebSocket upgrade
+//                        completed; closeCode and closeReason are populated.
+//   - 'network-error':   pre-upgrade failure or close code 1006 — refused,
+//                        unreachable, TLS or upgrade-time HTTP error.
+//   - 'manual':          the caller invoked client.disconnect().
+export type ConnectionErrorReason =
+    | 'offline'
+    | 'server-rejected'
+    | 'server-closed'
+    | 'network-error'
+    | 'manual';
+
+// ConnectionErrorInit carries the optional diagnostic fields attached to a
+// ConnectionError. closeCode/closeReason mirror the WebSocket CloseEvent
+// fields when available; cause carries the underlying ApiError for
+// 'server-rejected' so callers can read err.cause.code / err.cause.data.
+export interface ConnectionErrorInit {
+    closeCode?: number;
+    closeReason?: string;
+    cause?: unknown;
+}
+
+// ConnectionError is thrown (or attached to a rejected promise) whenever a
+// request fails because the connection itself is unhealthy — distinct from
+// ApiError, which represents a structured server-side error response. It
+// extends Error so existing `catch (err) { ... }` blocks keep working; new
+// code can switch on err.reason for user-facing messaging.
+export class ConnectionError extends Error {
+    readonly reason: ConnectionErrorReason;
+    readonly closeCode?: number;
+    readonly closeReason?: string;
+    // cause is the underlying ApiError for 'server-rejected', if any.
+    // For other reasons it is undefined. Typed `unknown` to align with the
+    // ES2022 Error.cause convention without forcing a specific shape.
+    readonly cause?: unknown;
+
+    constructor(reason: ConnectionErrorReason, message: string, init?: ConnectionErrorInit) {
+        super(message);
+        this.name = 'ConnectionError';
+        this.reason = reason;
+        this.closeCode = init?.closeCode;
+        this.closeReason = init?.closeReason;
+        this.cause = init?.cause;
+    }
+
+    isOffline(): boolean { return this.reason === 'offline'; }
+    isServerRejected(): boolean { return this.reason === 'server-rejected'; }
+    isServerClosed(): boolean { return this.reason === 'server-closed'; }
+    isNetworkError(): boolean { return this.reason === 'network-error'; }
+    isManual(): boolean { return this.reason === 'manual'; }
+}
 {{end}}
 
 {{define "types"}}
@@ -135,9 +197,26 @@ export function getSSEUrl(path: string = '/sse'): string {
 {{end}}
 
 {{define "api-client-class"}}
+// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+// transport up to the client's classification logic. SSE has no equivalent
+// (the EventSource error event exposes nothing structured), so the SSE
+// transport synthesizes an empty info object — it lands as 'network-error'
+// after offline/manual checks, which is the most accurate bucket browsers
+// will let us name.
+interface TransportCloseInfo {
+    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
+    code?: number;
+    /** WebSocket CloseEvent.reason, when non-empty. */
+    reason?: string;
+    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
+    wasClean?: boolean;
+    /** True when the close was already classified as a server-rejected protocol error. */
+    serverRejected?: boolean;
+}
+
 // Internal transport interface
 interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void>;
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -146,7 +225,7 @@ interface ClientTransport {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve, reject) => {
             // Detach and close previous socket so its deferred onclose
             // cannot interfere with the new connection (mobile wake race).
@@ -162,10 +241,21 @@ class WebSocketTransport implements ClientTransport {
             this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
-            this.ws.onclose = () => {
+            this.ws.onclose = (event) => {
                 this.ws = null;
+                // Surface the structured CloseEvent so the ApiClient can
+                // distinguish a clean post-upgrade close (codes 1000-1015,
+                // 4xxx) from a pre-upgrade abnormal closure (1006). The
+                // browser deliberately hides upgrade-time HTTP status for
+                // fingerprinting reasons, so 1006 is as fine-grained as
+                // we get for refused/DNS/TLS/4xx-during-upgrade failures.
+                const info: TransportCloseInfo = {
+                    code: event.code,
+                    reason: event.reason || undefined,
+                    wasClean: event.wasClean,
+                };
                 if (!opened) reject(new Error('WebSocket closed before open'));
-                onClose();
+                onClose(info);
             };
         });
     }
@@ -196,7 +286,7 @@ class SSETransport implements ClientTransport {
     private baseUrl: string = '';
     private onMessage: ((data: string) => void) | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
         this.onMessage = onMessage;
 
@@ -221,11 +311,14 @@ class SSETransport implements ClientTransport {
                 if (e.data) {
                     onMessage(e.data);
                 } else {
-                    // EventSource connection error (no data = connectivity issue)
+                    // EventSource connection error (no data = connectivity issue).
+                    // EventSource exposes nothing structured here, so the
+                    // ApiClient classifier falls through to 'network-error'
+                    // after offline/manual checks.
                     this.eventSource?.close();
                     this.eventSource = null;
                     this.connectionId = null;
-                    onClose();
+                    onClose({ wasClean: false });
                 }
             });
 
@@ -349,11 +442,22 @@ export class ApiClient {
     private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private loadingListeners = new Set<(count: number) => void>();
+    private connectionErrorListeners = new Set<(error: ConnectionError) => void>();
     private lastLoadingCount = 0;
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private manualDisconnect = false;
+    // pendingRejection is set when the server sends a ConnectionRejected
+    // ApiError just before tearing down the transport. handleClose() reads
+    // it so the resulting ConnectionError carries reason 'server-rejected'
+    // (with the original ApiError as cause) rather than the default
+    // 'manual' reading triggered by transport.disconnect().
+    private pendingRejection: ApiError | null = null;
+    // lastConnectionError is the most recently observed ConnectionError,
+    // exposed via getLastConnectionError() so a UI can render an offline
+    // banner / "server unreachable" message after the fact.
+    private lastConnectionError: ConnectionError | null = null;
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
@@ -382,33 +486,109 @@ export class ApiClient {
         return this.transport.connect(
             url,
             (data) => this.handleMessage(data),
-            () => this.handleClose(),
+            (info) => this.handleClose(info),
         ).then(() => {
             this.reconnectAttempts = 0;
             this.setState('connected');
         }).catch(() => {
-            this.handleClose();
+            // The transport's promise rejected before opening — treat as a
+            // pre-upgrade close with no diagnostic info available.
+            this.handleClose({ wasClean: false });
         });
     }
 
-    private handleClose(): void {
+    // classifyClose decides why the transport closed. Order matters:
+    //   1. Server-rejected wins because the server explicitly told us why
+    //      (we keep the ApiError as `cause`).
+    //   2. Manual disconnect comes next — the caller initiated the close.
+    //   3. Offline overrides everything else; navigator.onLine being false
+    //      means even a clean close happened during a network outage and
+    //      "offline" is the more useful message.
+    //   4. A close code outside the abnormal range (1006) and 0 means the
+    //      WebSocket upgrade succeeded and the server closed cleanly.
+    //   5. Otherwise the failure happened before/at upgrade time and the
+    //      browser collapses every cause into an indistinguishable
+    //      'network-error'.
+    private classifyClose(info?: TransportCloseInfo): ConnectionErrorReason {
+        if (this.pendingRejection || info?.serverRejected) {
+            return 'server-rejected';
+        }
+        if (this.manualDisconnect) return 'manual';
+        if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+            return 'offline';
+        }
+        if (info?.code !== undefined && info.code !== 1006 && info.code !== 0) {
+            return 'server-closed';
+        }
+        return 'network-error';
+    }
+
+    private buildConnectionError(reason: ConnectionErrorReason, info?: TransportCloseInfo): ConnectionError {
+        let message: string;
+        const init: ConnectionErrorInit = {
+            closeCode: info?.code,
+            closeReason: info?.reason,
+        };
+        switch (reason) {
+            case 'offline':
+                message = 'Offline: no network connection';
+                break;
+            case 'server-rejected': {
+                const cause = this.pendingRejection;
+                init.cause = cause ?? undefined;
+                message = cause?.message
+                    ? `Server rejected connection: ${cause.message}`
+                    : 'Server rejected connection';
+                break;
+            }
+            case 'server-closed':
+                message = info?.reason
+                    ? `Server closed connection (code ${info.code}): ${info.reason}`
+                    : `Server closed connection (code ${info?.code ?? 'unknown'})`;
+                break;
+            case 'network-error':
+                message = 'Network error: connection lost';
+                break;
+            case 'manual':
+                message = 'Disconnected';
+                break;
+        }
+        return new ConnectionError(reason, message, init);
+    }
+
+    private notifyConnectionError(error: ConnectionError): void {
+        this.lastConnectionError = error;
+        for (const listener of this.connectionErrorListeners) {
+            listener(error);
+        }
+    }
+
+    private handleClose(info?: TransportCloseInfo): void {
+        const reason = this.classifyClose(info);
+        const error = this.buildConnectionError(reason, info);
+        // Consume the pending rejection: subsequent reconnect attempts
+        // (e.g. after the auth flow refreshes) must not be misclassified.
+        this.pendingRejection = null;
+
         // Reject all pending requests (but keep subscription entries for reconnect)
         const subIds = new Set(this.subscriptions.keys());
         for (const [id, p] of this.pending) {
             if (!subIds.has(id)) {
                 p.onSettle?.();
-                p.reject(new Error('Connection closed'));
+                p.reject(error);
             }
             this.pending.delete(id);
         }
-        // End all in-flight streams with a connection-closed error. Streams
-        // are not auto-resumed on reconnect; consumers must restart them.
+        // End all in-flight streams with the structured connection error.
+        // Streams are not auto-resumed on reconnect; consumers must restart
+        // them.
         const streams = Array.from(this.streams.values());
         this.streams.clear();
         for (const s of streams) {
-            s.end(new Error('Connection closed'));
+            s.end(error);
         }
         this.notifyLoadingChange();
+        this.notifyConnectionError(error);
 
         if (this.manualDisconnect) {
             this.setState('disconnected');
@@ -467,7 +647,14 @@ export class ApiClient {
             this.flushBuffer();
             this.resubscribeAll();
         } else if (state === 'disconnected') {
-            this.rejectBuffer(new Error('Not connected'));
+            // Reuse the most recent classified error if handleClose() just
+            // ran, so a request buffered during a reconnect attempt that
+            // ultimately fails is rejected with the same reason as the
+            // close itself (e.g. 'offline'). Falls back to 'manual' when
+            // there's no prior error — that branch is hit by an idle
+            // disconnect() with no in-flight close.
+            const err = this.lastConnectionError ?? new ConnectionError('manual', 'Not connected');
+            this.rejectBuffer(err);
         }
         for (const listener of this.stateListeners) {
             listener(state);
@@ -482,6 +669,30 @@ export class ApiClient {
     onLoadingChange(listener: (count: number) => void): () => void {
         this.loadingListeners.add(listener);
         return () => this.loadingListeners.delete(listener);
+    }
+
+    /**
+     * onConnectionError registers a listener that fires every time a
+     * connection-level failure is classified (transport close, server
+     * rejection, etc.). The listener receives a structured ConnectionError
+     * carrying the reason and any close-event diagnostics the browser
+     * exposed. Use this to drive UI like an "Offline" banner.
+     *
+     * Returns an unsubscribe function. Multiple listeners are supported.
+     */
+    onConnectionError(listener: (error: ConnectionError) => void): () => void {
+        this.connectionErrorListeners.add(listener);
+        return () => this.connectionErrorListeners.delete(listener);
+    }
+
+    /**
+     * getLastConnectionError returns the most recent ConnectionError, or
+     * null if no failure has been observed (or the connection has never
+     * dropped). Useful right after `getState() === 'disconnected'` or
+     * 'reconnecting' to decide what message to show the user.
+     */
+    getLastConnectionError(): ConnectionError | null {
+        return this.lastConnectionError;
     }
 
     getLoadingCount(): number {
@@ -592,8 +803,14 @@ export class ApiClient {
                     break;
                 }
                 if (msg.code === ErrorCode.ConnectionRejected) {
+                    const apiError = new ApiError(msg.code, msg.message, msg.data);
                     this.manualDisconnect = true;
-                    this.options.onConnectionRejected?.(new ApiError(msg.code, msg.message, msg.data));
+                    // Stash the rejection so the imminent transport close
+                    // is classified as 'server-rejected' rather than the
+                    // default 'manual' that manualDisconnect=true would
+                    // otherwise produce. handleClose() consumes it.
+                    this.pendingRejection = apiError;
+                    this.options.onConnectionRejected?.(apiError);
                     this.transport.disconnect();
                 } else {
                     // Server-driven subscription refresh error
@@ -689,7 +906,21 @@ export class ApiClient {
                 }
                 return;
             }
-            reject(new Error('Not connected'));
+            // Disconnected and not reconnecting. Prefer the most recent
+            // ConnectionError (set by handleClose) so callers see the same
+            // reason that classified the transport drop. If we got here
+            // without a prior failure (e.g. caller never connected, or
+            // navigator.onLine flipped between connect and request), still
+            // surface a ConnectionError with the best reason we can name.
+            let err = this.lastConnectionError;
+            if (!err) {
+                if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+                    err = new ConnectionError('offline', 'Offline: no network connection');
+                } else {
+                    err = new ConnectionError('manual', 'Not connected');
+                }
+            }
+            reject(err);
         });
     }
 
@@ -864,7 +1095,12 @@ export class ApiClient {
                     if (started) return;
                     started = true;
                     if (!this.transport.isConnected()) {
-                        end(new Error('Not connected'));
+                        const err = this.lastConnectionError ?? (
+                            typeof navigator !== 'undefined' && navigator.onLine === false
+                                ? new ConnectionError('offline', 'Offline: no network connection')
+                                : new ConnectionError('manual', 'Not connected')
+                        );
+                        end(err);
                         return;
                     }
                     id = String(++this.requestId);

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -564,6 +564,14 @@ export class ApiClient {
     }
 
     private handleClose(info?: TransportCloseInfo): void {
+        // disconnect() rejects pending requests/streams synchronously and
+        // sets state to 'disconnected'. The transport's onclose still fires
+        // afterwards to confirm the close — short-circuit so we don't
+        // re-notify listeners or rebuild the error.
+        if (this.manualDisconnect && this.state === 'disconnected') {
+            this.pendingRejection = null;
+            return;
+        }
         const reason = this.classifyClose(info);
         const error = this.buildConnectionError(reason, info);
         // Consume the pending rejection: subsequent reconnect attempts
@@ -625,6 +633,7 @@ export class ApiClient {
     }
 
     disconnect(): void {
+        if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
         if (this.reconnectTimer) {
@@ -632,6 +641,26 @@ export class ApiClient {
             this.reconnectTimer = null;
         }
         this.subscriptions.clear();
+
+        // Reject in-flight requests/streams synchronously: the server may
+        // still respond between transport.disconnect() and the close event
+        // landing, racing the rejection in handleClose() and resolving the
+        // promise instead. Doing it here means the caller's "I'm done"
+        // semantics win over a late server reply.
+        const error = this.buildConnectionError('manual', undefined);
+        for (const [, p] of this.pending) {
+            p.onSettle?.();
+            p.reject(error);
+        }
+        this.pending.clear();
+        const streams = Array.from(this.streams.values());
+        this.streams.clear();
+        for (const s of streams) {
+            s.end(error);
+        }
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+
         this.transport.disconnect();
         this.setState('disconnected');
     }

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -17,9 +17,18 @@ import { useState, useEffect, useCallback, useMemo, useRef, useContext, createCo
 
 {{template "get-websocket-url" .}}
 
+// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+// transport up to the client's classification logic.
+interface TransportCloseInfo {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+    serverRejected?: boolean;
+}
+
 // Internal transport interface
 interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void>;
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -28,15 +37,19 @@ interface ClientTransport {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve) => {
             this.ws = new WebSocket(url);
             this.ws.onopen = () => resolve();
             this.ws.onerror = () => {};
             this.ws.onmessage = (e) => onMessage(e.data);
-            this.ws.onclose = () => {
+            this.ws.onclose = (event) => {
                 this.ws = null;
-                onClose();
+                onClose({
+                    code: event.code,
+                    reason: event.reason || undefined,
+                    wasClean: event.wasClean,
+                });
             };
         });
     }
@@ -64,7 +77,7 @@ class SSETransport implements ClientTransport {
     private connectionId: string | null = null;
     private baseUrl: string = '';
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
 
         return new Promise((resolve) => {
@@ -91,7 +104,7 @@ class SSETransport implements ClientTransport {
                     this.eventSource?.close();
                     this.eventSource = null;
                     this.connectionId = null;
-                    onClose();
+                    onClose({ wasClean: false });
                 }
             });
 
@@ -165,11 +178,14 @@ export class ApiClient {
     private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private loadingListeners = new Set<(count: number) => void>();
+    private connectionErrorListeners = new Set<(error: ConnectionError) => void>();
     private lastLoadingCount = 0;
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private manualDisconnect = false;
+    private pendingRejection: ApiError | null = null;
+    private lastConnectionError: ConnectionError | null = null;
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
@@ -196,22 +212,81 @@ export class ApiClient {
         return this.transport.connect(
             this.url,
             (data) => this.handleMessage(data),
-            () => this.handleClose(),
+            (info) => this.handleClose(info),
         ).then(() => {
             this.reconnectAttempts = 0;
             this.setState('connected');
         }).catch(() => {
-            this.handleClose();
+            this.handleClose({ wasClean: false });
         });
     }
 
-    private handleClose(): void {
+    private classifyClose(info?: TransportCloseInfo): ConnectionErrorReason {
+        if (this.pendingRejection || info?.serverRejected) {
+            return 'server-rejected';
+        }
+        if (this.manualDisconnect) return 'manual';
+        if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+            return 'offline';
+        }
+        if (info?.code !== undefined && info.code !== 1006 && info.code !== 0) {
+            return 'server-closed';
+        }
+        return 'network-error';
+    }
+
+    private buildConnectionError(reason: ConnectionErrorReason, info?: TransportCloseInfo): ConnectionError {
+        let message: string;
+        const init: ConnectionErrorInit = {
+            closeCode: info?.code,
+            closeReason: info?.reason,
+        };
+        switch (reason) {
+            case 'offline':
+                message = 'Offline: no network connection';
+                break;
+            case 'server-rejected': {
+                const cause = this.pendingRejection;
+                init.cause = cause ?? undefined;
+                message = cause?.message
+                    ? `Server rejected connection: ${cause.message}`
+                    : 'Server rejected connection';
+                break;
+            }
+            case 'server-closed':
+                message = info?.reason
+                    ? `Server closed connection (code ${info.code}): ${info.reason}`
+                    : `Server closed connection (code ${info?.code ?? 'unknown'})`;
+                break;
+            case 'network-error':
+                message = 'Network error: connection lost';
+                break;
+            case 'manual':
+                message = 'Disconnected';
+                break;
+        }
+        return new ConnectionError(reason, message, init);
+    }
+
+    private notifyConnectionError(error: ConnectionError): void {
+        this.lastConnectionError = error;
+        for (const listener of this.connectionErrorListeners) {
+            listener(error);
+        }
+    }
+
+    private handleClose(info?: TransportCloseInfo): void {
+        const reason = this.classifyClose(info);
+        const error = this.buildConnectionError(reason, info);
+        this.pendingRejection = null;
+
         for (const [, p] of this.pending) {
             p.onSettle?.();
-            p.reject(new Error('Connection closed'));
+            p.reject(error);
         }
         this.pending.clear();
         this.notifyLoadingChange();
+        this.notifyConnectionError(error);
 
         if (this.manualDisconnect) {
             this.setState('disconnected');
@@ -265,7 +340,8 @@ export class ApiClient {
         if (state === 'connected') {
             this.flushBuffer();
         } else if (state === 'disconnected') {
-            this.rejectBuffer(new Error('Not connected'));
+            const err = this.lastConnectionError ?? new ConnectionError('manual', 'Not connected');
+            this.rejectBuffer(err);
         }
         for (const listener of this.stateListeners) {
             listener(state);
@@ -280,6 +356,25 @@ export class ApiClient {
     onLoadingChange(listener: (count: number) => void): () => void {
         this.loadingListeners.add(listener);
         return () => this.loadingListeners.delete(listener);
+    }
+
+    /**
+     * onConnectionError registers a listener that fires every time a
+     * connection-level failure is classified. See ConnectionError /
+     * ConnectionErrorReason for the available reasons. Returns an
+     * unsubscribe function.
+     */
+    onConnectionError(listener: (error: ConnectionError) => void): () => void {
+        this.connectionErrorListeners.add(listener);
+        return () => this.connectionErrorListeners.delete(listener);
+    }
+
+    /**
+     * getLastConnectionError returns the most recent ConnectionError, or
+     * null if no failure has been observed.
+     */
+    getLastConnectionError(): ConnectionError | null {
+        return this.lastConnectionError;
     }
 
     getLoadingCount(): number {
@@ -412,7 +507,17 @@ export class ApiClient {
                 }
                 return;
             }
-            reject(new Error('Not connected'));
+            // Disconnected and not reconnecting. Surface the structured
+            // ConnectionError so callers can switch on err.reason.
+            let err = this.lastConnectionError;
+            if (!err) {
+                if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+                    err = new ConnectionError('offline', 'Offline: no network connection');
+                } else {
+                    err = new ConnectionError('manual', 'Not connected');
+                }
+            }
+            reject(err);
         });
     }
 

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -276,6 +276,14 @@ export class ApiClient {
     }
 
     private handleClose(info?: TransportCloseInfo): void {
+        // disconnect() rejects pending requests synchronously and sets
+        // state to 'disconnected'. The transport's onclose still fires
+        // afterwards to confirm the close — short-circuit so we don't
+        // re-notify listeners or rebuild the error.
+        if (this.manualDisconnect && this.state === 'disconnected') {
+            this.pendingRejection = null;
+            return;
+        }
         const reason = this.classifyClose(info);
         const error = this.buildConnectionError(reason, info);
         this.pendingRejection = null;
@@ -320,12 +328,28 @@ export class ApiClient {
     }
 
     disconnect(): void {
+        if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
         if (this.reconnectTimer) {
             clearTimeout(this.reconnectTimer);
             this.reconnectTimer = null;
         }
+
+        // Reject in-flight requests synchronously: the server may still
+        // respond between transport.disconnect() and the close event
+        // landing, racing the rejection in handleClose() and resolving
+        // the promise instead. Doing it here means the caller's "I'm
+        // done" semantics win over a late server reply.
+        const error = this.buildConnectionError('manual', undefined);
+        for (const [, p] of this.pending) {
+            p.onSettle?.();
+            p.reject(error);
+        }
+        this.pending.clear();
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+
         this.transport.disconnect();
         this.setState('disconnected');
     }

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -10,9 +10,18 @@
 
 {{template "get-websocket-url" .}}
 
+// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+// transport up to the client's classification logic.
+interface TransportCloseInfo {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+    serverRejected?: boolean;
+}
+
 // Internal transport interface
 interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void>;
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -21,15 +30,19 @@ interface ClientTransport {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve) => {
             this.ws = new WebSocket(url);
             this.ws.onopen = () => resolve();
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
-            this.ws.onclose = () => {
+            this.ws.onclose = (event) => {
                 this.ws = null;
-                onClose();
+                onClose({
+                    code: event.code,
+                    reason: event.reason || undefined,
+                    wasClean: event.wasClean,
+                });
             };
         });
     }
@@ -57,7 +70,7 @@ class SSETransport implements ClientTransport {
     private connectionId: string | null = null;
     private baseUrl: string = '';
 
-    connect(url: string, onMessage: (data: string) => void, onClose: () => void): Promise<void> {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
 
         return new Promise((resolve) => {
@@ -84,7 +97,7 @@ class SSETransport implements ClientTransport {
                     this.eventSource?.close();
                     this.eventSource = null;
                     this.connectionId = null;
-                    onClose();
+                    onClose({ wasClean: false });
                 }
             });
 
@@ -158,11 +171,14 @@ export class ApiClient {
     private pushHandlers = new Map<string, Set<(data: unknown) => void>>();
     private stateListeners = new Set<(state: ConnectionState) => void>();
     private loadingListeners = new Set<(count: number) => void>();
+    private connectionErrorListeners = new Set<(error: ConnectionError) => void>();
     private lastLoadingCount = 0;
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     private manualDisconnect = false;
+    private pendingRejection: ApiError | null = null;
+    private lastConnectionError: ConnectionError | null = null;
     private visibilityHandler: (() => void) | null = null;
     private onlineHandler: (() => void) | null = null;
 
@@ -189,22 +205,83 @@ export class ApiClient {
         return this.transport.connect(
             this.url,
             (data) => this.handleMessage(data),
-            () => this.handleClose(),
+            (info) => this.handleClose(info),
         ).then(() => {
             this.reconnectAttempts = 0;
             this.setState('connected');
         }).catch(() => {
-            this.handleClose();
+            this.handleClose({ wasClean: false });
         });
     }
 
-    private handleClose(): void {
+    // classifyClose decides why the transport closed. See _client-common.ts.tmpl
+    // for the rationale; this is the same logic.
+    private classifyClose(info?: TransportCloseInfo): ConnectionErrorReason {
+        if (this.pendingRejection || info?.serverRejected) {
+            return 'server-rejected';
+        }
+        if (this.manualDisconnect) return 'manual';
+        if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+            return 'offline';
+        }
+        if (info?.code !== undefined && info.code !== 1006 && info.code !== 0) {
+            return 'server-closed';
+        }
+        return 'network-error';
+    }
+
+    private buildConnectionError(reason: ConnectionErrorReason, info?: TransportCloseInfo): ConnectionError {
+        let message: string;
+        const init: ConnectionErrorInit = {
+            closeCode: info?.code,
+            closeReason: info?.reason,
+        };
+        switch (reason) {
+            case 'offline':
+                message = 'Offline: no network connection';
+                break;
+            case 'server-rejected': {
+                const cause = this.pendingRejection;
+                init.cause = cause ?? undefined;
+                message = cause?.message
+                    ? `Server rejected connection: ${cause.message}`
+                    : 'Server rejected connection';
+                break;
+            }
+            case 'server-closed':
+                message = info?.reason
+                    ? `Server closed connection (code ${info.code}): ${info.reason}`
+                    : `Server closed connection (code ${info?.code ?? 'unknown'})`;
+                break;
+            case 'network-error':
+                message = 'Network error: connection lost';
+                break;
+            case 'manual':
+                message = 'Disconnected';
+                break;
+        }
+        return new ConnectionError(reason, message, init);
+    }
+
+    private notifyConnectionError(error: ConnectionError): void {
+        this.lastConnectionError = error;
+        for (const listener of this.connectionErrorListeners) {
+            listener(error);
+        }
+    }
+
+    private handleClose(info?: TransportCloseInfo): void {
+        const reason = this.classifyClose(info);
+        const error = this.buildConnectionError(reason, info);
+        this.pendingRejection = null;
+
         for (const [, p] of this.pending) {
             p.onSettle?.();
-            p.reject(new Error('Connection closed'));
+            p.reject(error);
         }
         this.pending.clear();
         this.notifyLoadingChange();
+        this.notifyConnectionError(error);
 
         if (this.manualDisconnect) {
             this.setState('disconnected');
@@ -258,7 +335,8 @@ export class ApiClient {
         if (state === 'connected') {
             this.flushBuffer();
         } else if (state === 'disconnected') {
-            this.rejectBuffer(new Error('Not connected'));
+            const err = this.lastConnectionError ?? new ConnectionError('manual', 'Not connected');
+            this.rejectBuffer(err);
         }
         for (const listener of this.stateListeners) {
             listener(state);
@@ -273,6 +351,25 @@ export class ApiClient {
     onLoadingChange(listener: (count: number) => void): () => void {
         this.loadingListeners.add(listener);
         return () => this.loadingListeners.delete(listener);
+    }
+
+    /**
+     * onConnectionError registers a listener that fires every time a
+     * connection-level failure is classified. See ConnectionError /
+     * ConnectionErrorReason for the available reasons. Returns an
+     * unsubscribe function.
+     */
+    onConnectionError(listener: (error: ConnectionError) => void): () => void {
+        this.connectionErrorListeners.add(listener);
+        return () => this.connectionErrorListeners.delete(listener);
+    }
+
+    /**
+     * getLastConnectionError returns the most recent ConnectionError, or
+     * null if no failure has been observed.
+     */
+    getLastConnectionError(): ConnectionError | null {
+        return this.lastConnectionError;
     }
 
     getLoadingCount(): number {
@@ -405,7 +502,17 @@ export class ApiClient {
                 }
                 return;
             }
-            reject(new Error('Not connected'));
+            // Disconnected and not reconnecting. Surface the structured
+            // ConnectionError so callers can switch on err.reason.
+            let err = this.lastConnectionError;
+            if (!err) {
+                if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+                    err = new ConnectionError('offline', 'Offline: no network connection');
+                } else {
+                    err = new ConnectionError('manual', 'Not connected');
+                }
+            }
+            reject(err);
         });
     }
 

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -271,6 +271,14 @@ export class ApiClient {
     }
 
     private handleClose(info?: TransportCloseInfo): void {
+        // disconnect() rejects pending requests synchronously and sets
+        // state to 'disconnected'. The transport's onclose still fires
+        // afterwards to confirm the close — short-circuit so we don't
+        // re-notify listeners or rebuild the error.
+        if (this.manualDisconnect && this.state === 'disconnected') {
+            this.pendingRejection = null;
+            return;
+        }
         const reason = this.classifyClose(info);
         const error = this.buildConnectionError(reason, info);
         this.pendingRejection = null;
@@ -315,12 +323,28 @@ export class ApiClient {
     }
 
     disconnect(): void {
+        if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
         if (this.reconnectTimer) {
             clearTimeout(this.reconnectTimer);
             this.reconnectTimer = null;
         }
+
+        // Reject in-flight requests synchronously: the server may still
+        // respond between transport.disconnect() and the close event
+        // landing, racing the rejection in handleClose() and resolving
+        // the promise instead. Doing it here means the caller's "I'm
+        // done" semantics win over a late server reply.
+        const error = this.buildConnectionError('manual', undefined);
+        for (const [, p] of this.pending) {
+            p.onSettle?.();
+            p.reject(error);
+        }
+        this.pending.clear();
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+
         this.transport.disconnect();
         this.setState('disconnected');
     }


### PR DESCRIPTION
## Summary

The TS client previously rejected every connection-level failure with bare `new Error('Connection closed' | 'Not connected')`, leaving apps unable to distinguish "no network" from "server rejected" from "manual disconnect". This adds a typed `ConnectionError` (extending `Error`) carrying a typed `reason` field plus close-event diagnostics.

Five reasons, picked to match what browsers actually let JS observe:

| Reason | When |
|---|---|
| `offline` | `navigator.onLine === false` at failure time. |
| `server-rejected` | Server sent `ApiError` with code `ConnectionRejected` (e.g. invalid session) before closing. Original `ApiError` is attached as `err.cause`. |
| `server-closed` | Transport closed cleanly after WebSocket upgrade completed; `err.closeCode` and `err.closeReason` carry the `CloseEvent` fields. |
| `network-error` | Pre-upgrade failure or close code 1006 (refused, unreachable, TLS, HTTP error during upgrade). Browsers deliberately collapse these into one bucket. |
| `manual` | Caller invoked `client.disconnect()`. |

The four-bucket split is deliberate: WebSocket APIs hide upgrade-time HTTP status codes for fingerprinting reasons, so refused/DNS/TLS/4xx-during-upgrade are indistinguishable from JS — that's `network-error`.

## What changes

- New types: `ConnectionError`, `ConnectionErrorReason`, `ConnectionErrorInit`. `ConnectionError extends Error` so legacy `catch (err) { ... err instanceof Error }` paths still work.
- `WebSocketTransport` captures `CloseEvent.{code, reason, wasClean}` and threads them up via a new `TransportCloseInfo` type. `SSETransport` synthesizes minimal info (EventSource exposes nothing structured).
- `ApiClient.handleClose` classifies + builds a `ConnectionError`, stores it in `lastConnectionError`, and rejects pending requests/streams with it.
- `ApiClient.request` (and `requestStream`) now reject with the most recent `ConnectionError` instead of bare `Error('Not connected')`. Falls back to `'offline'`/`'manual'` when no prior error exists.
- New listener API: `client.onConnectionError(listener)` and `client.getLastConnectionError()`. The existing `onConnectionRejected` callback continues to fire for backward compatibility.
- The `ConnectionRejected` ApiError path is wrapped: a `pendingRejection` field is set so the imminent transport close lands as `'server-rejected'` (not `'manual'`), with the original `ApiError` attached as `err.cause`.
- Updated all three templates (`_client-common.ts.tmpl`, `client.ts.tmpl`, `client-react.ts.tmpl`) and regenerated `example/{vanilla,react}/client` outputs.
- README adds a "Connection Errors" section; `doc.go` adds a Connection Errors block adjacent to the Error Handling section.

## Follow-up commit: refresh APROT_AI.md

`APROT_AI.md` had drifted significantly since 920b3ed — many user-facing features (streaming handlers, transform tags, validation, subscription refresh, REST + OpenAPI + Zod, `useQuerySuspense`, `useStream`, `useIsLoading`, `conn.Set/Get`, graceful shutdown, and now `ConnectionError`) were missing. Rewrote it as a fast-reference digest that points at `doc.go` for the authoritative overview.

Also added a CLAUDE.md rule requiring `APROT_AI.md` updates alongside `README.md` and `doc.go` on user-facing changes, so it doesn't drift again.

## Test plan

- [x] `go test ./...` — passes, including the new `TestGenerateConnectionError` template assertion.
- [x] `cd example/react/client && npx tsc --noEmit` — clean.
- [x] New e2e test `e2e/tests/connection-error.test.ts` (7 tests) — covers reason union, predicates, server-rejected end-to-end (with cause chaining), manual disconnect (both pre- and mid-flight), `onConnectionError` firing, and offline classification via `navigator.onLine` stub. All pass.
- [x] Full e2e suite (excluding the pre-existing flaky `sse.test.ts`) — 69 tests pass across 10 files. The SSE test failures predate this PR (verified by stashing template changes and rerunning against master-generated client).

## Notes for reviewers

- The five-reason union is intentionally narrow because anything finer is unobservable from JS. We can't tell DNS failure from TCP refused from TLS handshake from upgrade-time HTTP 401 — they all land as code 1006 with no reason text.
- `lastConnectionError` is set on every classified close. `request()` reuses it for the immediate-reject path so a buffered call that never gets a chance to send rejects with the same reason as the close that aborted reconnect.
- `pendingRejection` is consumed in `handleClose` — subsequent reconnect attempts (e.g. after auth refresh in dynamic-URL flows) won't be misclassified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)