### PR TITLE
Add opt-in start/end hooks to tasks.Enable

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -49,6 +49,10 @@ gen.Generate()
 - Hierarchical: `tasks.SubTask(ctx, title, fn)`.
 - Server-wide: `tasks.StartSharedTask[Meta](ctx, title)`.
 - Enable: `tasks.Enable(registry)` before generation/serving.
+- Lifecycle hooks (opt-in): `tasks.Enable(registry, tasks.WithTaskStartHook(fn), tasks.WithTaskEndHook(fn))`.
+  - `TaskStartHook(ctx, id, title, parentID) ctx` — fires when a task transitions to Running. Returned `ctx` propagates to handler + subtasks; use it to attach the title to your logger.
+  - `TaskEndHook(ctx, id, title, parentID, err)` — fires once per task on completion or failure. `err` is non-nil on failure; cancellation surfaces as `err.Error() == "canceled"`. The `ctx` passed in is the one returned by the start hook.
+  - Both hooks fire for root tasks and subtasks. `parentID` is empty for root tasks. `Task.SubTask` / `TaskSub.SubTask` (no ctx parameter) call the start hook with `context.Background`; use the package-level `tasks.SubTask(ctx, ...)` to retain context propagation.
 
 ## Handlers
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Push events** — broadcast to all clients or target specific users
 - **Hierarchical tasks** — nested task trees with progress tracking, streamed to clients (see [`tasks`](https://pkg.go.dev/github.com/marrasen/aprot/tasks) subpackage)
 - **Shared tasks** — server-wide tasks visible to all clients with typed metadata
+- **Task lifecycle hooks** — opt-in `WithTaskStartHook`/`WithTaskEndHook` callbacks observe every task start/end (root and subtasks); the start hook decorates `ctx` so the title flows into your logger of choice (slog, zap, zerolog, …)
 - **Progress reporting** — built-in support for long-running operations
 - **Request cancellation** — clients cancel via AbortController; handlers see cancel cause
 - **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting

--- a/example/react/api/registry.go
+++ b/example/react/api/registry.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"context"
+	"log"
+
 	"github.com/marrasen/aprot"
 	"github.com/marrasen/aprot/tasks"
 )
@@ -31,8 +34,28 @@ func NewRegistry() (*aprot.Registry, *Handlers, *Todos) {
 	registry.RegisterPushEventFor(handlers, UserUpdatedEvent{})
 	registry.RegisterPushEventFor(handlers, SystemNotificationEvent{})
 
-	// Enable shared tasks with typed metadata
-	tasks.EnableWithMeta[TaskMeta](registry)
+	// Enable shared tasks with typed metadata.
+	// Lifecycle hooks log every task's start and end with title — root tasks
+	// and subtasks both fire. Swap log.Printf for slog / zap / zerolog as
+	// needed; the start hook can also decorate ctx so downstream handler
+	// logs pick up the title automatically.
+	tasks.EnableWithMeta[TaskMeta](registry,
+		tasks.WithTaskStartHook(func(ctx context.Context, id, title, parentID string) context.Context {
+			if parentID == "" {
+				log.Printf("[task] started id=%s title=%q", id, title)
+			} else {
+				log.Printf("[task] started id=%s title=%q parent=%s", id, title, parentID)
+			}
+			return ctx
+		}),
+		tasks.WithTaskEndHook(func(ctx context.Context, id, title, parentID string, err error) {
+			if err != nil {
+				log.Printf("[task] failed id=%s title=%q err=%v", id, title, err)
+				return
+			}
+			log.Printf("[task] completed id=%s title=%q", id, title)
+		}),
+	)
 
 	return registry, handlers, todos
 }

--- a/example/vanilla/api/registry.go
+++ b/example/vanilla/api/registry.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"context"
+	"log"
+
 	"github.com/marrasen/aprot"
 	"github.com/marrasen/aprot/tasks"
 )
@@ -32,8 +35,28 @@ func NewRegistry(state *SharedState, authMiddleware aprot.Middleware) *aprot.Reg
 	registry.RegisterPushEventFor(protectedHandlers, DirectMessageEvent{})
 
 	// Enable shared tasks with typed metadata
-	// (registers TaskStateEvent, TaskUpdateEvent, CancelTask handler)
-	tasks.EnableWithMeta[TaskMeta](registry)
+	// (registers TaskStateEvent, TaskUpdateEvent, CancelTask handler).
+	// Lifecycle hooks log every task's start and end with title — root tasks
+	// and subtasks both fire. Swap log.Printf for slog / zap / zerolog as
+	// needed; the start hook can also decorate ctx so downstream handler
+	// logs pick up the title automatically.
+	tasks.EnableWithMeta[TaskMeta](registry,
+		tasks.WithTaskStartHook(func(ctx context.Context, id, title, parentID string) context.Context {
+			if parentID == "" {
+				log.Printf("[task] started id=%s title=%q", id, title)
+			} else {
+				log.Printf("[task] started id=%s title=%q parent=%s", id, title, parentID)
+			}
+			return ctx
+		}),
+		tasks.WithTaskEndHook(func(ctx context.Context, id, title, parentID string, err error) {
+			if err != nil {
+				log.Printf("[task] failed id=%s title=%q err=%v", id, title, err)
+				return
+			}
+			log.Printf("[task] completed id=%s title=%q", id, title)
+		}),
+	)
 
 	return registry
 }

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -81,8 +81,13 @@ func (t *Task[M]) Err(err error) {
 }
 
 // SubTask creates a child node under this task.
+//
+// This entry point has no caller-supplied context, so the start hook (if
+// installed) is called with [context.Background]. Use the package-level
+// [SubTask] to retain context propagation into the start hook.
 func (t *Task[M]) SubTask(title string) *TaskSub[M] {
 	child := t.node.createChild(title)
+	child.fireStart(context.Background())
 	return &TaskSub[M]{node: child}
 }
 
