### PR TITLE
Server hardening + REST/tasks fixes (P0+P1 from #207)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Run Go tests
         run: go test -race -v ./...
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Check Go formatting
         run: test -z "$(gofmt -l .)"
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Lint root module
         uses: golangci/golangci-lint-action@v7
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - uses: actions/setup-node@v4
         with:
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - uses: actions/setup-node@v4
         with:

--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -33,6 +33,10 @@ http.Handle("/sse/", server.HTTPTransport())
 http.Handle("/api/", aprot.NewRESTAdapter(registry)) // optional REST
 ```
 
+Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{MaxMessageSize, WriteTimeout, PingInterval, PongTimeout}` — inbound size limit (default 4 MiB), stalled-peer write timeout (30s), WS keepalive ping (30s) and pong timeout (60s). Handler panics are recovered per request and returned as internal errors.
+
+**Cookie-auth deployments must set an origin check** (default allows all origins — CSWSH risk): `server.SetCheckOrigin(func(r *http.Request) bool { return r.Header.Get("Origin") == "https://app.example.com" })`.
+
 ### 3. TypeScript Generation
 ```go
 gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
@@ -47,7 +51,7 @@ gen.Generate()
 ### 4. Progress & Tasks
 - Simple: `aprot.Progress(ctx).Update(current, total, message)`.
 - Hierarchical: `tasks.SubTask(ctx, title, fn)`.
-- Server-wide: `tasks.StartSharedTask[Meta](ctx, title)`.
+- Server-wide: `tasks.StartTask[Meta](ctx, title, tasks.Shared())`. Start it on `context.WithoutCancel(ctx)` for a fire-and-forget task that outlives the handler — then the goroutine must finish it via `task.Close()` / `task.Fail()` / `task.Err()`.
 - Enable: `tasks.Enable(registry)` before generation/serving.
 
 ## Handlers
@@ -161,7 +165,7 @@ server.Broadcast(&UserCreatedEvent{ID: "1"})
 server.PushToUser("user_123", &NotificationEvent{Message: "hello"})
 ```
 
-Event name on the wire is the Go type name. Subscribed via the generated per-event hook (React) or `subscribe`/`onUserCreated` standalone (vanilla).
+Event name on the wire is the Go type name. Subscribed via the generated per-event hook (React) or the `onUserCreatedEvent`-style standalone (vanilla) — generated names match the Go event type name exactly.
 
 ## Subscription Refresh
 
@@ -239,19 +243,20 @@ The `'server-rejected'` bucket is also surfaced via the older `onConnectionRejec
 
 ## TypeScript Hooks (React Output)
 
-aprot generates **only two hook flavors per handler**: `useXxx()` for query/subscription, and `useStreamXxx()` / `usePushXxx()` for streams and push events. There is **no per-handler mutation hook** — call the generated async function directly, or use the query hook's `mutate(action)` helper to compose a mutation with a refetch.
+aprot generates one hook per handler named after the handler itself: `useXxx()` for query/subscription handlers **and** stream handlers (e.g. stream handler `Numbers` → `useNumbers()`), plus `useXxxEvent()` for push events (named after the Go event type, e.g. `UserCreatedEvent` → `useUserCreatedEvent()`). There is **no per-handler mutation hook** — call the generated async function directly, or use the query hook's `mutate(action)` helper to compose a mutation with a refetch.
 
 ```tsx
 import {
   useListUsers, useGetUser, createUser, deleteUser,
-  useUserCreatedEvent, useStreamNumbers,
+  useUserCreatedEvent,
 } from './api/handlers';
+import { useNumbers } from './api/streaming-handlers';
 import { useApiClient } from './api/client';
 
 const { data, isLoading, error, refetch, mutate, cancel } = useListUsers();
 const { data: user } = useGetUser(userId);                          // re-fetches when userId changes
 
-const { items, done, error, isLoading, restart, cancel } = useStreamNumbers(10, 100);
+const { items, done, error, isLoading, restart, cancel } = useNumbers(10, 100);
 const { lastEvent, events, clear } = useUserCreatedEvent();
 ```
 
@@ -374,7 +379,7 @@ function UserView({ id }: { id: string }) {
   return <h1>{user.name}</h1>;
 }
 ```
-Errors propagate to the nearest error boundary. Mutations and streams stay on `useMutation` / `useStream`.
+Errors propagate to the nearest error boundary. Mutations stay on the generated async functions (or the query hook's `mutate` helper); streams stay on the generated stream hooks.
 
 ### Connection / loading hooks
 ```tsx
@@ -386,7 +391,7 @@ const isLoading = useIsLoading();               // any in-flight request anywher
 
 ### Generic primitives
 ```tsx
-import { useQuery, useMutation, useStream, usePushEvent } from './api/client';
+import { useQuery, useStream, usePushEvent } from './api/client';
 ```
 
 ## Vanilla Output
@@ -394,11 +399,11 @@ import { useQuery, useMutation, useStream, usePushEvent } from './api/client';
 Per-handler standalone functions plus `subscribe`/`unsubscribe` helpers for live data:
 
 ```ts
-import { listUsers, subscribeListUsers, onUserCreated } from './api/handlers';
+import { listUsers, subscribeListUsers, onUserCreatedEvent } from './api/handlers';
 
 const users = await listUsers(client);
 const unsub = subscribeListUsers(client, (next) => render(next));
-const off = onUserCreated(client, (evt) => append(evt));
+const off = onUserCreatedEvent(client, (evt) => append(evt));
 ```
 
 ## Cancel Causes

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Request cancellation** — clients cancel via AbortController; handlers see cancel cause
 - **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
+- **Connection hardening** — per-request panic recovery, inbound message size limits, write timeouts that drop stalled clients, and WebSocket keepalive pings — all configurable via `ServerOptions`
 - **Automatic reconnection** — page visibility + network-aware, with exponential backoff; supports dynamic URL functions for token refresh on reconnect
 - **Struct validation** — opt-in server-side validation via `go-playground/validator` struct tags, automatically enforced before handler dispatch
 - **Input transformation** — declarative `transform` struct tags (`trim`, `trimleft`, `trimright`, `uppercase`, `lowercase`, `removeempty`) normalize fields before validation runs
@@ -723,6 +724,38 @@ const off = client.onConnectionError((err) => {
     else hideOfflineBanner();
 });
 ```
+
+## Server Hardening & Security
+
+The server protects itself from misbehaving clients out of the box, and every limit is configurable through `ServerOptions`:
+
+```go
+server := aprot.NewServer(registry, aprot.ServerOptions{
+    MaxMessageSize: 1 << 20,          // max inbound WS frame / SSE body size (default 4 MiB)
+    WriteTimeout:   10 * time.Second, // drop peers that stop reading (default 30s)
+    PingInterval:   30 * time.Second, // WebSocket keepalive ping interval (default 30s)
+    PongTimeout:    60 * time.Second, // drop peers with no inbound traffic (default 60s)
+})
+```
+
+Set any of these to `-1` to disable it. Defaults apply when the field is zero.
+
+- **Panic recovery** — a panic in a handler (or middleware) is recovered per request and sent to the client as an internal error, mirroring `net/http`. One buggy handler cannot take down the process.
+- **Message size limits** — oversized WebSocket frames close the connection; oversized SSE RPC bodies get HTTP 413.
+- **Write timeout** — a client that stops reading is disconnected once a write blocks longer than `WriteTimeout`, so it cannot back-pressure broadcasts or other connections.
+- **Keepalive** — the server pings on `PingInterval` and drops connections with no inbound traffic for `PongTimeout`, so half-open connections (NATs, dropped Wi-Fi) are cleaned up.
+
+### Origin checking (cross-site WebSocket hijacking)
+
+By default the WebSocket upgrader accepts **any** `Origin` header so non-browser clients work out of the box. If your deployment authenticates browsers with **cookies**, you must restrict origins — otherwise any website a logged-in user visits can open an authenticated WebSocket to your server from their browser:
+
+```go
+server.SetCheckOrigin(func(r *http.Request) bool {
+    return r.Header.Get("Origin") == "https://app.example.com"
+})
+```
+
+Token-based auth (e.g. a token passed via the connection URL) is not affected by this, but setting an origin check is still good hygiene for browser-facing deployments.
 
 ## REST Adapter
 

--- a/connection.go
+++ b/connection.go
@@ -296,6 +296,13 @@ func (c *Conn) handleIncomingMessage(data []byte) {
 
 func (c *Conn) handleRequest(msg IncomingMessage) {
 	defer c.server.requestsWg.Done()
+	// Each request runs on its own goroutine, so an unrecovered panic would
+	// kill the whole process, not just this request (unlike net/http).
+	defer func() {
+		if r := recover(); r != nil {
+			c.sendError(msg.ID, CodeInternalError, fmt.Sprintf("handler panicked: %v", r))
+		}
+	}()
 
 	info, ok := c.server.registry.Get(msg.Method)
 	if !ok {
@@ -482,6 +489,11 @@ func (c *Conn) sendStreamEnd(reqID string, err error) {
 
 func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	defer c.server.requestsWg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			c.sendError(msg.ID, CodeInternalError, fmt.Sprintf("handler panicked: %v", r))
+		}
+	}()
 
 	info, ok := c.server.registry.Get(msg.Method)
 	if !ok {
@@ -579,6 +591,11 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 // and sends the updated response directly to the subscriber.
 func (c *Conn) refreshSubscription(sub *subscription) {
 	defer c.server.requestsWg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			c.sendError(sub.id, CodeInternalError, fmt.Sprintf("handler panicked: %v", r))
+		}
+	}()
 
 	// Check that the subscription still exists (may have been unsubscribed)
 	if !c.server.subscriptions.has(c.id, sub.id) {

--- a/doc.go
+++ b/doc.go
@@ -224,9 +224,35 @@
 // cannot be exposed via REST and will panic at registration — use
 // WebSocket or SSE for those.
 //
-// Use [ServerOptions] to configure client reconnection behavior. The server
-// sends this configuration to clients on connect; TypeScript clients apply it
-// automatically.
+// Use [ServerOptions] to configure client reconnection behavior and
+// connection hardening. The reconnect settings are sent to clients on
+// connect; TypeScript clients apply them automatically. The hardening
+// settings protect the server from misbehaving clients:
+//
+//	server := aprot.NewServer(registry, aprot.ServerOptions{
+//	    MaxMessageSize: 1 << 20,          // max inbound WS frame / SSE body size (default 4 MiB)
+//	    WriteTimeout:   10 * time.Second, // drop peers that stop reading (default 30s)
+//	    PingInterval:   30 * time.Second, // WebSocket keepalive ping interval (default 30s)
+//	    PongTimeout:    60 * time.Second, // drop peers with no inbound traffic (default 60s)
+//	})
+//
+// Set a field to -1 to disable that limit; zero applies the default.
+// Handler panics are recovered per request and surfaced to the client as
+// internal errors, mirroring net/http — one buggy handler cannot take down
+// the process.
+//
+// # Security
+//
+// The WebSocket upgrader accepts any Origin header by default so that
+// non-browser clients work out of the box. Deployments that authenticate
+// browsers with cookies must restrict origins with [Server.SetCheckOrigin] —
+// otherwise any website a logged-in user visits can open an authenticated
+// WebSocket to the server from the user's browser (cross-site WebSocket
+// hijacking):
+//
+//	server.SetCheckOrigin(func(r *http.Request) bool {
+//	    return r.Header.Get("Origin") == "https://app.example.com"
+//	})
 //
 // # Connection Lifecycle
 //

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433
+	github.com/go-playground/validator/v10 v10.30.2
 	github.com/gorilla/websocket v1.5.3
 )
 
@@ -11,7 +12,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.30.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -12,9 +16,15 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rest.go
+++ b/rest.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-json-experiment/json"
@@ -196,9 +198,15 @@ func (a *RESTAdapter) handleRequest(w http.ResponseWriter, r *http.Request, rout
 	// Build JSON params array (same format as WebSocket)
 	var jsonParams []any
 
-	// Add path params (in order)
+	// Add path params (in order), converted to the JSON type the handler
+	// expects — the strict decoder rejects e.g. "123" for an int param.
 	for _, pp := range route.PathParams {
-		val := r.PathValue(pp.Name)
+		val, err := convertPathParam(r.PathValue(pp.Name), pp.Info.Type)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, CodeInvalidParams,
+				fmt.Sprintf("invalid value for path parameter %q: %v", pp.Name, err))
+			return
+		}
 		jsonParams = append(jsonParams, val)
 	}
 
@@ -255,7 +263,9 @@ func (a *RESTAdapter) handleRequest(w http.ResponseWriter, r *http.Request, rout
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	data, err := json.Marshal(result)
+	// Use the shared sql.Null-aware marshaler so the REST wire format
+	// matches the WebSocket/SSE transports.
+	data, err := marshalJSON(result)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, CodeInternalError, "failed to marshal response")
 		return
@@ -283,6 +293,46 @@ func (a *RESTAdapter) buildHandler(info *HandlerInfo) Handler {
 	}
 
 	return handler
+}
+
+// convertPathParam converts a raw path segment into a value that marshals
+// to the JSON type matching the Go parameter: numbers and bools become raw
+// JSON tokens, everything else stays a JSON string.
+func convertPathParam(val string, t reflect.Type) (any, error) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return jsontext.Value(strconv.FormatInt(n, 10)), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return jsontext.Value(strconv.FormatUint(n, 10)), nil
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, err
+		}
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil, fmt.Errorf("value %q is not representable in JSON", val)
+		}
+		return jsontext.Value(strconv.FormatFloat(f, 'g', -1, 64)), nil
+	case reflect.Bool:
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+		return jsontext.Value(strconv.FormatBool(b)), nil
+	default:
+		return val, nil // marshaled as a JSON string
+	}
 }
 
 // marshalJSONParams marshals a mixed slice of values into a JSON array.

