### PR TITLE
Add <ApiClientErrorProvider> + useApiClientError for global error capture

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -318,6 +318,33 @@ function AddTodoButton() {
 
 You manage `isLoading` / `error` / `AbortController` yourself. The trade-off is honest: the generated function is a typed `Promise<TRes>` that resolves with the actual value or throws — no hidden state machine.
 
+**Pattern 3 — global error capture with `<ApiClientErrorProvider>`.** Drop in a provider, read errors from `useApiClientError()`. Inside the provider, `useApiClient()` returns a `Proxy`-wrapped client that reports errors from `request` / `subscribe` / `requestStream` to the provider in addition to throwing as before. Generated hooks (`useQuery`, `mutate`, `useStream`) all flow through `useApiClient()` internally, so their errors surface here too without per-hook wiring.
+
+```tsx
+import {
+  ApiClient, ApiClientProvider, ApiClientErrorProvider, useApiClientError,
+} from './api/client';
+
+function App() {
+  return (
+    <ApiClientProvider value={client}>
+      <ApiClientErrorProvider>
+        <ErrorBanner />
+        <Page />
+      </ApiClientErrorProvider>
+    </ApiClientProvider>
+  );
+}
+
+function ErrorBanner() {
+  const { error, clear } = useApiClientError();
+  if (!error) return null;
+  return <div role="alert">{error.message} <button onClick={clear}>Dismiss</button></div>;
+}
+```
+
+Latest error wins (newer replaces older); `clear()` resets to `null`. The provider does **not** swallow — calls still throw, so `try/catch` and per-hook `error` fields keep working. Without an `<ApiClientErrorProvider>` above, `useApiClient()` returns the raw client and `useApiClientError()` throws — adoption is fully opt-in.
+
 ### Migrating from `useXxxMutation()` (removed)
 
 If your codebase still calls `useXxxMutation()`, see `MIGRATION_MUTATION_HOOKS.md` for an agent-runnable rewrite prompt. Quick summary: `useCreateUserMutation()` → either `useApiClient() + createUser(client, …)` (raw, throws) or `useListUsers().mutate((c) => createUser(c, …))` (refetch-after-mutation).

--- a/README.md
+++ b/README.md
@@ -437,6 +437,44 @@ You manage `isLoading` / `error` / `AbortController` yourself. The trade-off is 
 
 A previous version of aprot generated `useXxxMutation()` hooks whose `mutate()` swallowed errors and returned `undefined as TRes` on failure. The `Promise<TRes>` type lied at runtime; `void` mutations couldn't distinguish success from "not yet called"; and the only correct after-success pattern (`useEffect([data])`) was non-obvious. The two patterns above cover the same ground without the foot-guns. See [`MIGRATION_MUTATION_HOOKS.md`](MIGRATION_MUTATION_HOOKS.md) for a rewrite prompt that AI agents can run against an existing codebase.
 
+### Catching errors globally with `<ApiClientErrorProvider>`
+
+Patterns 1 and 2 wire errors per call site. When a component (or app) fans out to many hooks and ad-hoc client calls and just wants a single place to surface failures, drop in `<ApiClientErrorProvider>` and read from `useApiClientError()`:
+
+```tsx
+import {
+  ApiClient, ApiClientProvider, ApiClientErrorProvider,
+  useApiClient, useApiClientError,
+} from './api/client';
+
+const client = new ApiClient(`ws://${location.host}/ws`);
+
+function App() {
+    return (
+        <ApiClientProvider value={client}>
+            <ApiClientErrorProvider>
+                <ErrorBanner />
+                <UsersPanel />
+            </ApiClientErrorProvider>
+        </ApiClientProvider>
+    );
+}
+
+function ErrorBanner() {
+    const { error, clear } = useApiClientError();
+    if (!error) return null;
+    return (
+        <div role="alert">
+            {error.message} <button onClick={clear}>Dismiss</button>
+        </div>
+    );
+}
+```
+
+Inside the provider, `useApiClient()` returns a `Proxy`-wrapped client whose `request`, `subscribe`, and `requestStream` calls report errors to the provider — in addition to throwing / re-surfacing them as before. Generated hooks (`useListUsers`, `useQuery`, `mutate`, `useStream`) all retrieve their client through `useApiClient()` internally, so their errors flow up too without any per-hook wiring.
+
+Only the latest error is held; `clear()` resets it. The provider observes errors but does **not** swallow them — wrapped client calls still throw, so per-hook `error` fields and explicit `try/catch` keep working. Without an `<ApiClientErrorProvider>` above, `useApiClient()` returns the raw client unchanged and `useApiClientError()` throws — adoption is fully opt-in.
+
 ## Streaming Handlers
 
 Handlers can return `iter.Seq[T]` (Go 1.23+) and each yielded value is delivered to the client as a separate websocket message. The generated TypeScript function returns an `AsyncIterable<T>`, so you can consume results with `for await` and render them as they arrive — ideal for progressive list population, large result sets, or any handler whose output is naturally lazy.

--- a/doc.go
+++ b/doc.go
@@ -456,6 +456,34 @@
 // after-success pattern (useEffect([data])) was non-obvious. See the
 // repository's MIGRATION_MUTATION_HOOKS.md for a rewrite prompt.
 //
+// # Global Error Capture (TypeScript Client)
+//
+// Wrap a region of the React tree in <ApiClientErrorProvider> to surface every
+// API error inside a single hook, instead of wiring per-call try/catch. Errors
+// from imperative client.request() / requestStream() / subscribe() calls AND
+// from generated query / stream / mutate hooks all flow through the provider,
+// because every hook retrieves its client via useApiClient() and useApiClient()
+// returns a Proxy-wrapped client when the provider is mounted above it:
+//
+//	import { ApiClientProvider, ApiClientErrorProvider, useApiClient,
+//	         useApiClientError } from './api/client';
+//
+//	<ApiClientProvider value={client}>
+//	  <ApiClientErrorProvider>
+//	    <App />
+//	  </ApiClientErrorProvider>
+//	</ApiClientProvider>
+//
+// Read with useApiClientError():
+//
+//	const { error, clear } = useApiClientError();
+//
+// Only the latest error is held (newer overrides older); clear() resets it.
+// The provider observes errors but does not swallow them — wrapped client
+// calls still throw, so per-hook `error` fields and explicit try/catch keep
+// working. Without <ApiClientErrorProvider> above, useApiClient() returns the
+// raw client unchanged and useApiClientError() throws — adoption is opt-in.
+//
 // # React Suspense
 //
 // In addition to per-handler hooks like `useListUsers()` that return

--- a/example/react/client/src/App.tsx
+++ b/example/react/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { Component, Suspense, useEffect, useState, useRef } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
-import { ApiClient, ApiClientProvider, ApiError, useApiClient, useConnection, useIsLoading, useQuerySuspense } from './api/client'
+import { ApiClient, ApiClientProvider, ApiClientErrorProvider, ApiError, useApiClient, useApiClientError, useConnection, useIsLoading, useQuerySuspense } from './api/client'
 import { TaskNodeStatus } from './api/tasks-handler'
 import type { TaskNodeStatusType } from './api/tasks-handler'
 import {
@@ -720,6 +720,35 @@ function EventLog({ logs, onClear }: { logs: { message: string; type: string; ti
   )
 }
 
+// GlobalErrorBanner reads the latest error captured by <ApiClientErrorProvider>
+// and surfaces it as a dismissible banner. Every API call below the provider
+// — imperative client.request() calls AND errors thrown inside generated hooks
+// (useListUsers, useNumbers, etc.) — flows through here, so apps that don't
+// want per-call try/catch can rely on this single surface.
+function GlobalErrorBanner() {
+  const { error, clear } = useApiClientError()
+  if (!error) return null
+  return (
+    <div
+      style={{
+        padding: '10px 14px',
+        background: '#f8d7da',
+        border: '1px solid #f5c6cb',
+        borderRadius: 4,
+        color: '#721c24',
+        marginBottom: 12,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+      }}
+    >
+      <span><strong>API error:</strong> {error.message}</span>
+      <button onClick={clear} style={{ padding: '2px 10px' }}>Dismiss</button>
+    </div>
+  )
+}
+
 function AppContent() {
   const [logs, setLogs] = useState<{ message: string; type: string; time: string }[]>([])
   const { isConnected } = useConnection()
@@ -744,6 +773,7 @@ function AppContent() {
         <GlobalLoadingIndicator />
       </h1>
       <ConnectionStatus />
+      <GlobalErrorBanner />
       <div className="grid">
         <CreateUserForm onLog={addLog} />
         <UsersList />
@@ -780,7 +810,9 @@ export default function App() {
 
   return (
     <ApiClientProvider value={client}>
-      <AppContent />
+      <ApiClientErrorProvider>
+        <AppContent />
+      </ApiClientErrorProvider>
     </ApiClientProvider>
   )
 }

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -1186,12 +1186,132 @@ const ApiClientContext = createContext<ApiClient | null>(null);
 
 export const ApiClientProvider = ApiClientContext.Provider;
 
+// ApiErrorReporter is the internal callback an <ApiClientErrorProvider> installs
+// so the wrapped client can report errors up. It is intentionally not exported:
+// callers read the captured error via useApiClientError().
+type ApiErrorReporter = (err: Error) => void;
+const ApiErrorReporterContext = createContext<ApiErrorReporter | null>(null);
+
+// ApiClientErrorState is what useApiClientError() returns: the latest captured
+// error and a clear() to reset it. Only one error is held at a time — newer
+// errors replace older ones.
+export interface ApiClientErrorState {
+    error: Error | null;
+    clear: () => void;
+}
+const ApiClientErrorContext = createContext<ApiClientErrorState | null>(null);
+
+// wrapClientWithErrorReporter returns a Proxy over the ApiClient that reports
+// errors from the three transport entry points (request, subscribe,
+// requestStream) to the provider, then re-throws / re-surfaces them so
+// existing per-hook error handling and try/catch sites keep working. All
+// other methods are returned bound to the original client so `this` stays
+// correct.
+function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter): ApiClient {
+    return new Proxy(client, {
+        get(target, prop) {
+            const value = Reflect.get(target, prop);
+            if (typeof value !== 'function') return value;
+
+            if (prop === 'request') {
+                return function (...args: unknown[]) {
+                    const result = (value as (...a: unknown[]) => Promise<unknown>).apply(target, args);
+                    return result.catch((err: unknown) => {
+                        if (err instanceof Error) report(err);
+                        throw err;
+                    });
+                };
+            }
+            if (prop === 'subscribe') {
+                return function (
+                    method: string,
+                    params: unknown[],
+                    callback: (data: unknown) => void,
+                    onError?: (err: Error) => void,
+                ) {
+                    const wrappedOnError = (err: Error) => {
+                        report(err);
+                        onError?.(err);
+                    };
+                    return (value as (...a: unknown[]) => () => void).apply(
+                        target,
+                        [method, params, callback, wrappedOnError],
+                    );
+                };
+            }
+            if (prop === 'requestStream') {
+                return function (method: string, params: unknown[], options?: unknown) {
+                    const iterable = (value as (...a: unknown[]) => AsyncIterable<unknown>).apply(
+                        target,
+                        [method, params, options],
+                    );
+                    return {
+                        [Symbol.asyncIterator](): AsyncIterator<unknown> {
+                            const inner = iterable[Symbol.asyncIterator]();
+                            return {
+                                async next() {
+                                    try {
+                                        return await inner.next();
+                                    } catch (err) {
+                                        if (err instanceof Error) report(err);
+                                        throw err;
+                                    }
+                                },
+                                return: inner.return ? inner.return.bind(inner) : undefined,
+                                throw: inner.throw ? inner.throw.bind(inner) : undefined,
+                            };
+                        },
+                    };
+                };
+            }
+            return (value as (...a: unknown[]) => unknown).bind(target);
+        },
+    });
+}
+
 export function useApiClient(): ApiClient {
     const client = useContext(ApiClientContext);
     if (!client) {
         throw new Error('useApiClient must be used within an ApiClientProvider');
     }
-    return client;
+    const reporter = useContext(ApiErrorReporterContext);
+    return useMemo(
+        () => (reporter ? wrapClientWithErrorReporter(client, reporter) : client),
+        [client, reporter],
+    );
+}
+
+// ApiClientErrorProvider catches errors from API client calls made anywhere
+// below it — both imperative client.request() / requestStream() / subscribe()
+// calls and errors that flow through generated hooks (useQuery, useStream,
+// mutate), since those go through useApiClient() which returns the wrapped
+// client when this provider is installed. The wrapped client still throws /
+// re-surfaces errors normally, so per-hook error fields and try/catch keep
+// working — the provider just observes a copy.
+//
+// Read the latest captured error with useApiClientError(); call clear() to
+// dismiss. Only one error is held at a time (newest wins).
+export function ApiClientErrorProvider({ children }: { children: React.ReactNode }) {
+    const [error, setError] = useState<Error | null>(null);
+    const clear = useCallback(() => setError(null), []);
+    const report = useCallback<ApiErrorReporter>((err) => setError(err), []);
+    const state = useMemo<ApiClientErrorState>(() => ({ error, clear }), [error, clear]);
+    return React.createElement(
+        ApiErrorReporterContext.Provider,
+        { value: report },
+        React.createElement(ApiClientErrorContext.Provider, { value: state }, children),
+    );
+}
+
+// useApiClientError returns the latest error captured by the nearest
+// <ApiClientErrorProvider> ancestor and a clear() to reset it. Throws if
+// no provider is mounted above.
+export function useApiClientError(): ApiClientErrorState {
+    const ctx = useContext(ApiClientErrorContext);
+    if (!ctx) {
+        throw new Error('useApiClientError must be used within an ApiClientErrorProvider');
+    }
+    return ctx;
 }
 
 // Connection state hook

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -1208,12 +1208,132 @@ const ApiClientContext = createContext<ApiClient | null>(null);
 
 export const ApiClientProvider = ApiClientContext.Provider;
 
+// ApiErrorReporter is the internal callback an <ApiClientErrorProvider> installs
+// so the wrapped client can report errors up. It is intentionally not exported:
+// callers read the captured error via useApiClientError().
+type ApiErrorReporter = (err: Error) => void;
+const ApiErrorReporterContext = createContext<ApiErrorReporter | null>(null);
+
+// ApiClientErrorState is what useApiClientError() returns: the latest captured
+// error and a clear() to reset it. Only one error is held at a time — newer
+// errors replace older ones.
+export interface ApiClientErrorState {
+    error: Error | null;
+    clear: () => void;
+}
+const ApiClientErrorContext = createContext<ApiClientErrorState | null>(null);
+
+// wrapClientWithErrorReporter returns a Proxy over the ApiClient that reports
+// errors from the three transport entry points (request, subscribe,
+// requestStream) to the provider, then re-throws / re-surfaces them so
+// existing per-hook error handling and try/catch sites keep working. All
+// other methods are returned bound to the original client so `this` stays
+// correct.
+function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter): ApiClient {
+    return new Proxy(client, {
+        get(target, prop) {
+            const value = Reflect.get(target, prop);
+            if (typeof value !== 'function') return value;
+
+            if (prop === 'request') {
+                return function (...args: unknown[]) {
+                    const result = (value as (...a: unknown[]) => Promise<unknown>).apply(target, args);
+                    return result.catch((err: unknown) => {
+                        if (err instanceof Error) report(err);
+                        throw err;
+                    });
+                };
+            }
+            if (prop === 'subscribe') {
+                return function (
+                    method: string,
+                    params: unknown[],
+                    callback: (data: unknown) => void,
+                    onError?: (err: Error) => void,
+                ) {
+                    const wrappedOnError = (err: Error) => {
+                        report(err);
+                        onError?.(err);
+                    };
+                    return (value as (...a: unknown[]) => () => void).apply(
+                        target,
+                        [method, params, callback, wrappedOnError],
+                    );
+                };
+            }
+            if (prop === 'requestStream') {
+                return function (method: string, params: unknown[], options?: unknown) {
+                    const iterable = (value as (...a: unknown[]) => AsyncIterable<unknown>).apply(
+                        target,
+                        [method, params, options],
+                    );
+                    return {
+                        [Symbol.asyncIterator](): AsyncIterator<unknown> {
+                            const inner = iterable[Symbol.asyncIterator]();
+                            return {
+                                async next() {
+                                    try {
+                                        return await inner.next();
+                                    } catch (err) {
+                                        if (err instanceof Error) report(err);
+                                        throw err;
+                                    }
+                                },
+                                return: inner.return ? inner.return.bind(inner) : undefined,
+                                throw: inner.throw ? inner.throw.bind(inner) : undefined,
+                            };
+                        },
+                    };
+                };
+            }
+            return (value as (...a: unknown[]) => unknown).bind(target);
+        },
+    });
+}
+
 export function useApiClient(): ApiClient {
     const client = useContext(ApiClientContext);
     if (!client) {
         throw new Error('useApiClient must be used within an ApiClientProvider');
     }
-    return client;
+    const reporter = useContext(ApiErrorReporterContext);
+    return useMemo(
+        () => (reporter ? wrapClientWithErrorReporter(client, reporter) : client),
+        [client, reporter],
+    );
+}
+
+// ApiClientErrorProvider catches errors from API client calls made anywhere
+// below it — both imperative client.request() / requestStream() / subscribe()
+// calls and errors that flow through generated hooks (useQuery, useStream,
+// mutate), since those go through useApiClient() which returns the wrapped
+// client when this provider is installed. The wrapped client still throws /
+// re-surfaces errors normally, so per-hook error fields and try/catch keep
+// working — the provider just observes a copy.
+//
+// Read the latest captured error with useApiClientError(); call clear() to
+// dismiss. Only one error is held at a time (newest wins).
+export function ApiClientErrorProvider({ children }: { children: React.ReactNode }) {
+    const [error, setError] = useState<Error | null>(null);
+    const clear = useCallback(() => setError(null), []);
+    const report = useCallback<ApiErrorReporter>((err) => setError(err), []);
+    const state = useMemo<ApiClientErrorState>(() => ({ error, clear }), [error, clear]);
+    return React.createElement(
+        ApiErrorReporterContext.Provider,
+        { value: report },
+        React.createElement(ApiClientErrorContext.Provider, { value: state }, children),
+    );
+}
+
+// useApiClientError returns the latest error captured by the nearest
+// <ApiClientErrorProvider> ancestor and a clear() to reset it. Throws if
+// no provider is mounted above.
+export function useApiClientError(): ApiClientErrorState {
+    const ctx = useContext(ApiClientErrorContext);
+    if (!ctx) {
+        throw new Error('useApiClientError must be used within an ApiClientErrorProvider');
+    }
+    return ctx;
 }
 
 // Connection state hook


### PR DESCRIPTION
## Summary

- New opt-in `<ApiClientErrorProvider>` + `useApiClientError()` hook that surface every error from API client calls (imperative + generated hooks) at a single location, eliminating per-call try/catch boilerplate when that's not wanted.
- Inside the provider, `useApiClient()` returns a `Proxy`-wrapped client whose `request`, `subscribe`, and `requestStream` calls report errors to the provider in addition to throwing / re-surfacing them as before. Per-hook `error` fields and explicit `try/catch` keep working — the provider observes a copy, doesn't swallow.
- Generated hooks (`useQuery`, `mutate`, `useStream`) all retrieve their client through `useApiClient()` internally, so their errors flow up too without any per-hook wiring.
- Single-latest-error model with `clear()` to reset (matching the dismissable banner UX).
- Without the provider, `useApiClient()` returns the raw client unchanged and `useApiClientError()` throws — adoption is fully opt-in.

## Implementation

- `templates/_client-common.ts.tmpl` (`react-context` block):
  - New `ApiErrorReporterContext` (internal) and `ApiClientErrorContext` (read via the public hook).
  - New `wrapClientWithErrorReporter(client, report)` Proxy. Wraps three transport entry points; binds everything else through unchanged so `this` stays correct.
  - `useApiClient()` consults the reporter context and `useMemo`s the wrapped client per `(client, reporter)` tuple — preserving reference equality for `useEffect([client])` consumers.
  - New `ApiClientErrorProvider` exported (uses `React.createElement` so the generated file stays `.ts`, not `.tsx`).
  - New `useApiClientError()` exported.
- `example/react/client/src/App.tsx` dogfoods the new provider with a `<GlobalErrorBanner />` so the example app demonstrates the feature.
- Docs updated: `README.md` (new "Catching errors globally with `<ApiClientErrorProvider>`" subsection), `doc.go` (new `# Global Error Capture (TypeScript Client)` section), `APROT_AI.md` (new Pattern 3).

## Verification

- [x] `go test ./...` — pass
- [x] `gofmt -l .` — clean
- [x] `cd example/react/tools/generate && go run main.go` then `cd example/react/client && npx tsc --noEmit` — pass
- [x] `cd example/vanilla/tools/generate && go run main.go` — vanilla output unchanged (the new code is gated to the `react-context` template block)
- [x] Manual smoke via the dogfooded `App.tsx` (build the example, kill the server mid-session, confirm the banner shows the resulting `ConnectionError` and `Dismiss` clears it)

## Test plan
- [ ] Reviewer: run `cd example/react/server && go run .` + `cd example/react/client && npm run dev`, exercise CreateUser with empty fields (validation error) and confirm banner shows
- [ ] Reviewer: kill server mid-session, confirm banner shows `ConnectionError` and `Dismiss` resets
- [ ] Reviewer: confirm per-hook `useListUsers().error` and per-form local error state still work alongside the global banner

## Out of scope (follow-up if wanted)

A formal automated React test was scoped out: the existing `e2e/` setup is vanilla-only, so adding a single `.test.tsx` would have meant pulling in `react`, `react-dom`, `@testing-library/react`, `happy-dom`, JSX config, and a separate React generator. Happy to do that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)