@@ -138,8 +143,13 @@ func (s *TaskSub[M]) SetMeta(v M) {
 }
 
 // SubTask creates a child node under this sub-task.
+//
+// This entry point has no caller-supplied context, so the start hook (if
+// installed) is called with [context.Background]. Use the package-level
+// [SubTask] to retain context propagation into the start hook.
 func (s *TaskSub[M]) SubTask(title string) *TaskSub[M] {
 	child := s.node.createChild(title)
+	child.fireStart(context.Background())
 	return &TaskSub[M]{node: child}
 }
 
@@ -171,6 +181,7 @@ func SubTask(ctx context.Context, title string, fn func(ctx context.Context) err
 
 	child := parent.createChild(title)
 	childCtx := withTaskNode(ctx, child)
+	childCtx = child.fireStart(childCtx)
 	err := fn(childCtx)
 
 	if err != nil {
@@ -236,6 +247,7 @@ func OutputWriter(ctx context.Context, title string) io.WriteCloser {
 	}
 
 	child := parent.createChild(title)
+	child.fireStart(ctx)
 	return &outputWriter{node: child}
 }
 
@@ -262,6 +274,7 @@ func WriterProgress(ctx context.Context, title string, size int) io.WriteCloser 
 	child.mu.Lock()
 	child.total = size
 	child.mu.Unlock()
+	child.fireStart(ctx)
 	return &progressWriter{node: child, total: size}
 }
 
@@ -296,6 +309,7 @@ func startRequestTask[M any](ctx context.Context, title string) (context.Context
 		id:       d.allocID(),
 		title:    title,
 		status:   TaskNodeStatusCreated,
+		hooks:    rd.hooks,
 	}
 	root.addChild(node)
 
@@ -307,6 +321,7 @@ func startRequestTask[M any](ctx context.Context, title string) (context.Context
 	d.sendSnapshot(nil)
 
 	node.setStatus(TaskNodeStatusRunning)
+	ctx = node.fireStart(ctx)
 	return ctx, &Task[M]{node: node}
 }
 
@@ -332,6 +347,7 @@ func startSharedTask[M any](ctx context.Context, title string) (context.Context,
 	// Use the task's own cancellable context, with delivery and node set.
 	taskCtx := withDelivery(node.ctx, node.delivery)
 	taskCtx = withTaskNode(taskCtx, node)
+	taskCtx = node.fireStart(taskCtx)
 
 	return taskCtx, &Task[M]{node: node}
 }