--- a/rest_params_test.go
+++ b/rest_params_test.go
@@ -1,0 +1,164 @@
+package aprot
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type ItemResponse struct {
+	ID      int     `json:"id"`
+	Enabled bool    `json:"enabled"`
+	Score   float64 `json:"score"`
+}
+
+type TypedParamHandlers struct{}
+
+func (h *TypedParamHandlers) GetItem(ctx context.Context, id int) (*ItemResponse, error) {
+	return &ItemResponse{ID: id}, nil
+}
+
+func (h *TypedParamHandlers) GetFlag(ctx context.Context, enabled bool) (*ItemResponse, error) {
+	return &ItemResponse{Enabled: enabled}, nil
+}
+
+func (h *TypedParamHandlers) GetScore(ctx context.Context, value float64) (*ItemResponse, error) {
+	return &ItemResponse{Score: value}, nil
+}
+
+type NullableRESTResponse struct {
+	Name sql.NullString `json:"name"`
+	Age  sql.NullInt64  `json:"age"`
+}
+
+type NullRESTHandlers struct{}
+
+func (h *NullRESTHandlers) GetProfile(ctx context.Context) (*NullableRESTResponse, error) {
+	return &NullableRESTResponse{
+		Name: sql.NullString{String: "Alice", Valid: true},
+		Age:  sql.NullInt64{Valid: false},
+	}, nil
+}
+
+func setupTypedParamServer(t *testing.T) (*httptest.Server, *RESTAdapter) {
+	t.Helper()
+	registry := NewRegistry()
+	registry.RegisterREST(&TypedParamHandlers{})
+	adapter := NewRESTAdapter(registry)
+	ts := httptest.NewServer(adapter)
+	t.Cleanup(ts.Close)
+	return ts, adapter
+}
+
+// findRoutePath resolves the route path for a method and substitutes the
+// single path parameter with val.
+func findRoutePath(t *testing.T, adapter *RESTAdapter, method, val string) string {
+	t.Helper()
+	for _, r := range adapter.Routes() {
+		if r.MethodName == method {
+			if len(r.PathParams) != 1 {
+				t.Fatalf("%s: expected 1 path param, got %d", method, len(r.PathParams))
+			}
+			return strings.Replace(r.Path, "{"+r.PathParams[0].Name+"}", val, 1)
+		}
+	}
+	t.Fatalf("route for %s not found", method)
+	return ""
+}
+
+func getBody(t *testing.T, url string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// Non-string scalar path params must be converted to their JSON types
+// instead of being passed as JSON strings (which the strict decoder rejects).
+func TestRESTIntPathParam(t *testing.T) {
+	ts, adapter := setupTypedParamServer(t)
+
+	status, body := getBody(t, ts.URL+findRoutePath(t, adapter, "GetItem", "42"))
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", status, body)
+	}
+	if !strings.Contains(body, `"id":42`) {
+		t.Errorf("expected id 42 in body, got %s", body)
+	}
+}
+
+func TestRESTBoolPathParam(t *testing.T) {
+	ts, adapter := setupTypedParamServer(t)
+
+	status, body := getBody(t, ts.URL+findRoutePath(t, adapter, "GetFlag", "true"))
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", status, body)
+	}
+	if !strings.Contains(body, `"enabled":true`) {
+		t.Errorf("expected enabled true in body, got %s", body)
+	}
+}
+
+func TestRESTFloatPathParam(t *testing.T) {
+	ts, adapter := setupTypedParamServer(t)
+
+	status, body := getBody(t, ts.URL+findRoutePath(t, adapter, "GetScore", "2.5"))
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", status, body)
+	}
+	if !strings.Contains(body, `"score":2.5`) {
+		t.Errorf("expected score 2.5 in body, got %s", body)
+	}
+}
+
+// A non-numeric value for an int path param must be a 400, not a 500.
+func TestRESTInvalidIntPathParam(t *testing.T) {
+	ts, adapter := setupTypedParamServer(t)
+
+	status, _ := getBody(t, ts.URL+findRoutePath(t, adapter, "GetItem", "abc"))
+	if status != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", status)
+	}
+}
+
+// REST responses must use the same sql.Null-aware marshaling as the
+// WebSocket/SSE path, so the wire format is identical across transports.
+func TestRESTSQLNullResponse(t *testing.T) {
+	registry := NewRegistry()
+	registry.RegisterREST(&NullRESTHandlers{})
+	adapter := NewRESTAdapter(registry)
+	ts := httptest.NewServer(adapter)
+	t.Cleanup(ts.Close)
+
+	var path string
+	for _, r := range adapter.Routes() {
+		if r.MethodName == "GetProfile" {
+			path = r.Path
+		}
+	}
+	if path == "" {
+		t.Fatal("GetProfile route not found")
+	}
+
+	status, body := getBody(t, ts.URL+path)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", status, body)
+	}
+	if !strings.Contains(body, `"name":"Alice"`) {
+		t.Errorf("expected unwrapped null-string, got %s", body)
+	}
+	if !strings.Contains(body, `"age":null`) {
+		t.Errorf("expected null for invalid NullInt64, got %s", body)
+	}
+	if strings.Contains(body, `"Valid"`) {
+		t.Errorf("raw sql.Null struct leaked into REST response: %s", body)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-json-experiment/json"
 	"github.com/gorilla/websocket"
@@ -32,6 +33,24 @@ type ServerOptions struct {
 	ReconnectMaxInterval int
 	// ReconnectMaxAttempts is the maximum number of reconnect attempts. 0 = unlimited. Default: 0
 	ReconnectMaxAttempts int
+	// MaxMessageSize is the maximum size in bytes of an inbound WebSocket
+	// frame or SSE RPC request body. Larger messages close the connection
+	// (WebSocket) or are rejected with 413 (SSE). Set to -1 to disable the
+	// limit. Default: 4 MiB.
+	MaxMessageSize int64
+	// WriteTimeout is the maximum time to write a single outbound WebSocket
+	// message. A connection whose peer stops reading is closed once a write
+	// exceeds this timeout, so a stalled client cannot back-pressure the
+	// whole server. Set to -1 to disable. Default: 30s.
+	WriteTimeout time.Duration
+	// PingInterval is how often the server sends WebSocket ping frames.
+	// Set to -1 to disable keepalive pings. Default: 30s.
+	PingInterval time.Duration
+	// PongTimeout is how long a WebSocket connection may go without any
+	// inbound traffic (data or pong) before it is considered dead and
+	// closed. Must be larger than PingInterval. Only effective while pings
+	// are enabled. Set to -1 to disable. Default: 60s.
+	PongTimeout time.Duration
 }
 
 func defaultServerOptions() ServerOptions {
@@ -39,6 +58,10 @@ func defaultServerOptions() ServerOptions {
 		ReconnectInterval:    1000,
 		ReconnectMaxInterval: 30000,
 		ReconnectMaxAttempts: 0,
+		MaxMessageSize:       4 << 20,
+		WriteTimeout:         30 * time.Second,
+		PingInterval:         30 * time.Second,
+		PongTimeout:          60 * time.Second,
 	}
 }
 
@@ -80,6 +103,19 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		}
 		if opt.ReconnectMaxAttempts > 0 {
 			options.ReconnectMaxAttempts = opt.ReconnectMaxAttempts
+		}
+		// Non-zero overrides the default; negative values disable a limit.
+		if opt.MaxMessageSize != 0 {
+			options.MaxMessageSize = opt.MaxMessageSize
+		}
+		if opt.WriteTimeout != 0 {
+			options.WriteTimeout = opt.WriteTimeout
+		}
+		if opt.PingInterval != 0 {
+			options.PingInterval = opt.PingInterval
+		}
+		if opt.PongTimeout != 0 {
+			options.PongTimeout = opt.PongTimeout
 		}
 	}
 
