### PR TITLE
Expose call source (struct + method) on useApiClientError

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -337,13 +337,21 @@ function App() {
 }
 
 function ErrorBanner() {
-  const { error, clear } = useApiClientError();
+  const { error, source, clear } = useApiClientError();
   if (!error) return null;
-  return <div role="alert">{error.message} <button onClick={clear}>Dismiss</button></div>;
+  const where = source ? `${source.struct}.${source.method}` : null;
+  return (
+    <div role="alert">
+      {where ? <strong>Error in {where}: </strong> : null}
+      {error.message} <button onClick={clear}>Dismiss</button>
+    </div>
+  );
 }
 ```
 
-Latest error wins (newer replaces older); `clear()` resets to `null`. The provider does **not** swallow — calls still throw, so `try/catch` and per-hook `error` fields keep working. Without an `<ApiClientErrorProvider>` above, `useApiClient()` returns the raw client and `useApiClientError()` throws — adoption is fully opt-in.
+`source: { struct, method } | null` is parsed from the wire name on the first dot — `'Todos.CreateTodo'` becomes `{ struct: 'Todos', method: 'CreateTodo' }`. It is `null` exactly when `error` is `null`. Wire names with no dot put the full string in `method` and leave `struct` as `''`.
+
+Latest error wins (newer replaces older); `clear()` resets both `error` and `source` to `null`. The provider does **not** swallow — calls still throw, so `try/catch` and per-hook `error` fields keep working. Without an `<ApiClientErrorProvider>` above, `useApiClient()` returns the raw client and `useApiClientError()` throws — adoption is fully opt-in.
 
 ### Migrating from `useXxxMutation()` (removed)
 

--- a/README.md
+++ b/README.md
@@ -461,10 +461,12 @@ function App() {
 }
 
 function ErrorBanner() {
-    const { error, clear } = useApiClientError();
+    const { error, source, clear } = useApiClientError();
     if (!error) return null;
+    const where = source ? `${source.struct}.${source.method}` : null;
     return (
         <div role="alert">
+            {where ? <strong>Error in {where}: </strong> : null}
             {error.message} <button onClick={clear}>Dismiss</button>
         </div>
     );
@@ -472,6 +474,8 @@ function ErrorBanner() {
 ```
 
 Inside the provider, `useApiClient()` returns a `Proxy`-wrapped client whose `request`, `subscribe`, and `requestStream` calls report errors to the provider — in addition to throwing / re-surfacing them as before. Generated hooks (`useListUsers`, `useQuery`, `mutate`, `useStream`) all retrieve their client through `useApiClient()` internally, so their errors flow up too without any per-hook wiring.
+
+Alongside `error`, `useApiClientError()` returns a `source: { struct, method } | null` parsed from the wire name (e.g. `'Todos.CreateTodo'` → `{ struct: 'Todos', method: 'CreateTodo' }`), so a banner can name the call that failed. `source` is `null` exactly when `error` is `null`. If a caller invokes the client with a wire name that has no dot, `struct` is `''` and `method` holds the full name.
 
 Only the latest error is held; `clear()` resets it. The provider observes errors but does **not** swallow them — wrapped client calls still throw, so per-hook `error` fields and explicit `try/catch` keep working. Without an `<ApiClientErrorProvider>` above, `useApiClient()` returns the raw client unchanged and `useApiClientError()` throws — adoption is fully opt-in.
 

--- a/doc.go
+++ b/doc.go
@@ -476,13 +476,21 @@
 //
 // Read with useApiClientError():
 //
-//	const { error, clear } = useApiClientError();
+//	const { error, source, clear } = useApiClientError();
+//	// source is { struct, method } | null — null exactly when error is null.
+//	// A failure from client.request('Todos.CreateTodo', …) yields
+//	// source = { struct: 'Todos', method: 'CreateTodo' }, so a banner can
+//	// name the failing call without each call site reporting itself.
 //
-// Only the latest error is held (newer overrides older); clear() resets it.
-// The provider observes errors but does not swallow them — wrapped client
-// calls still throw, so per-hook `error` fields and explicit try/catch keep
-// working. Without <ApiClientErrorProvider> above, useApiClient() returns the
-// raw client unchanged and useApiClientError() throws — adoption is opt-in.
+// The source is parsed from the wire name on the first dot. Calls whose wire
+// name has no dot set struct to ” and put the full name in method.
+//
+// Only the latest error is held (newer overrides older); clear() resets both
+// error and source. The provider observes errors but does not swallow them —
+// wrapped client calls still throw, so per-hook `error` fields and explicit
+// try/catch keep working. Without <ApiClientErrorProvider> above,
+// useApiClient() returns the raw client unchanged and useApiClientError()
+// throws — adoption is opt-in.
 //
 // # React Suspense
 //