@@ -361,6 +377,7 @@ func SharedSubTask(ctx context.Context, title string, fn func(ctx context.Contex
 
 	childCtx := withDelivery(node.ctx, node.delivery)
 	childCtx = withTaskNode(childCtx, node)
+	childCtx = node.fireStart(childCtx)
 
 	err := SubTask(childCtx, title, fn)
 

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -82,12 +82,13 @@ func (t *Task[M]) Err(err error) {
 
 // SubTask creates a child node under this task.
 //
-// This entry point has no caller-supplied context, so the start hook (if
-// installed) is called with [context.Background]. Use the package-level
-// [SubTask] to retain context propagation into the start hook.
+// Because this entry point takes no context parameter, the lifecycle hooks
+// inherit the parent task's context — the same context used for the
+// parent's hooks. Use the package-level [SubTask] when you need a derived
+// context returned to your handler code.
 func (t *Task[M]) SubTask(title string) *TaskSub[M] {
 	child := t.node.createChild(title)
-	child.fireStart(context.Background())
+	child.fireStart(t.node.currentCtx())
 	return &TaskSub[M]{node: child}
 }
 
@@ -144,12 +145,13 @@ func (s *TaskSub[M]) SetMeta(v M) {
 
 // SubTask creates a child node under this sub-task.
 //
-// This entry point has no caller-supplied context, so the start hook (if
-// installed) is called with [context.Background]. Use the package-level
-// [SubTask] to retain context propagation into the start hook.
+// Because this entry point takes no context parameter, the lifecycle hooks
+// inherit the parent sub-task's context — the same context used for the
+// parent's hooks. Use the package-level [SubTask] when you need a derived
+// context returned to your handler code.
 func (s *TaskSub[M]) SubTask(title string) *TaskSub[M] {
 	child := s.node.createChild(title)
-	child.fireStart(context.Background())
+	child.fireStart(s.node.currentCtx())
 	return &TaskSub[M]{node: child}
 }
 

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -83,7 +83,7 @@ func (t *Task[M]) Err(err error) {
 // SubTask creates a child node under this task.
 //
 // Because this entry point takes no context parameter, the lifecycle hooks
-// inherit the parent task's context — the same context used for the
+// inherit the parent task's context, the same context used for the
 // parent's hooks. Use the package-level [SubTask] when you need a derived
 // context returned to your handler code.
 func (t *Task[M]) SubTask(title string) *TaskSub[M] {

--- a/tasks/delivery.go
+++ b/tasks/delivery.go
@@ -24,10 +24,11 @@ type requestDelivery struct {
 	requestID string
 	nextID    atomic.Int64
 	root      *taskNode // lazily created implicit root
+	hooks     *enableOptions
 }
 
-func newRequestDelivery(conn *aprot.Conn, requestID string) *requestDelivery {
-	return &requestDelivery{conn: conn, requestID: requestID}
+func newRequestDelivery(conn *aprot.Conn, requestID string, hooks *enableOptions) *requestDelivery {
+	return &requestDelivery{conn: conn, requestID: requestID, hooks: hooks}
 }
 
 func (d *requestDelivery) sendSnapshot(_ *taskNode) {

--- a/tasks/doc.go
+++ b/tasks/doc.go
@@ -26,6 +26,33 @@
 // This registers the CancelTask handler, push event types, and the
 // middleware that wires task delivery into every request context.
 //
+// # Lifecycle hooks
+//
+// Pass [WithTaskStartHook] and/or [WithTaskEndHook] to observe every task's
+// start and end (root tasks and subtasks). The start hook can decorate the
+// task's context — the returned context is propagated to the handler and
+// any nested subtasks, so callbacks downstream (logging, tracing) see the
+// task title automatically:
+//
+//	tasks.Enable(registry,
+//	    tasks.WithTaskStartHook(func(ctx context.Context, id, title, parent string) context.Context {
+//	        logger := slog.With("task_id", id, "task_title", title)
+//	        return ctxlog.With(ctx, logger)
+//	    }),
+//	    tasks.WithTaskEndHook(func(ctx context.Context, id, title, parent string, err error) {
+//	        if err != nil {
+//	            slog.ErrorContext(ctx, "task failed", "err", err)
+//	        } else {
+//	            slog.InfoContext(ctx, "task completed")
+//	        }
+//	    }),
+//	)
+//
+// The end hook receives the context returned by the start hook, so the
+// decorated logger / span is available on completion too. Hooks fire at most
+// once per task per phase (start, end). Cancellation surfaces as a non-nil
+// err with message "canceled".
+//
 // # Request-scoped tasks
 //
 // Create a task inside a handler. It auto-completes when the handler

--- a/tasks/enable.go
+++ b/tasks/enable.go
@@ -14,8 +14,11 @@ func (h *tasksHandler) CancelTask(ctx context.Context, taskId string) error {
 	return CancelSharedTask(ctx, taskId)
 }
 
-// Enable registers the shared task system with the registry.
-func Enable(r *aprot.Registry) {
+// Enable registers the shared task system with the registry. Pass options
+// such as [WithTaskStartHook] or [WithTaskEndHook] to observe task lifecycle
+// events.
+func Enable(r *aprot.Registry, opts ...EnableOption) {
+	o := buildEnableOptions(opts)
 	handler := &tasksHandler{}
 	r.Register(handler)
 	r.RegisterEnumFor(handler, TaskNodeStatusValues())
@@ -28,7 +31,7 @@ func Enable(r *aprot.Registry) {
 		appendTaskConvenienceCode(results, mode, nil)
 	})
 	r.OnServerInit(func(s *aprot.Server) {
-		tm := newTaskManager(s)
+		tm := newTaskManager(s, o)
 		s.Use(taskMiddleware(tm))
 		s.OnConnect(func(ctx context.Context, conn *aprot.Conn) error {
 			states := tm.snapshotAllForConn(conn.ID())
@@ -41,8 +44,11 @@ func Enable(r *aprot.Registry) {
 	})
 }
 
-// EnableWithMeta registers the shared task system with typed metadata.
-func EnableWithMeta[M any](r *aprot.Registry) {
+// EnableWithMeta registers the shared task system with typed metadata. Pass
+// options such as [WithTaskStartHook] or [WithTaskEndHook] to observe task
+// lifecycle events.
+func EnableWithMeta[M any](r *aprot.Registry, opts ...EnableOption) {
+	o := buildEnableOptions(opts)
 	metaType := reflect.TypeFor[M]()
 	handler := &tasksHandler{}
 	r.Register(handler)
@@ -56,7 +62,7 @@ func EnableWithMeta[M any](r *aprot.Registry) {
 		appendTaskConvenienceCode(results, mode, metaType)
 	})
 	r.OnServerInit(func(s *aprot.Server) {
-		tm := newTaskManager(s)
+		tm := newTaskManager(s, o)
 		s.Use(taskMiddleware(tm))
 		s.OnConnect(func(ctx context.Context, conn *aprot.Conn) error {
 			states := tm.snapshotAllForConn(conn.ID())

--- a/tasks/interceptor.go
+++ b/tasks/interceptor.go
@@ -15,7 +15,7 @@ func taskMiddleware(tm *taskManager) aprot.Middleware {
 			if conn == nil {
 				return next(ctx, req)
 			}
-			d := newRequestDelivery(conn, req.ID)
+			d := newRequestDelivery(conn, req.ID, tm.hooks)
 			ctx = withDelivery(ctx, d)
 			slot := &taskSlot{}
 			ctx = withTaskSlot(ctx, slot)

--- a/tasks/options.go
+++ b/tasks/options.go
@@ -1,0 +1,70 @@
+package tasks
+
+import "context"
+
+// TaskStartHook is called when a task transitions into the Running state
+// (root task or subtask). The returned context replaces the task's context
+// for the lifetime of the task — return ctx unchanged to keep it as-is, or
+// return a derived context to attach the title to your structured logger,
+// trace span, or other context-aware machinery.
+//
+// parentID is empty for root tasks; for subtasks it is the ID of the parent
+// node. Hooks run synchronously on the caller goroutine — keep them fast and
+// non-blocking.
+type TaskStartHook func(ctx context.Context, id, title, parentID string) context.Context
+
+// TaskEndHook is called exactly once per task when it terminates. err is nil
+// on success and non-nil on failure (cancellation surfaces as a non-nil err
+// with message "canceled"). Hooks run synchronously on the caller goroutine.
+//
+// parentID is empty for root tasks.
+type TaskEndHook func(ctx context.Context, id, title, parentID string, err error)
+
+// EnableOption configures the task system at registration time. Pass options
+// to [Enable] or [EnableWithMeta].
+type EnableOption func(*enableOptions)
+
+type enableOptions struct {
+	onStart TaskStartHook
+	onEnd   TaskEndHook
+}
+
+func buildEnableOptions(opts []EnableOption) *enableOptions {
+	o := &enableOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(o)
+		}
+	}
+	return o
+}
+
+// WithTaskStartHook installs hook h, called whenever a task starts. The
+// returned context replaces the task's context for the rest of its lifetime
+// (including subtasks). Use it to attach the task title to your logger:
+//
+//	tasks.Enable(registry, tasks.WithTaskStartHook(
+//	    func(ctx context.Context, id, title, parentID string) context.Context {
+//	        logger := slog.With("task_id", id, "task_title", title)
+//	        return ctxlog.With(ctx, logger)
+//	    },
+//	))
+func WithTaskStartHook(h TaskStartHook) EnableOption {
+	return func(o *enableOptions) { o.onStart = h }
+}
+
+// WithTaskEndHook installs hook h, called whenever a task ends. err is nil on
+// success, non-nil on failure (including cancellation):
+//
+//	tasks.Enable(registry, tasks.WithTaskEndHook(
+//	    func(ctx context.Context, id, title, parentID string, err error) {
+//	        if err != nil {
+//	            slog.ErrorContext(ctx, "task failed", "id", id, "title", title, "err", err)
+//	            return
+//	        }
+//	        slog.InfoContext(ctx, "task completed", "id", id, "title", title)
+//	    },
+//	))
+func WithTaskEndHook(h TaskEndHook) EnableOption {
+	return func(o *enableOptions) { o.onEnd = h }
+}

--- a/tasks/options_test.go
+++ b/tasks/options_test.go
@@ -1,0 +1,456 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/marrasen/aprot"
+)
+
+// hookEvent is one captured invocation of either start or end hook.
+type hookEvent struct {
+	kind     string // "start" or "end"
+	id       string
+	title    string
+	parentID string
+	err      error
+	ctxValue any // value pulled from ctx with key probeKey, if any
+}
+
+// recorder collects hook invocations from concurrent goroutines.
+type recorder struct {
+	mu     sync.Mutex
+	events []hookEvent
+}
+
+func (r *recorder) snapshot() []hookEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]hookEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+type probeKeyType struct{}
+
+var probeKey probeKeyType
+
+// makeRecorder builds an enableOptions with both hooks installed; the start
+// hook also stores a marker on ctx so we can verify the decorated ctx
+// reaches the end hook.
+func makeRecorder() (*recorder, *enableOptions) {
+	r := &recorder{}
+	opts := buildEnableOptions([]EnableOption{
+		WithTaskStartHook(func(ctx context.Context, id, title, parent string) context.Context {
+			r.mu.Lock()
+			r.events = append(r.events, hookEvent{
+				kind: "start", id: id, title: title, parentID: parent,
+				ctxValue: ctx.Value(probeKey),
+			})
+			r.mu.Unlock()
+			return context.WithValue(ctx, probeKey, "decorated:"+id)
+		}),
+		WithTaskEndHook(func(ctx context.Context, id, title, parent string, err error) {
+			r.mu.Lock()
+			r.events = append(r.events, hookEvent{
+				kind: "end", id: id, title: title, parentID: parent, err: err,
+				ctxValue: ctx.Value(probeKey),
+			})
+			r.mu.Unlock()
+		}),
+	})
+	return r, opts
+}
+
+func findEvent(events []hookEvent, kind, title string) (hookEvent, bool) {
+	for _, e := range events {
+		if e.kind == kind && e.title == title {
+			return e, true
+		}
+	}
+	return hookEvent{}, false
+}
+
+// TestStartHookFiresForRequestScopedRoot verifies that StartTask invokes the
+// start hook with the root task's ID and an empty parentID.
+func TestStartHookFiresForRequestScopedRoot(t *testing.T) {
+	r, opts := makeRecorder()
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := withDelivery(context.Background(), d)
+
+	taskCtx, task := StartTask[any](ctx, "import users")
+	if task == nil {
+		t.Fatal("StartTask returned nil")
+	}
+
+	startEv, ok := findEvent(r.snapshot(), "start", "import users")
+	if !ok {
+		t.Fatal("start hook was not fired")
+	}
+	if startEv.parentID != "" {
+		t.Errorf("parentID for root: got %q, want empty", startEv.parentID)
+	}
+	if startEv.id == "" {
+		t.Error("start hook id is empty")
+	}
+	// The decorated ctx should be returned to the caller.
+	if got := taskCtx.Value(probeKey); got != "decorated:"+startEv.id {
+		t.Errorf("returned ctx not decorated by start hook: got %v", got)
+	}
+
+	task.Close()
+
+	endEv, ok := findEvent(r.snapshot(), "end", "import users")
+	if !ok {
+		t.Fatal("end hook was not fired on Close")
+	}
+	if endEv.err != nil {
+		t.Errorf("end err: got %v, want nil", endEv.err)
+	}
+	if endEv.ctxValue != "decorated:"+startEv.id {
+		t.Errorf("end hook did not receive decorated ctx: got %v", endEv.ctxValue)
+	}
+}
+
+// TestEndHookFiresOnFail verifies that Task.Fail invokes the end hook with
+// the user-supplied error message.
+func TestEndHookFiresOnFail(t *testing.T) {
+	r, opts := makeRecorder()
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := withDelivery(context.Background(), d)
+
+	_, task := StartTask[any](ctx, "broken job")
+	task.Fail("disk full")
+
+	endEv, ok := findEvent(r.snapshot(), "end", "broken job")
+	if !ok {
+		t.Fatal("end hook was not fired on Fail")
+	}
+	if endEv.err == nil || endEv.err.Error() != "disk full" {
+		t.Errorf("end err: got %v, want %q", endEv.err, "disk full")
+	}
+}
+
+// TestSubTaskHookPropagation verifies the package-level SubTask fires both
+// hooks with the parent's ID as parentID, and that the start hook's
+// returned ctx reaches the user's fn.
+func TestSubTaskHookPropagation(t *testing.T) {
+	r, opts := makeRecorder()
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := withDelivery(context.Background(), d)
+
+	parentCtx, parent := StartTask[any](ctx, "parent")
+	if parent == nil {
+		t.Fatal("StartTask returned nil")
+	}
+	parentID := parent.ID()
+
+	var seenInsideFn any
+	err := SubTask(parentCtx, "child", func(childCtx context.Context) error {
+		seenInsideFn = childCtx.Value(probeKey)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SubTask err: %v", err)
+	}
+	parent.Close()
+
+	events := r.snapshot()
+
+	startChild, ok := findEvent(events, "start", "child")
+	if !ok {
+		t.Fatal("start hook for child was not fired")
+	}
+	if startChild.parentID != parentID {
+		t.Errorf("child parentID: got %q, want %q", startChild.parentID, parentID)
+	}
+
+	endChild, ok := findEvent(events, "end", "child")
+	if !ok {
+		t.Fatal("end hook for child was not fired")
+	}
+	if endChild.err != nil {
+		t.Errorf("child end err: got %v, want nil", endChild.err)
+	}
+
+	// The start hook decorates ctx; fn should see the child's decoration.
+	if got := seenInsideFn; got != "decorated:"+startChild.id {
+		t.Errorf("fn ctx not decorated by child start hook: got %v", got)
+	}
+}
+
+// TestSharedTaskHooks verifies hooks fire for shared root tasks created via
+// taskManager.create + manual status flip (matches the StartTask shared
+// path's sequence).
+func TestSharedTaskHooks(t *testing.T) {
+	r, opts := makeRecorder()
+	_, tm := setupTestServer(t)
+	tm.hooks = opts // inject after setup since setupTestServer uses nil
+
+	ctx := context.Background()
+	ctx = aprot.WithTestConnection(ctx, 1)
+	ctx = withTaskManager(ctx, tm)
+
+	taskCtx, task := StartTask[any](ctx, "shared op", Shared())
+	if task == nil {
+		t.Fatal("StartTask returned nil")
+	}
+
+	startEv, ok := findEvent(r.snapshot(), "start", "shared op")
+	if !ok {
+		t.Fatal("start hook was not fired for shared task")
+	}
+	if got := taskCtx.Value(probeKey); got != "decorated:"+startEv.id {
+		t.Errorf("returned ctx not decorated: got %v", got)
+	}
+
+	task.Close()
+
+	endEv, ok := findEvent(r.snapshot(), "end", "shared op")
+	if !ok {
+		t.Fatal("end hook was not fired for shared task")
+	}
+	if endEv.err != nil {
+		t.Errorf("end err: got %v, want nil", endEv.err)
+	}
+}
+
+// TestCascadeFailureHooks verifies that failTop on a parent fires the end
+// hook for each running child, with the cascade error message.
+func TestCascadeFailureHooks(t *testing.T) {
+	r, opts := makeRecorder()
+	_, tm := setupTestServer(t)
+	tm.hooks = opts
+
+	root := tm.create("root", 1, true, context.Background())
+	root.mu.Lock()
+	root.status = TaskNodeStatusRunning
+	root.mu.Unlock()
+
+	child1 := root.createChild("child-1")
+	child2 := root.createChild("child-2")
+	_ = child1
+	_ = child2
+
+	root.failTop("canceled")
+
+	events := r.snapshot()
+
+	for _, title := range []string{"root", "child-1", "child-2"} {
+		ev, ok := findEvent(events, "end", title)
+		if !ok {
+			t.Errorf("end hook for %q was not fired", title)
+			continue
+		}
+		if ev.err == nil || ev.err.Error() != "canceled" {
+			t.Errorf("%q end err: got %v, want %q", title, ev.err, "canceled")
+		}
+	}
+}
+
+// TestHookIdempotency verifies that double-completing or double-failing a
+// task does not fire the end hook twice.
+func TestHookIdempotency(t *testing.T) {
+	t.Run("completeTop double", func(t *testing.T) {
+		r, opts := makeRecorder()
+		_, tm := setupTestServer(t)
+		tm.hooks = opts
+
+		node := tm.create("once", 1, true, context.Background())
+		node.mu.Lock()
+		node.status = TaskNodeStatusRunning
+		node.mu.Unlock()
+
+		node.completeTop()
+		node.completeTop() // no-op per existing idempotency
+
+		ends := 0
+		for _, e := range r.snapshot() {
+			if e.kind == "end" && e.title == "once" {
+				ends++
+			}
+		}
+		if ends != 1 {
+			t.Errorf("end fired %d times, want 1", ends)
+		}
+	})
+
+	t.Run("setStatus then finalize", func(t *testing.T) {
+		// Simulates Task.Close (non-shared) followed by middleware
+		// finalizeTaskSlot — both call setStatus(Completed).
+		r, opts := makeRecorder()
+		tc := newTestPushConn()
+		d := newRequestDelivery(tc.Conn, "req-1", opts)
+		ctx := withDelivery(context.Background(), d)
+		slot := &taskSlot{}
+		ctx = withTaskSlot(ctx, slot)
+
+		_, task := StartTask[any](ctx, "twice")
+		task.Close()
+		// Simulate middleware finalize.
+		finalizeTaskSlot(ctx, slot, nil, d)
+
+		ends := 0
+		for _, e := range r.snapshot() {
+			if e.kind == "end" && e.title == "twice" {
+				ends++
+			}
+		}
+		if ends != 1 {
+			t.Errorf("end fired %d times, want 1", ends)
+		}
+	})
+}
+
+// TestNoHooksDoesNotBreak verifies that calling Enable without options leaves
+// task creation working and avoids any hook invocation.
+func TestNoHooksDoesNotBreak(t *testing.T) {
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", nil)
+	ctx := withDelivery(context.Background(), d)
+
+	_, task := StartTask[any](ctx, "no hooks")
+	if task == nil {
+		t.Fatal("StartTask returned nil")
+	}
+	task.Close()
+	// No assertion needed — passing means no panic and no invariant broke.
+}
+
+// TestOnlyStartHookInstalled verifies that installing only WithTaskStartHook
+// works (end hook is silently absent) and vice versa.
+func TestOnlyStartHookInstalled(t *testing.T) {
+	t.Run("start only", func(t *testing.T) {
+		var startCalls int
+		opts := buildEnableOptions([]EnableOption{
+			WithTaskStartHook(func(ctx context.Context, id, title, parent string) context.Context {
+				startCalls++
+				return ctx
+			}),
+		})
+		tc := newTestPushConn()
+		d := newRequestDelivery(tc.Conn, "req-1", opts)
+		ctx := withDelivery(context.Background(), d)
+
+		_, task := StartTask[any](ctx, "start-only")
+		task.Close()
+
+		if startCalls != 1 {
+			t.Errorf("start fired %d times, want 1", startCalls)
+		}
+	})
+
+	t.Run("end only", func(t *testing.T) {
+		// End-only configuration must still receive the original request ctx
+		// (not context.Background()) so ctx-aware loggers / spans still work.
+		type endOnlyKey struct{}
+
+		var endErr error
+		var endCalls int
+		var endCtxValue any
+		opts := buildEnableOptions([]EnableOption{
+			WithTaskEndHook(func(ctx context.Context, id, title, parent string, err error) {
+				endCalls++
+				endErr = err
+				endCtxValue = ctx.Value(endOnlyKey{})
+			}),
+		})
+		tc := newTestPushConn()
+		d := newRequestDelivery(tc.Conn, "req-1", opts)
+		ctx := context.WithValue(context.Background(), endOnlyKey{}, "request-scoped")
+		ctx = withDelivery(ctx, d)
+
+		_, task := StartTask[any](ctx, "end-only")
+		task.Fail("boom")
+
+		if endCalls != 1 {
+			t.Errorf("end fired %d times, want 1", endCalls)
+		}
+		if endErr == nil || endErr.Error() != "boom" {
+			t.Errorf("end err: got %v, want %q", endErr, "boom")
+		}
+		if endCtxValue != "request-scoped" {
+			t.Errorf("end hook did not receive request ctx: got %v", endCtxValue)
+		}
+	})
+}
+
+// TestOutputWriterHooks verifies OutputWriter creates a child task that fires
+// both hooks.
+func TestOutputWriterHooks(t *testing.T) {
+	r, opts := makeRecorder()
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := withDelivery(context.Background(), d)
+
+	w := OutputWriter(ctx, "build log")
+	_, _ = w.Write([]byte("compiling..."))
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	events := r.snapshot()
+	if _, ok := findEvent(events, "start", "build log"); !ok {
+		t.Error("start hook for OutputWriter was not fired")
+	}
+	if _, ok := findEvent(events, "end", "build log"); !ok {
+		t.Error("end hook for OutputWriter was not fired")
+	}
+}
+
+// TestSubTaskFailedFnFiresEndWithError verifies that a SubTask whose fn
+// returns an error fires the end hook with that error.
+func TestSubTaskFailedFnFiresEndWithError(t *testing.T) {
+	r, opts := makeRecorder()
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := withDelivery(context.Background(), d)
+
+	sentinel := errors.New("validation failed")
+	err := SubTask(ctx, "validate", func(ctx context.Context) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("SubTask err: got %v, want %v", err, sentinel)
+	}
+
+	endEv, ok := findEvent(r.snapshot(), "end", "validate")
+	if !ok {
+		t.Fatal("end hook was not fired")
+	}
+	if endEv.err == nil || endEv.err.Error() != "validation failed" {
+		t.Errorf("end err: got %v, want %q", endEv.err, "validation failed")
+	}
+}
+
+// TestTaskSubMethodSubTask verifies Task.SubTask and TaskSub.SubTask fire
+// both hooks (with context.Background since no ctx is supplied).
+func TestTaskSubMethodSubTask(t *testing.T) {
+	r, opts := makeRecorder()
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := withDelivery(context.Background(), d)
+
+	_, task := StartTask[any](ctx, "root")
+
+	sub1 := task.SubTask("level-1")
+	sub2 := sub1.SubTask("level-2")
+	sub2.Close()
+	sub1.Close()
+	task.Close()
+
+	events := r.snapshot()
+	for _, title := range []string{"root", "level-1", "level-2"} {
+		if _, ok := findEvent(events, "start", title); !ok {
+			t.Errorf("start hook for %q was not fired", title)
+		}
+		if _, ok := findEvent(events, "end", title); !ok {
+			t.Errorf("end hook for %q was not fired", title)
+		}
+	}
+}

--- a/tasks/options_test.go
+++ b/tasks/options_test.go
@@ -454,3 +454,49 @@ func TestTaskSubMethodSubTask(t *testing.T) {
 		}
 	}
 }
+
+// TestTaskSubMethodInheritsParentCtx verifies that subtasks created via
+// Task.SubTask / TaskSub.SubTask (no ctx parameter) inherit the parent's
+// stashed ctx for their hooks, instead of falling back to
+// context.Background. This lets ctx-aware loggers/spans set on the request
+// ctx flow into subtask end-hook callbacks.
+func TestTaskSubMethodInheritsParentCtx(t *testing.T) {
+	type rootKey struct{}
+
+	var mu sync.Mutex
+	seen := map[string]any{}
+	opts := buildEnableOptions([]EnableOption{
+		WithTaskEndHook(func(ctx context.Context, id, title, parent string, err error) {
+			mu.Lock()
+			seen[title] = ctx.Value(rootKey{})
+			mu.Unlock()
+		}),
+	})
+
+	tc := newTestPushConn()
+	d := newRequestDelivery(tc.Conn, "req-1", opts)
+	ctx := context.WithValue(context.Background(), rootKey{}, "request-scoped")
+	ctx = withDelivery(ctx, d)
+
+	_, task := StartTask[any](ctx, "root")
+
+	sub1 := task.SubTask("level-1")
+	sub2 := sub1.SubTask("level-2")
+	sub2.Close()
+	sub1.Close()
+	task.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, title := range []string{"root", "level-1", "level-2"} {
+		v, ok := seen[title]
+		if !ok {
+			t.Errorf("end hook for %q was not fired", title)
+			continue
+		}
+		if v != "request-scoped" {
+			t.Errorf("end hook for %q did not see request-scoped ctx value: got %v",
+				title, v)
+		}
+	}
+}

--- a/tasks/shared_task.go
+++ b/tasks/shared_task.go
@@ -17,13 +17,15 @@ type taskManager struct {
 	nextID         atomic.Int64
 	lastProgress   map[string]time.Time
 	lastProgressMu sync.Mutex
+	hooks          *enableOptions
 }
 
-func newTaskManager(server *aprot.Server) *taskManager {
+func newTaskManager(server *aprot.Server, hooks *enableOptions) *taskManager {
 	return &taskManager{
 		server:       server,
 		tasks:        make(map[string]*taskNode),
 		lastProgress: make(map[string]time.Time),
+		hooks:        hooks,
 	}
 }
 
@@ -47,6 +49,7 @@ func (tm *taskManager) create(title string, connID uint64, topLevel bool, ctx co
 		manager:     tm,
 		ownerConnID: connID,
 		topLevel:    topLevel,
+		hooks:       tm.hooks,
 	}
 
 	tm.mu.Lock()

--- a/tasks/shared_task_test.go
+++ b/tasks/shared_task_test.go
@@ -27,7 +27,7 @@ func setupTestServer(t *testing.T) (*aprot.Server, *taskManager) {
 	registry.RegisterPushEventFor(handler, TaskUpdateEvent{})
 
 	server := aprot.NewServer(registry)
-	tm := newTaskManager(server)
+	tm := newTaskManager(server, nil)
 	t.Cleanup(func() {
 		tm.stop()
 		server.Stop(context.Background()) //nolint:errcheck
@@ -675,7 +675,7 @@ func TestSharedSubTaskStandalone(t *testing.T) {
 func TestSharedSubTaskWithoutConnection(t *testing.T) {
 	// Supply a request delivery so the SubTask fallback has something to work with.
 	tc := newTestPushConn()
-	d := newRequestDelivery(tc.Conn, "req-1")
+	d := newRequestDelivery(tc.Conn, "req-1", nil)
 	ctx := withDelivery(context.Background(), d)
 
 	var innerCtx context.Context

--- a/tasks/task_tree.go
+++ b/tasks/task_tree.go
@@ -83,13 +83,21 @@ func (n *taskNode) fireEnd(err error) {
 	if n.hooks == nil || n.hooks.onEnd == nil {
 		return
 	}
+	n.hooks.onEnd(n.currentCtx(), n.id, n.title, n.parentID, err)
+}
+
+// currentCtx returns the context most recently stashed by fireStart, or
+// context.Background if fireStart never ran (no hooks installed). Used by
+// fireEnd and by subtask creation paths that need a sensible default ctx
+// when no caller-supplied ctx is available.
+func (n *taskNode) currentCtx() context.Context {
 	n.mu.Lock()
 	ctx := n.hookCtx
 	n.mu.Unlock()
 	if ctx == nil {
-		ctx = context.Background()
+		return context.Background()
 	}
-	n.hooks.onEnd(ctx, n.id, n.title, n.parentID, err)
+	return ctx
 }
 
 func (n *taskNode) snapshot() *TaskNode {

--- a/tasks/task_tree.go
+++ b/tasks/task_tree.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 )
@@ -26,6 +27,7 @@ func itoa(n int64) string {
 type taskNode struct {
 	delivery taskDelivery
 	id       string
+	parentID string // empty for root nodes
 	title    string
 	status   TaskNodeStatus
 	error    string
@@ -35,6 +37,13 @@ type taskNode struct {
 	children []*taskNode
 	mu       sync.Mutex
 
+	// Lifecycle hook state. hooks is shared across all nodes in a task tree
+	// (set at root creation, inherited by children). hookCtx, guarded by mu,
+	// is the context returned by the start hook — passed to the end hook so
+	// decorations done at start (e.g. attaching a logger) reach completion.
+	hooks   *enableOptions
+	hookCtx context.Context
+
 	// Shared-task-only fields:
 	cancel      context.CancelFunc // non-nil for top-level shared tasks
 	ctx         context.Context    // task-scoped context for shared tasks
@@ -42,6 +51,45 @@ type taskNode struct {
 	ownerConnID uint64             // connection that created this task
 	topLevel    bool               // true if created by StartTask with Shared()
 
+}
+
+// fireStart calls the start hook (if installed) and stashes the resulting
+// context for later use by fireEnd. Returns the context to use downstream
+// (decorated by the hook, or the input ctx if no hook is installed).
+//
+// The input ctx is stashed even when no start hook is installed, so that an
+// end-hook-only configuration still sees the original request ctx (instead
+// of context.Background()) on completion. Each call site in api.go invokes
+// fireStart exactly once per node, so no idempotency guard is needed here.
+func (n *taskNode) fireStart(ctx context.Context) context.Context {
+	if n.hooks == nil {
+		return ctx
+	}
+	out := ctx
+	if n.hooks.onStart != nil {
+		out = n.hooks.onStart(ctx, n.id, n.title, n.parentID)
+	}
+	n.mu.Lock()
+	n.hookCtx = out
+	n.mu.Unlock()
+	return out
+}
+
+// fireEnd calls the end hook (if installed) with the context returned by
+// fireStart (or context.Background() if none). Idempotency lives in the
+// callers (setStatus, setFailed, completeTop, failTop) which short-circuit
+// on terminal status, so this method does not re-check.
+func (n *taskNode) fireEnd(err error) {
+	if n.hooks == nil || n.hooks.onEnd == nil {
+		return
+	}
+	n.mu.Lock()
+	ctx := n.hookCtx
+	n.mu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	n.hooks.onEnd(ctx, n.id, n.title, n.parentID, err)
 }
 
 func (n *taskNode) snapshot() *TaskNode {
@@ -80,15 +128,27 @@ func (n *taskNode) addChild(child *taskNode) {
 
 func (n *taskNode) setStatus(s TaskNodeStatus) {
 	n.mu.Lock()
-	defer n.mu.Unlock()
+	if n.status == TaskNodeStatusCompleted || n.status == TaskNodeStatusFailed {
+		n.mu.Unlock()
+		return
+	}
 	n.status = s
+	n.mu.Unlock()
+	if s == TaskNodeStatusCompleted {
+		n.fireEnd(nil)
+	}
 }
 
 func (n *taskNode) setFailed(msg string) {
 	n.mu.Lock()
-	defer n.mu.Unlock()
+	if n.status == TaskNodeStatusCompleted || n.status == TaskNodeStatusFailed {
+		n.mu.Unlock()
+		return
+	}
 	n.status = TaskNodeStatusFailed
 	n.error = msg
+	n.mu.Unlock()
+	n.fireEnd(errors.New(msg))
 }
 
 func (n *taskNode) setProgress(current, total int) {
@@ -121,8 +181,10 @@ func (n *taskNode) createChild(title string) *taskNode {
 	child := &taskNode{
 		delivery: n.delivery,
 		id:       n.delivery.allocID(),
+		parentID: n.id,
 		title:    title,
 		status:   TaskNodeStatusCreated,
+		hooks:    n.hooks,
 	}
 	n.addChild(child)
 	n.delivery.sendSnapshot(nil)
@@ -157,6 +219,7 @@ func (n *taskNode) completeTop() {
 		n.cancel()
 	}
 	n.delivery.sendSnapshot(nil)
+	n.fireEnd(nil)
 	if n.manager != nil {
 		go func() {
 			time.Sleep(200 * time.Millisecond)
@@ -181,6 +244,7 @@ func (n *taskNode) failTop(msg string) {
 	}
 	n.failChildren(msg)
 	n.delivery.sendSnapshot(nil)
+	n.fireEnd(errors.New(msg))
 	if n.manager != nil {
 		go func() {
 			time.Sleep(200 * time.Millisecond)
@@ -198,11 +262,16 @@ func (n *taskNode) failChildren(msg string) {
 
 	for _, child := range children {
 		child.mu.Lock()
+		fired := false
 		if child.status == TaskNodeStatusRunning || child.status == TaskNodeStatusCreated {
 			child.status = TaskNodeStatusFailed
 			child.error = msg
+			fired = true
 		}
 		child.mu.Unlock()
+		if fired {
+			child.fireEnd(errors.New(msg))
+		}
 		child.failChildren(msg)
 	}
 }
@@ -248,6 +317,7 @@ func ensureRoot(d *requestDelivery) *taskNode {
 		id:       "root",
 		title:    "",
 		status:   TaskNodeStatusRunning,
+		hooks:    d.hooks,
 	}
 	return d.root
 }

--- a/tasks/task_tree_test.go
+++ b/tasks/task_tree_test.go
@@ -79,7 +79,7 @@ func newTestPushConn() *aprot.TestPushConn {
 // newTestCtx returns a context that has a request delivery backed by a
 // TestPushConn.
 func newTestCtx(tc *aprot.TestPushConn) context.Context {
-	d := newRequestDelivery(tc.Conn, "req-1")
+	d := newRequestDelivery(tc.Conn, "req-1", nil)
 	return withDelivery(context.Background(), d)
 }
 


### PR DESCRIPTION
## Summary
- Adds opt-in `WithTaskStartHook` and `WithTaskEndHook` options to `tasks.Enable` / `tasks.EnableWithMeta`. The start hook returns a decorated `ctx` that propagates to the handler and every nested subtask; the end hook fires once on completion or failure (cancellation surfaces as `err.Error() == "canceled"`).
- Logger-agnostic — works with `log`, `slog`, `zerolog`, `zap`, anything ctx-aware. Both example apps wired up to log task lifecycle via `log.Printf`.
- Idempotency moved into the state machine: `setStatus` / `setFailed` short-circuit on terminal status, matching the existing `completeTop` / `failTop` pattern.

## Test plan
- [x] `go test ./...` passes
- [x] `go test -race ./tasks/...` passes
- [x] New tests in `tasks/options_test.go` cover root + subtask hooks, ctx propagation, cascade-failure, idempotency, partial-hook installation, end-hook-only ctx fallback
- [ ] Run vanilla example, trigger a task, verify `[task] started/completed` log lines
- [ ] Run react example, same

🤖 Generated with [Claude Code](https://claude.com/claude-code)