@@ -135,13 +171,11 @@ func (s *Server) OnStop(hook func()) {
 	s.stopHooks = append(s.stopHooks, hook)
 }
 
-// ForEachConn iterates over all active connections under a read lock.
-// The callback must not block or call methods that acquire the server's
-// write lock.
+// ForEachConn iterates over a snapshot of the active connections. The
+// callback runs outside the server's lock, so it may block or send; note
+// that a connection may be closing concurrently while it is visited.
 func (s *Server) ForEachConn(fn func(conn *Conn)) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for conn := range s.conns {
+	for _, conn := range s.connsSnapshot() {
 		fn(conn)
 	}
 }
@@ -207,13 +241,19 @@ func (s *Server) buildHandler(info *HandlerInfo) Handler {
 // registered via RegisterPushEventFor.
 func (s *Server) PushToUser(userID string, data any) {
 	event := s.registry.eventName(data)
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
-	if conns, ok := s.userConns[userID]; ok {
-		for conn := range conns {
-			_ = conn.push(event, data)
-		}
+	// Snapshot under the lock, send outside it: pushes can block on a slow
+	// connection's send buffer, and blocking while holding s.mu would stall
+	// register/unregister for every other connection.
+	s.mu.RLock()
+	conns := make([]*Conn, 0, len(s.userConns[userID]))
+	for conn := range s.userConns[userID] {
+		conns = append(conns, conn)
+	}
+	s.mu.RUnlock()
+
+	for _, conn := range conns {
+		_ = conn.push(event, data)
 	}
 }
 
@@ -244,6 +284,15 @@ func (s *Server) disassociateUser(conn *Conn) {
 }
 
 // SetCheckOrigin sets the origin check function for the WebSocket upgrader.
+//
+// The default accepts any Origin so non-browser clients work out of the box.
+// Deployments that authenticate browsers with cookies MUST restrict origins,
+// otherwise any website can open an authenticated WebSocket to this server
+// from a visitor's browser (cross-site WebSocket hijacking):
+//
+//	server.SetCheckOrigin(func(r *http.Request) bool {
+//	    return r.Header.Get("Origin") == "https://app.example.com"
+//	})
 func (s *Server) SetCheckOrigin(f func(r *http.Request) bool) {
 	s.upgrader.CheckOrigin = f
 }
@@ -276,8 +325,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	connID := atomic.AddUint64(&s.nextConnID, 1)
 	ctx := r.Context()
-	wst := newWSTransport(ws)
+	wst := newWSTransport(ws, s.options)
 	conn := newConn(wst, s, connID, r, ctx)
+
+	// Bound the direct writes below (rejection/config) the same way the
+	// write pump bounds its writes; the pump refreshes the deadline per
+	// message once it starts.
+	if s.options.WriteTimeout > 0 {
+		_ = ws.SetWriteDeadline(time.Now().Add(s.options.WriteTimeout))
+	}
 
 	// Run connect hooks before starting message processing
 	if err := s.runConnectHooks(ctx, conn); err != nil {
@@ -301,12 +357,22 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // registered via RegisterPushEventFor.
 func (s *Server) Broadcast(data any) {
 	event := s.registry.eventName(data)
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	for conn := range s.conns {
+	for _, conn := range s.connsSnapshot() {
 		_ = conn.push(event, data)
 	}
+}
+
+// connsSnapshot copies the current connection set under the read lock.
+// Senders iterate the copy without holding the lock, so a blocking send
+// can never wedge register/unregister processing.
+func (s *Server) connsSnapshot() []*Conn {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conns := make([]*Conn, 0, len(s.conns))
+	for conn := range s.conns {
+		conns = append(conns, conn)
+	}
+	return conns
 }
 
 // ConnectionCount returns the number of active connections.

--- a/server_hardening_test.go
+++ b/server_hardening_test.go
@@ -1,0 +1,352 @@
+package aprot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/gorilla/websocket"
+)
+
+// Handlers used by the hardening tests.
+type PanicHandlers struct {
+	calls atomic.Int32
+}
+
+func (h *PanicHandlers) Boom(ctx context.Context, req *EchoRequest) (*EchoResponse, error) {
+	panic("boom: " + req.Message)
+}
+
+func (h *PanicHandlers) SubscribeBoom(ctx context.Context) (*EchoResponse, error) {
+	panic("subscribe boom")
+}
+
+func (h *PanicHandlers) SubscribeFlaky(ctx context.Context) (*EchoResponse, error) {
+	RegisterRefreshTrigger(ctx, "flaky")
+	if h.calls.Add(1) > 1 {
+		panic("refresh boom")
+	}
+	return &EchoResponse{Message: "ok"}, nil
+}
+
+func (h *PanicHandlers) Safe(ctx context.Context, req *EchoRequest) (*EchoResponse, error) {
+	return &EchoResponse{Message: req.Message}, nil
+}
+
+func setupPanicServer(t *testing.T) (*httptest.Server, *Server, *PanicHandlers) {
+	t.Helper()
+	registry := NewRegistry()
+	handlers := &PanicHandlers{}
+	registry.Register(handlers)
+	server := NewServer(registry)
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+	return ts, server, handlers
+}
+
+// readMessageOfType reads messages until one of the wanted type arrives,
+// skipping others (e.g. push events). Fails the test on timeout.
+func readMessageOfType(t *testing.T, ws *websocket.Conn, want MessageType, timeout time.Duration) ErrorMessage {
+	t.Helper()
+	_ = ws.SetReadDeadline(time.Now().Add(timeout))
+	defer ws.SetReadDeadline(time.Time{})
+	for {
+		var msg ErrorMessage // superset of ResponseMessage fields we need (type, id, code, message)
+		if err := ws.ReadJSON(&msg); err != nil {
+			t.Fatalf("reading message of type %q: %v", want, err)
+		}
+		if msg.Type == want {
+			return msg
+		}
+	}
+}
+
+// A panic in a unary handler must be recovered, surfaced as an internal
+// error response, and must not kill the connection or the process.
+func TestHandlerPanicRecovered(t *testing.T) {
+	ts, _, _ := setupPanicServer(t)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "PanicHandlers.Boom", Params: jsontext.Value(`[{"message":"hi"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	errMsg := readMessageOfType(t, ws, TypeError, 3*time.Second)
+	if errMsg.ID != "1" {
+		t.Errorf("expected error for request 1, got %q", errMsg.ID)
+	}
+	if errMsg.Code != CodeInternalError {
+		t.Errorf("expected CodeInternalError, got %d", errMsg.Code)
+	}
+	if !strings.Contains(errMsg.Message, "panic") {
+		t.Errorf("expected panic mention in message, got %q", errMsg.Message)
+	}
+
+	// The same connection must still work.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "2", Method: "PanicHandlers.Safe", Params: jsontext.Value(`[{"message":"still alive"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	resp := readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	if resp.ID != "2" {
+		t.Errorf("expected response for request 2, got %q", resp.ID)
+	}
+}
+
+// A panic in a subscription handler must be recovered the same way.
+func TestSubscribeHandlerPanicRecovered(t *testing.T) {
+	ts, _, _ := setupPanicServer(t)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "s1", Method: "PanicHandlers.SubscribeBoom"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	errMsg := readMessageOfType(t, ws, TypeError, 3*time.Second)
+	if errMsg.Code != CodeInternalError {
+		t.Errorf("expected CodeInternalError, got %d", errMsg.Code)
+	}
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "2", Method: "PanicHandlers.Safe", Params: jsontext.Value(`[{"message":"alive"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	resp := readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	if resp.ID != "2" {
+		t.Errorf("expected response for request 2, got %q", resp.ID)
+	}
+}
+
+// A panic during a server-driven subscription refresh must be recovered.
+func TestRefreshPanicRecovered(t *testing.T) {
+	ts, server, _ := setupPanicServer(t)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "s1", Method: "PanicHandlers.SubscribeFlaky"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	resp := readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	if resp.ID != "s1" {
+		t.Fatalf("expected subscribe response, got id %q", resp.ID)
+	}
+
+	server.TriggerRefresh("flaky")
+
+	errMsg := readMessageOfType(t, ws, TypeError, 3*time.Second)
+	if errMsg.ID != "s1" || errMsg.Code != CodeInternalError {
+		t.Errorf("expected internal error for s1, got id=%q code=%d", errMsg.ID, errMsg.Code)
+	}
+
+	// Server must still be functional.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "2", Method: "PanicHandlers.Safe", Params: jsontext.Value(`[{"message":"alive"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	resp = readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	if resp.ID != "2" {
+		t.Errorf("expected response for request 2, got %q", resp.ID)
+	}
+}
+
+func setupHardeningServer(t *testing.T, opts ServerOptions) (*httptest.Server, *Server) {
+	t.Helper()
+	registry := NewRegistry()
+	handlers := &IntegrationHandlers{}
+	registry.Register(handlers)
+	registry.RegisterPushEventFor(handlers, NotificationEvent{})
+	server := NewServer(registry, opts)
+	handlers.server = server
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+	return ts, server
+}
+
+func waitForConnCount(t *testing.T, server *Server, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if server.ConnectionCount() == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("connection count never reached %d (still %d)", want, server.ConnectionCount())
+}
+
+// A frame larger than MaxMessageSize must close the connection instead of
+// being buffered in full.
+func TestMaxMessageSizeClosesConnection(t *testing.T) {
+	ts, server := setupHardeningServer(t, ServerOptions{MaxMessageSize: 1024})
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+	waitForConnCount(t, server, 1, 2*time.Second)
+
+	big := `{"type":"request","id":"1","method":"IntegrationHandlers.Echo","params":[{"message":"` + strings.Repeat("x", 8192) + `"}]}`
+	// The server may tear the connection down while we are still writing,
+	// so a write error here is the same expected outcome as a read error.
+	if err := ws.WriteMessage(websocket.TextMessage, []byte(big)); err == nil {
+		_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				break // connection closed by server, as expected
+			}
+		}
+	}
+	waitForConnCount(t, server, 0, 3*time.Second)
+}
+
+// The server must send WebSocket pings at the configured interval.
+func TestServerSendsPings(t *testing.T) {
+	ts, _ := setupHardeningServer(t, ServerOptions{PingInterval: 50 * time.Millisecond})
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	pinged := make(chan struct{}, 1)
+	ws.SetPingHandler(func(string) error {
+		select {
+		case pinged <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+
+	go func() {
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-pinged:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server never sent a ping")
+	}
+}
+
+// A peer that never reads (and therefore never answers pings) must be
+// dropped after PongTimeout instead of lingering forever.
+func TestUnresponsivePeerDropped(t *testing.T) {
+	ts, server := setupHardeningServer(t, ServerOptions{
+		PingInterval: 25 * time.Millisecond,
+		PongTimeout:  150 * time.Millisecond,
+	})
+
+	ws := connectWS(t, ts) // reads config, then never reads again
+	defer ws.Close()
+	waitForConnCount(t, server, 1, 2*time.Second)
+
+	// Don't read: no pong responses are generated.
+	waitForConnCount(t, server, 0, 5*time.Second)
+}
+
+// A client that stops reading must not be able to wedge the whole server:
+// Broadcast must not block other connections, and the stalled client must
+// be dropped via the write timeout.
+func TestStalledClientDoesNotBlockServer(t *testing.T) {
+	ts, server := setupHardeningServer(t, ServerOptions{
+		WriteTimeout: 200 * time.Millisecond,
+	})
+
+	// Client A connects and then stops reading entirely.
+	wsA := connectWS(t, ts)
+	defer wsA.Close()
+
+	// Client B connects and drains everything in the background.
+	wsB := connectWS(t, ts)
+	defer wsB.Close()
+	go func() {
+		for {
+			if _, _, err := wsB.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+	waitForConnCount(t, server, 2, 2*time.Second)
+
+	// Flood broadcasts until A's send queue and socket buffers are full.
+	big := strings.Repeat("x", 64*1024)
+	floodDone := make(chan struct{})
+	go func() {
+		defer close(floodDone)
+		for i := 0; i < 5000 && server.ConnectionCount() > 1; i++ {
+			server.Broadcast(&NotificationEvent{Message: big})
+		}
+	}()
+
+	// The stalled client must get dropped (write timeout), which also
+	// proves the server's run loop and locks were never wedged.
+	waitForConnCount(t, server, 1, 15*time.Second)
+
+	select {
+	case <-floodDone:
+	case <-time.After(15 * time.Second):
+		t.Fatal("broadcast flood never finished — Broadcast is blocked on the stalled connection")
+	}
+
+	// A fresh connection must work normally.
+	wsC := connectWS(t, ts)
+	defer wsC.Close()
+	if err := wsC.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "IntegrationHandlers.Echo", Params: jsontext.Value(`[{"message":"hello"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	resp := readMessageOfType(t, wsC, TypeResponse, 5*time.Second)
+	if resp.ID != "1" {
+		t.Errorf("expected echo response, got id %q", resp.ID)
+	}
+}
+
+// SSE RPC bodies above MaxMessageSize must be rejected with 413.
+func TestSSEBodyLimit(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&PanicHandlers{})
+	server := NewServer(registry, ServerOptions{MaxMessageSize: 1024})
+
+	ts := httptest.NewServer(server.HTTPTransport())
+	t.Cleanup(ts.Close)
+
+	body := `{"connectionId":"x","id":"1","method":"PanicHandlers.Safe","params":[{"message":"` + strings.Repeat("a", 8192) + `"}]}`
+	resp, err := http.Post(ts.URL+"/rpc", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d", resp.StatusCode)
+	}
+}
+
+// Defaults and merge semantics for the hardening options.
+func TestHardeningOptionDefaults(t *testing.T) {
+	opts := defaultServerOptions()
+	if opts.MaxMessageSize != 4<<20 {
+		t.Errorf("default MaxMessageSize = %d, want %d", opts.MaxMessageSize, 4<<20)
+	}
+	if opts.WriteTimeout != 30*time.Second {
+		t.Errorf("default WriteTimeout = %v, want 30s", opts.WriteTimeout)
+	}
+	if opts.PingInterval != 30*time.Second {
+		t.Errorf("default PingInterval = %v, want 30s", opts.PingInterval)
+	}
+	if opts.PongTimeout != 60*time.Second {
+		t.Errorf("default PongTimeout = %v, want 60s", opts.PongTimeout)
+	}
+
+	// Negative values disable a limit and must survive the merge.
+	registry := NewRegistry()
+	server := NewServer(registry, ServerOptions{MaxMessageSize: -1, WriteTimeout: -1, PingInterval: -1, PongTimeout: -1})
+	defer server.Stop(context.Background())
+	if server.options.MaxMessageSize != -1 || server.options.WriteTimeout != -1 || server.options.PingInterval != -1 || server.options.PongTimeout != -1 {
+		t.Errorf("negative (disabled) options were not preserved: %+v", server.options)
+	}
+}

--- a/sse_handler.go
+++ b/sse_handler.go
@@ -3,6 +3,7 @@ package aprot
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -11,6 +12,26 @@ import (
 	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 )
+
+// decodeBody unmarshals a request body into v, enforcing the server's
+// MaxMessageSize. It writes the error response itself and returns false
+// when the body is invalid or too large.
+func (h *sseHandler) decodeBody(w http.ResponseWriter, r *http.Request, v any) bool {
+	body := r.Body
+	if h.server.options.MaxMessageSize > 0 {
+		body = http.MaxBytesReader(w, r.Body, h.server.options.MaxMessageSize)
+	}
+	if err := json.UnmarshalRead(body, v); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return false
+		}
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
 
 // sseHandler handles SSE+HTTP transport.
 type sseHandler struct {
@@ -156,8 +177,7 @@ func (h *sseHandler) handleRPC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req rpcRequest
-	if err := json.UnmarshalRead(r.Body, &req); err != nil {
-		http.Error(w, "invalid JSON", http.StatusBadRequest)
+	if !h.decodeBody(w, r, &req) {
 		return
 	}
 
@@ -205,8 +225,7 @@ type cancelRequestBody struct {
 
 func (h *sseHandler) handleCancel(w http.ResponseWriter, r *http.Request) {
 	var req cancelRequestBody
-	if err := json.UnmarshalRead(r.Body, &req); err != nil {
-		http.Error(w, "invalid JSON", http.StatusBadRequest)
+	if !h.decodeBody(w, r, &req) {
 		return
 	}
 

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -325,7 +325,12 @@ func startSharedTask[M any](ctx context.Context, title string) (context.Context,
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()
 
-	if slot := taskSlotFromContext(ctx); slot != nil {
+	// A detached context (context.WithoutCancel — recognizable by its nil
+	// Done channel) is the documented fire-and-forget pattern: the task
+	// outlives the handler, so it must not be auto-finalized by the task
+	// middleware when the handler returns. The background goroutine owns
+	// completion via Task.Close / Task.Fail / Task.Err.
+	if slot := taskSlotFromContext(ctx); slot != nil && ctx.Done() != nil {
 		slot.node = node
 	}
 

--- a/tasks/detached_task_test.go
+++ b/tasks/detached_task_test.go
@@ -1,0 +1,109 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marrasen/aprot"
+)
+
+// A shared task started on a detached context (context.WithoutCancel) is the
+// documented fire-and-forget pattern: it must NOT be auto-completed by the
+// task middleware when the handler returns, and its context must stay alive
+// so a background goroutine can keep working.
+func TestStartSharedTaskDetachedOutlivesHandler(t *testing.T) {
+	_, tm := setupTestServer(t)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	defer reqCancel()
+
+	tc := newTestPushConn()
+	ctx := tc.WithContext(reqCtx)
+
+	var taskCtx context.Context
+	var task *Task[struct{}]
+
+	mw := taskMiddleware(tm)
+	handler := mw(func(ctx context.Context, req *aprot.Request) (any, error) {
+		taskCtx, task = StartTask[struct{}](context.WithoutCancel(ctx), "bg-job", Shared())
+		if task == nil {
+			t.Fatal("StartTask returned nil")
+		}
+		return "ok", nil
+	})
+
+	if _, err := handler(ctx, &aprot.Request{ID: "r1", Method: "test"}); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	// Simulate connection.go defer cancel() after the handler returns.
+	reqCancel()
+
+	// The background task must still be running with a live context.
+	if err := taskCtx.Err(); err != nil {
+		t.Fatalf("detached task context was canceled by middleware finalize: %v", err)
+	}
+
+	found := false
+	for _, s := range tm.snapshotAll() {
+		if s.Title == "bg-job" {
+			found = true
+			if s.Status != TaskNodeStatusRunning {
+				t.Errorf("detached task status = %q, want running", s.Status)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("detached task was removed from the manager after the handler returned")
+	}
+
+	// The background goroutine remains responsible for finishing it.
+	task.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stillThere := false
+		for _, s := range tm.snapshotAll() {
+			if s.Title == "bg-job" && s.Status == TaskNodeStatusRunning {
+				stillThere = true
+			}
+		}
+		if !stillThere {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("task.Close() did not complete the detached task")
+}
+
+// A disconnect while the handler is still running must not fail a detached
+// shared task either.
+func TestStartSharedTaskDetachedSurvivesDisconnect(t *testing.T) {
+	_, tm := setupTestServer(t)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	defer reqCancel()
+
+	tc := newTestPushConn()
+	ctx := tc.WithContext(reqCtx)
+
+	var taskCtx context.Context
+
+	mw := taskMiddleware(tm)
+	handler := mw(func(ctx context.Context, req *aprot.Request) (any, error) {
+		taskCtx, _ = StartTask[struct{}](context.WithoutCancel(ctx), "bg-survive", Shared())
+		// Client disconnects mid-handler.
+		reqCancel()
+		return nil, nil
+	})
+
+	_, _ = handler(ctx, &aprot.Request{ID: "r1", Method: "test"})
+
+	if err := taskCtx.Err(); err != nil {
+		t.Fatalf("detached task context canceled on disconnect: %v", err)
+	}
+	for _, s := range tm.snapshotAll() {
+		if s.Title == "bg-survive" && s.Status == TaskNodeStatusFailed {
+			t.Fatalf("detached task was failed with %q on disconnect", s.Error)
+		}
+	}
+}

--- a/tasks/doc.go
+++ b/tasks/doc.go
@@ -57,12 +57,24 @@
 // All clients receive [TaskStateEvent] and [TaskUpdateEvent] push events.
 // Each client sees an IsOwner flag indicating whether it started the task.
 //
-// To let a shared task outlive the client connection, use
+// A shared task started on the request context is auto-completed (or
+// auto-failed) when the handler returns, like a request-scoped task.
+//
+// To let a shared task outlive the handler and the client connection —
+// the fire-and-forget pattern — start it on a detached context with
 // [context.WithoutCancel]:
 //
 //	ctx, task := tasks.StartTask[MyMeta](
 //	    context.WithoutCancel(ctx), "Background job", tasks.Shared(),
 //	)
+//	go func() {
+//	    defer task.Err(doWork(ctx)) // completes or fails the task
+//	}()
+//	return &tasks.TaskRef{TaskID: task.ID()}, nil
+//
+// A detached task is not auto-finalized when the handler returns: the
+// background goroutine owns its lifecycle and must call [Task.Close],
+// [Task.Fail], or [Task.Err] when done.
 //
 // # SharedSubTask bridge
 //

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -12,13 +12,15 @@ type wsTransport struct {
 	ws   *websocket.Conn
 	send chan []byte
 	done chan struct{} // closed once to signal shutdown; makes Send a no-op
+	opts ServerOptions // read limit, write timeout, and keepalive settings
 }
 
-func newWSTransport(ws *websocket.Conn) *wsTransport {
+func newWSTransport(ws *websocket.Conn, opts ServerOptions) *wsTransport {
 	return &wsTransport{
 		ws:   ws,
 		send: make(chan []byte, 256),
 		done: make(chan struct{}),
+		opts: opts,
 	}
 }
 
@@ -27,7 +29,8 @@ func (t *wsTransport) Send(data []byte) error {
 	// immediately if the transport is closed. Previously this method dropped
 	// on a full buffer, which silently lost responses/progress for slow
 	// clients; streams need guaranteed delivery and all other message types
-	// benefit too.
+	// benefit too. The wait is bounded: writePump enforces WriteTimeout, so
+	// a peer that stops reading is closed instead of stalling senders forever.
 	select {
 	case <-t.done:
 		return ErrConnectionClosed
@@ -63,35 +66,73 @@ func (t *wsTransport) CloseGracefully() error {
 }
 
 // readPump reads messages from the WebSocket and dispatches them to the connection.
+// It enforces MaxMessageSize and, when keepalive pings are enabled, a read
+// deadline that drops half-open connections whose peer no longer responds.
 func (t *wsTransport) readPump(conn *Conn) {
 	defer func() {
 		conn.server.unregister <- conn
 		t.ws.Close()
 	}()
 
+	if t.opts.MaxMessageSize > 0 {
+		t.ws.SetReadLimit(t.opts.MaxMessageSize)
+	}
+	keepalive := t.opts.PingInterval > 0 && t.opts.PongTimeout > 0
+	if keepalive {
+		_ = t.ws.SetReadDeadline(time.Now().Add(t.opts.PongTimeout))
+		t.ws.SetPongHandler(func(string) error {
+			return t.ws.SetReadDeadline(time.Now().Add(t.opts.PongTimeout))
+		})
+	}
+
 	for {
 		_, data, err := t.ws.ReadMessage()
 		if err != nil {
 			return
 		}
+		if keepalive {
+			// Any inbound traffic proves liveness, not just pongs.
+			_ = t.ws.SetReadDeadline(time.Now().Add(t.opts.PongTimeout))
+		}
 		conn.handleIncomingMessage(data)
 	}
 }
 
-// writePump writes messages from the send channel to the WebSocket.
-// It exits when done is closed; the send channel is never closed (only
-// the sender should close a channel, but multiple goroutines may send).
+// writePump writes messages from the send channel to the WebSocket and sends
+// keepalive pings. It exits when done is closed; the send channel is never
+// closed (only the sender should close a channel, but multiple goroutines may
+// send).
 func (t *wsTransport) writePump() {
 	defer t.ws.Close()
+
+	var pingC <-chan time.Time
+	if t.opts.PingInterval > 0 {
+		ticker := time.NewTicker(t.opts.PingInterval)
+		defer ticker.Stop()
+		pingC = ticker.C
+	}
 
 	for {
 		select {
 		case <-t.done:
 			return
+		case <-pingC:
+			if err := t.writeMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
 		case data := <-t.send:
-			if err := t.ws.WriteMessage(websocket.TextMessage, data); err != nil {
+			if err := t.writeMessage(websocket.TextMessage, data); err != nil {
 				return
 			}
 		}
 	}
+}
+
+// writeMessage writes one frame, bounded by WriteTimeout so a peer that
+// stops reading cannot stall the pump (and with it every Send caller).
+func (t *wsTransport) writeMessage(messageType int, data []byte) error {
+	if t.opts.WriteTimeout > 0 {
+		_ = t.ws.SetWriteDeadline(time.Now().Add(t.opts.WriteTimeout))
+	}
+	return t.ws.WriteMessage(messageType, data)
 }


### PR DESCRIPTION
Implements the P0 and P1 findings from #207. All fixes were developed test-first: every bug has a regression test that failed before the fix (the panic test crashed the entire test process, the stall test deadlocked, the REST tests returned 400).

## P0 — server hardening

- **Stalled-client deadlock (#207 item 1):** `writePump` now enforces `WriteTimeout` per frame, and `Broadcast` / `PushToUser` / `ForEachConn` snapshot the connection set and send **outside** `s.mu`. A client that stops reading gets dropped instead of wedging register/unregister for the whole server. Covered by `TestStalledClientDoesNotBlockServer`.
- **Handler panics (#207 item 2):** `handleRequest`, `handleSubscribe`, and `refreshSubscription` recover panics and respond with `CodeInternalError`, mirroring `net/http`. Covered by `TestHandlerPanicRecovered`, `TestSubscribeHandlerPanicRecovered`, `TestRefreshPanicRecovered`.
- **Limits & keepalive (#207 item 3):** new `ServerOptions` fields, all with `-1` to disable:
  - `MaxMessageSize` (default 4 MiB) — `SetReadLimit` on WS, `http.MaxBytesReader` (413) on SSE rpc/cancel bodies
  - `WriteTimeout` (default 30s)
  - `PingInterval` / `PongTimeout` (defaults 30s/60s) — WS keepalive pings + read deadline so half-open connections are cleaned up
- **Origin check (#207 item 4):** documented the allow-all default and the CSWSH risk for cookie-auth deployments in README, doc.go, APROT_AI.md, and on `SetCheckOrigin` itself. The default is unchanged to avoid breaking non-browser clients.

## P1 — broken documented features

- **REST scalar path params (#207 item 5):** path values are converted to the JSON type the handler expects, so `GetItem(ctx, id int)` works; invalid values return a clear 400. REST responses now go through the shared sql.Null-aware marshaler, so the wire format matches WS/SSE.
- **Detached shared tasks (#207 item 6):** `StartTask(..., Shared())` on a `context.WithoutCancel` context (recognizable by its nil `Done()`) is no longer auto-finalized by the task middleware — the documented fire-and-forget pattern now actually works, and the background goroutine owns completion via `Task.Close/Fail/Err`. Inline shared tasks keep the existing auto-finalize behavior (existing test `TestStartSharedTaskMiddlewareFinalize` still passes).

## Hygiene

- CI uses `go-version-file: go.mod` (jobs were pinned to Go 1.25 while go.mod requires 1.26)
- `go mod tidy` (validator/v10 was misfiled as indirect)
- APROT_AI.md drift fixes: `StartSharedTask` → `StartTask`+`Shared()`, removed nonexistent `useMutation`, corrected generated hook names (`useNumbers`, `onUserCreatedEvent`)

## Behavior changes to be aware of

Previously-unlimited deployments now get default limits: 4 MiB max inbound message, 30s write timeout, 30s/60s ping/pong keepalive. Any of them can be restored to the old unlimited behavior with `-1`. The detached-shared-task change only affects tasks started on `WithoutCancel` contexts, which previously got killed on handler return — nothing could have depended on that.

`go test ./... -race` passes. Remaining #207 items (P2 runtime races, codegen drift, P3) are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