--- a/example/react/client/src/App.tsx
+++ b/example/react/client/src/App.tsx
@@ -726,8 +726,9 @@ function EventLog({ logs, onClear }: { logs: { message: string; type: string; ti
 // (useListUsers, useNumbers, etc.) — flows through here, so apps that don't
 // want per-call try/catch can rely on this single surface.
 function GlobalErrorBanner() {
-  const { error, clear } = useApiClientError()
+  const { error, source, clear } = useApiClientError()
   if (!error) return null
+  const where = source ? `${source.struct}.${source.method}` : null
   return (
     <div
       style={{
@@ -743,7 +744,9 @@ function GlobalErrorBanner() {
         gap: 12,
       }}
     >
-      <span><strong>API error:</strong> {error.message}</span>
+      <span>
+        <strong>API error{where ? ` in ${where}` : ''}:</strong> {error.message}
+      </span>
       <button onClick={clear} style={{ padding: '2px 10px' }}>Dismiss</button>
     </div>
   )

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -1186,17 +1186,37 @@ const ApiClientContext = createContext<ApiClient | null>(null);
 
 export const ApiClientProvider = ApiClientContext.Provider;
 
+// ApiClientErrorSource identifies which generated call produced an error. The
+// wire name of every generated call is "Struct.Method" (e.g. "Todos.CreateTodo"),
+// so struct names the handler/namespace and method names the operation. If a
+// caller invokes the client with a name that has no dot, struct is the empty
+// string and method holds the full wire name.
+export interface ApiClientErrorSource {
+    struct: string;
+    method: string;
+}
+
+// parseMethodSource splits a "Struct.Method" wire name into the source object
+// reported to <ApiClientErrorProvider>. Split on the first dot only.
+function parseMethodSource(wireMethod: string): ApiClientErrorSource {
+    const dot = wireMethod.indexOf('.');
+    if (dot < 0) return { struct: '', method: wireMethod };
+    return { struct: wireMethod.slice(0, dot), method: wireMethod.slice(dot + 1) };
+}
+
 // ApiErrorReporter is the internal callback an <ApiClientErrorProvider> installs
 // so the wrapped client can report errors up. It is intentionally not exported:
 // callers read the captured error via useApiClientError().
-type ApiErrorReporter = (err: Error) => void;
+type ApiErrorReporter = (err: Error, source: ApiClientErrorSource) => void;
 const ApiErrorReporterContext = createContext<ApiErrorReporter | null>(null);
 
 // ApiClientErrorState is what useApiClientError() returns: the latest captured
-// error and a clear() to reset it. Only one error is held at a time — newer
-// errors replace older ones.
+// error, the source (struct + method) of the call that produced it, and a
+// clear() to reset it. Only one error is held at a time — newer errors replace
+// older ones. source is null exactly when error is null.
 export interface ApiClientErrorState {
     error: Error | null;
+    source: ApiClientErrorSource | null;
     clear: () => void;
 }
 const ApiClientErrorContext = createContext<ApiClientErrorState | null>(null);
@@ -1215,9 +1235,10 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
 
             if (prop === 'request') {
                 return function (...args: unknown[]) {
+                    const wireMethod = typeof args[0] === 'string' ? args[0] : '';
                     const result = (value as (...a: unknown[]) => Promise<unknown>).apply(target, args);
                     return result.catch((err: unknown) => {
-                        if (err instanceof Error) report(err);
+                        if (err instanceof Error) report(err, parseMethodSource(wireMethod));
                         throw err;
                     });
                 };
@@ -1229,8 +1250,9 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
                     callback: (data: unknown) => void,
                     onError?: (err: Error) => void,
                 ) {
+                    const source = parseMethodSource(method);
                     const wrappedOnError = (err: Error) => {
-                        report(err);
+                        report(err, source);
                         onError?.(err);
                     };
                     return (value as (...a: unknown[]) => () => void).apply(
@@ -1241,6 +1263,7 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
             }
             if (prop === 'requestStream') {
                 return function (method: string, params: unknown[], options?: unknown) {
+                    const source = parseMethodSource(method);
                     const iterable = (value as (...a: unknown[]) => AsyncIterable<unknown>).apply(
                         target,
                         [method, params, options],
@@ -1253,7 +1276,7 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
                                     try {
                                         return await inner.next();
                                     } catch (err) {
-                                        if (err instanceof Error) report(err);
+                                        if (err instanceof Error) report(err, source);
                                         throw err;
                                     }
                                 },
@@ -1290,12 +1313,24 @@ export function useApiClient(): ApiClient {
 // working — the provider just observes a copy.
 //
 // Read the latest captured error with useApiClientError(); call clear() to
-// dismiss. Only one error is held at a time (newest wins).
+// dismiss. Only one error is held at a time (newest wins). The captured state
+// also exposes the source — `{ struct, method }` parsed from the wire name —
+// so a banner can say "Error in Todos.CreateTodo" instead of just the message.
 export function ApiClientErrorProvider({ children }: { children: React.ReactNode }) {
     const [error, setError] = useState<Error | null>(null);
-    const clear = useCallback(() => setError(null), []);
-    const report = useCallback<ApiErrorReporter>((err) => setError(err), []);
-    const state = useMemo<ApiClientErrorState>(() => ({ error, clear }), [error, clear]);
+    const [source, setSource] = useState<ApiClientErrorSource | null>(null);
+    const clear = useCallback(() => {
+        setError(null);
+        setSource(null);
+    }, []);
+    const report = useCallback<ApiErrorReporter>((err, src) => {
+        setError(err);
+        setSource(src);
+    }, []);
+    const state = useMemo<ApiClientErrorState>(
+        () => ({ error, source, clear }),
+        [error, source, clear],
+    );
     return React.createElement(
         ApiErrorReporterContext.Provider,
         { value: report },

--- a/generate_test.go
+++ b/generate_test.go
@@ -446,6 +446,40 @@ func TestGenerateReact(t *testing.T) {
 	}
 }
 
+func TestGenerateReactErrorProviderSource(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&TestHandlers{})
+
+	gen := NewGenerator(registry).WithOptions(GeneratorOptions{
+		Mode: OutputReact,
+	})
+
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	output := buf.String()
+
+	if !strings.Contains(output, "export interface ApiClientErrorSource") {
+		t.Error("Missing ApiClientErrorSource interface")
+	}
+	if !strings.Contains(output, "struct: string") {
+		t.Error("ApiClientErrorSource should expose `struct: string`")
+	}
+	if !strings.Contains(output, "method: string") {
+		t.Error("ApiClientErrorSource should expose `method: string`")
+	}
+	if !strings.Contains(output, "source: ApiClientErrorSource | null") {
+		t.Error("ApiClientErrorState should expose `source: ApiClientErrorSource | null`")
+	}
+	if !strings.Contains(output, "ApiErrorReporter = (err: Error, source: ApiClientErrorSource) => void") {
+		t.Error("ApiErrorReporter should carry the ApiClientErrorSource alongside the error")
+	}
+	if !strings.Contains(output, "parseMethodSource") {
+		t.Error("Expected a parseMethodSource helper that splits 'Struct.Method' into source")
+	}
+}
+
 func TestGenerateReactMultiFileGenericHooks(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&TestHandlers{})

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -1208,17 +1208,37 @@ const ApiClientContext = createContext<ApiClient | null>(null);
 
 export const ApiClientProvider = ApiClientContext.Provider;
 
+// ApiClientErrorSource identifies which generated call produced an error. The
+// wire name of every generated call is "Struct.Method" (e.g. "Todos.CreateTodo"),
+// so struct names the handler/namespace and method names the operation. If a
+// caller invokes the client with a name that has no dot, struct is the empty
+// string and method holds the full wire name.
+export interface ApiClientErrorSource {
+    struct: string;
+    method: string;
+}
+
+// parseMethodSource splits a "Struct.Method" wire name into the source object
+// reported to <ApiClientErrorProvider>. Split on the first dot only.
+function parseMethodSource(wireMethod: string): ApiClientErrorSource {
+    const dot = wireMethod.indexOf('.');
+    if (dot < 0) return { struct: '', method: wireMethod };
+    return { struct: wireMethod.slice(0, dot), method: wireMethod.slice(dot + 1) };
+}
+
 // ApiErrorReporter is the internal callback an <ApiClientErrorProvider> installs
 // so the wrapped client can report errors up. It is intentionally not exported:
 // callers read the captured error via useApiClientError().
-type ApiErrorReporter = (err: Error) => void;
+type ApiErrorReporter = (err: Error, source: ApiClientErrorSource) => void;
 const ApiErrorReporterContext = createContext<ApiErrorReporter | null>(null);
 
 // ApiClientErrorState is what useApiClientError() returns: the latest captured
-// error and a clear() to reset it. Only one error is held at a time — newer
-// errors replace older ones.
+// error, the source (struct + method) of the call that produced it, and a
+// clear() to reset it. Only one error is held at a time — newer errors replace
+// older ones. source is null exactly when error is null.
 export interface ApiClientErrorState {
     error: Error | null;
+    source: ApiClientErrorSource | null;
     clear: () => void;
 }
 const ApiClientErrorContext = createContext<ApiClientErrorState | null>(null);
@@ -1237,9 +1257,10 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
 
             if (prop === 'request') {
                 return function (...args: unknown[]) {
+                    const wireMethod = typeof args[0] === 'string' ? args[0] : '';
                     const result = (value as (...a: unknown[]) => Promise<unknown>).apply(target, args);
                     return result.catch((err: unknown) => {
-                        if (err instanceof Error) report(err);
+                        if (err instanceof Error) report(err, parseMethodSource(wireMethod));
                         throw err;
                     });
                 };
@@ -1251,8 +1272,9 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
                     callback: (data: unknown) => void,
                     onError?: (err: Error) => void,
                 ) {
+                    const source = parseMethodSource(method);
                     const wrappedOnError = (err: Error) => {
-                        report(err);
+                        report(err, source);
                         onError?.(err);
                     };
                     return (value as (...a: unknown[]) => () => void).apply(
@@ -1263,6 +1285,7 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
             }
             if (prop === 'requestStream') {
                 return function (method: string, params: unknown[], options?: unknown) {
+                    const source = parseMethodSource(method);
                     const iterable = (value as (...a: unknown[]) => AsyncIterable<unknown>).apply(
                         target,
                         [method, params, options],
@@ -1275,7 +1298,7 @@ function wrapClientWithErrorReporter(client: ApiClient, report: ApiErrorReporter
                                     try {
                                         return await inner.next();
                                     } catch (err) {
-                                        if (err instanceof Error) report(err);
+                                        if (err instanceof Error) report(err, source);
                                         throw err;
                                     }
                                 },
@@ -1312,12 +1335,24 @@ export function useApiClient(): ApiClient {
 // working — the provider just observes a copy.
 //
 // Read the latest captured error with useApiClientError(); call clear() to
-// dismiss. Only one error is held at a time (newest wins).
+// dismiss. Only one error is held at a time (newest wins). The captured state
+// also exposes the source — `{ struct, method }` parsed from the wire name —
+// so a banner can say "Error in Todos.CreateTodo" instead of just the message.
 export function ApiClientErrorProvider({ children }: { children: React.ReactNode }) {
     const [error, setError] = useState<Error | null>(null);
-    const clear = useCallback(() => setError(null), []);
-    const report = useCallback<ApiErrorReporter>((err) => setError(err), []);
-    const state = useMemo<ApiClientErrorState>(() => ({ error, clear }), [error, clear]);
+    const [source, setSource] = useState<ApiClientErrorSource | null>(null);
+    const clear = useCallback(() => {
+        setError(null);
+        setSource(null);
+    }, []);
+    const report = useCallback<ApiErrorReporter>((err, src) => {
+        setError(err);
+        setSource(src);
+    }, []);
+    const state = useMemo<ApiClientErrorState>(
+        () => ({ error, source, clear }),
+        [error, source, clear],
+    );
     return React.createElement(
         ApiErrorReporterContext.Provider,
         { value: report },


### PR DESCRIPTION
## Summary
- `useApiClientError()` now returns `source: { struct, method } | null` alongside `error`, parsed from the wire name on the first dot (e.g. `'Todos.CreateTodo'` → `{ struct: 'Todos', method: 'CreateTodo' }`). `source` is `null` exactly when `error` is `null`; `clear()` resets both.
- The `<ApiClientErrorProvider>`'s reporter is threaded through the proxy at `request` / `subscribe` / `requestStream` so both generated hooks and imperative client calls carry the source. Wire names without a dot put the full string in `method` and leave `struct` as `''`.
- Example banner updated to read `API error in Todos.CreateTodo: …`; `README.md`, `doc.go`, and `APROT_AI.md` updated per repo rules.

## Test plan
- [x] `go test ./...`
- [x] `npx tsc --noEmit` on `example/react/client`
- [x] New `TestGenerateReactErrorProviderSource` asserts the generated client exposes `ApiClientErrorSource`, the new state shape, the updated reporter signature, and the `parseMethodSource` helper
- [ ] Manually trigger a failing request in the React example and confirm the banner labels the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)