### PR TITLE
Runtime lifecycle hardening (P2 from #207)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -73,6 +73,13 @@ func (c *Conn) ID() uint64 {
 	return c.id
 }
 
+// isClosed reports whether the connection has been closed.
+func (c *Conn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
 // Info returns HTTP request information captured at connection time.
 func (c *Conn) Info() ConnInfo {
 	return c.info
@@ -250,8 +257,26 @@ func (c *Conn) sendProgress(id string, current, total int, message string) {
 
 func (c *Conn) registerRequest(id string, cancel context.CancelCauseFunc) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	if c.closed {
+		// The connection was closed between the request goroutine starting and
+		// reaching here. close() already swept c.requests, so storing this
+		// cancel would leak it: the handler would block on ctx.Done() forever,
+		// holding requestsWg and stalling Server.Stop. Cancel immediately.
+		c.mu.Unlock()
+		cancel(ErrConnectionClosed)
+		return
+	}
+	// A client may (maliciously or accidentally) reuse an in-flight request
+	// ID. Overwriting the map entry would orphan the previous request's
+	// cancel func — its context would never be canceled until the connection
+	// closes. Cancel the shadowed request instead.
+	old := c.requests[id]
 	c.requests[id] = cancel
+	c.mu.Unlock()
+
+	if old != nil {
+		old(ErrClientCanceled)
+	}
 }
 
 func (c *Conn) unregisterRequest(id string) {
@@ -570,14 +595,20 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	if len(keys) > 0 {
 		if c.server.subscriptions.has(c.id, msg.ID) {
 			c.server.subscriptions.updateKeys(c.id, msg.ID, keys)
-		} else {
-			c.server.subscriptions.register(&subscription{
-				conn:   c,
-				id:     msg.ID,
-				method: msg.Method,
-				keys:   keys,
-				params: msg.Params,
-			})
+			// Re-subscribe with the same ID may carry new params; refresh them
+			// so server-driven re-execution doesn't replay the stale ones.
+			c.server.subscriptions.updateParams(c.id, msg.ID, msg.Params)
+		} else if !c.server.subscriptions.register(&subscription{
+			conn:   c,
+			id:     msg.ID,
+			method: msg.Method,
+			keys:   keys,
+			params: msg.Params,
+		}) {
+			// The connection closed while the handler was running; the
+			// subscription was refused so it can't outlive the conn. Don't
+			// send a response — the transport is gone.
+			return
 		}
 	}
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1,0 +1,407 @@
+package aprot
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/gorilla/websocket"
+)
+
+// userConnCount returns the number of connections tracked for a user.
+func userConnCount(s *Server, userID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.userConns[userID])
+}
+
+// waitForUserConnCount polls until the user's tracked connection count reaches
+// want, failing the test on timeout. Association happens on the server's
+// connection goroutine, so a poll avoids racing it.
+func waitForUserConnCount(t *testing.T, s *Server, userID string, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if userConnCount(s, userID) == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("userConns[%q] never reached %d (still %d)", userID, want, userConnCount(s, userID))
+}
+
+func wsURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}
+
+// A request that registers after the connection has been closed must be
+// canceled immediately. Otherwise a handler blocking on ctx.Done() runs
+// forever, holds requestsWg, and stalls Server.Stop. (#207 P2)
+func TestRegisterRequestAfterCloseCancelsImmediately(t *testing.T) {
+	tc := NewTestPushConn(1)
+	c := tc.Conn
+
+	c.close()
+
+	var gotCause error
+	called := false
+	cancel := func(cause error) {
+		called = true
+		gotCause = cause
+	}
+	c.registerRequest("late", cancel)
+
+	if !called {
+		t.Fatal("late request registered after close was never canceled (leaks requestsWg, stalls Stop)")
+	}
+	if gotCause != ErrConnectionClosed {
+		t.Errorf("cancel cause = %v, want ErrConnectionClosed", gotCause)
+	}
+
+	c.mu.Lock()
+	_, exists := c.requests["late"]
+	c.mu.Unlock()
+	if exists {
+		t.Error("a canceled late request must not be retained in c.requests")
+	}
+}
+
+// A connect hook that rejects the connection after an earlier hook called
+// SetUserID must not leave the connection registered in userConns. Otherwise
+// a later PushToUser fills the dead connection's send buffer and can wedge
+// the server. (#207 P2)
+func TestConnectHookRejectionAfterSetUserIDDisassociates(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&IntegrationHandlers{})
+	server := NewServer(registry)
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		conn.SetUserID("u1")
+		return nil
+	})
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		return errors.New("rejected by policy")
+	})
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+	defer server.Stop(context.Background())
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL(ts.URL), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.Close()
+
+	// The connection associates "u1" during the first hook, then the second
+	// hook rejects it; the rejection path must disassociate it back to 0.
+	waitForUserConnCount(t, server, "u1", 0, 2*time.Second)
+}
+
+// Same guarantee for the SSE transport.
+func TestSSEConnectHookRejectionAfterSetUserIDDisassociates(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&IntegrationHandlers{})
+	server := NewServer(registry)
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		conn.SetUserID("u1")
+		return nil
+	})
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		return errors.New("rejected by policy")
+	})
+	ts := httptest.NewServer(server.HTTPTransport())
+	defer ts.Close()
+	defer server.Stop(context.Background())
+
+	resp, err := ts.Client().Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET SSE: %v", err)
+	}
+	defer resp.Body.Close()
+
+	waitForUserConnCount(t, server, "u1", 0, 2*time.Second)
+}
+
+// --- Re-subscribe params freshness (#207 P2) ---
+
+type paramReq struct {
+	Tag string `json:"tag"`
+}
+
+type paramResp struct {
+	Tag string `json:"tag"`
+}
+
+type paramSubHandlers struct{}
+
+// Watch is a subscribable handler: it echoes the request tag and registers a
+// fixed refresh trigger so a server-driven refresh re-executes it using the
+// subscription's stored params.
+func (h *paramSubHandlers) Watch(ctx context.Context, req *paramReq) (*paramResp, error) {
+	RegisterRefreshTrigger(ctx, "watch")
+	return &paramResp{Tag: req.Tag}, nil
+}
+
+// readResponseTag reads messages until a response for wantID arrives and
+// returns its result tag.
+func readResponseTag(t *testing.T, ws *websocket.Conn, wantID string, timeout time.Duration) string {
+	t.Helper()
+	_ = ws.SetReadDeadline(time.Now().Add(timeout))
+	defer ws.SetReadDeadline(time.Time{})
+	for {
+		var msg struct {
+			Type   MessageType `json:"type"`
+			ID     string      `json:"id"`
+			Result paramResp   `json:"result"`
+		}
+		if err := ws.ReadJSON(&msg); err != nil {
+			t.Fatalf("waiting for response %q: %v", wantID, err)
+		}
+		if msg.Type == TypeResponse && msg.ID == wantID {
+			return msg.Result.Tag
+		}
+	}
+}
+
+// Re-subscribing with the same ID but different params must update the stored
+// params, so a later server-driven refresh re-executes with the new params,
+// not the stale ones from the first subscribe. (#207 P2)
+func TestReSubscribeUpdatesStoredParams(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&paramSubHandlers{})
+	server := NewServer(registry)
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+	defer server.Stop(context.Background())
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	sub := func(tag string) {
+		if err := ws.WriteJSON(IncomingMessage{
+			Type:   TypeSubscribe,
+			ID:     "s1",
+			Method: "paramSubHandlers.Watch",
+			Params: jsontext.Value(`[{"tag":"` + tag + `"}]`),
+		}); err != nil {
+			t.Fatalf("subscribe write: %v", err)
+		}
+		if got := readResponseTag(t, ws, "s1", 3*time.Second); got != tag {
+			t.Fatalf("subscribe response tag = %q, want %q", got, tag)
+		}
+	}
+
+	sub("first")
+	sub("second") // re-subscribe with same ID, new params
+
+	server.TriggerRefresh("watch")
+
+	if got := readResponseTag(t, ws, "s1", 3*time.Second); got != "second" {
+		t.Errorf("server-driven refresh used stale params: tag = %q, want %q", got, "second")
+	}
+}
+
+// A subscription must not be registered for a connection that has already
+// been closed. The handler's ctx.Err() guard runs before register(), so a
+// close racing in between could otherwise leave a subscription that
+// re-executes forever on every TriggerRefresh and writes to a dead
+// transport. register() must refuse closed connections. (#207 P2)
+func TestSubscribeRegisterAfterCloseDoesNotLeak(t *testing.T) {
+	tc := NewTestPushConn(7)
+	c := tc.Conn
+	sm := c.server.subscriptions
+
+	c.close() // sets closed, runs unregisterConn
+
+	sub := &subscription{
+		conn:   c,
+		id:     "s1",
+		method: "X",
+		keys:   map[string]struct{}{"k": {}},
+	}
+	sm.register(sub)
+
+	if sm.has(c.id, "s1") {
+		t.Fatal("subscription registered for a closed connection leaks forever")
+	}
+}
+
+// --- Server.Stop lifecycle (#207 P2) ---
+
+// (a) A connection that registers after shutdown began must be closed by
+// run() and must not keep the server alive, or Stop hangs forever waiting
+// for the connection set to drain.
+func TestStopClosesConnectionRegisteredDuringShutdown(t *testing.T) {
+	server := NewServer(NewRegistry())
+
+	rt := &recordingTransport{}
+	conn := &Conn{
+		transport: rt,
+		server:    server,
+		requests:  make(map[string]context.CancelCauseFunc),
+		id:        99,
+	}
+
+	// Simulate ServeHTTP registering a connection after Stop has begun.
+	server.stopping.Store(true)
+	server.register <- conn
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- server.Stop(context.Background()) }()
+
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("Stop returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Server.Stop hung: a connection registered during shutdown was never drained")
+	}
+}
+
+// (b) A connection that finishes connecting after run() has already exited
+// must not block forever trying to register — ServeHTTP must give up.
+func TestLateConnectAfterStopDoesNotLeak(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&IntegrationHandlers{})
+	server := NewServer(registry)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		once.Do(func() { close(entered) })
+		<-release
+		return nil
+	})
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	connectDone := make(chan struct{})
+	go func() {
+		defer close(connectDone)
+		ws, _, err := websocket.DefaultDialer.Dial(wsURL(ts.URL), nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	<-entered // the connection is in the hook, not yet registered
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- server.Stop(context.Background()) }()
+
+	// Let Stop set stopping + drain (the in-hook conn isn't in its snapshot),
+	// then release the hook so the connection tries to register afterwards.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Server.Stop hung")
+	}
+	select {
+	case <-connectDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connection goroutine leaked: ServeHTTP blocked forever on register after run() exited")
+	}
+}
+
+// (c) Stop must honor the caller's context even on the final drain wait — a
+// pathological (e.g. blocking) disconnect hook must not hang Stop past its
+// deadline.
+func TestStopRespectsContextOnFinalWait(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&IntegrationHandlers{})
+	server := NewServer(registry)
+	server.OnDisconnect(func(ctx context.Context, conn *Conn) {
+		select {} // hang forever
+	})
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+	waitForConnCount(t, server, 1, 2*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- server.Stop(ctx) }()
+
+	select {
+	case err := <-stopDone:
+		if err == nil {
+			t.Fatal("Stop returned nil; expected context deadline error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Server.Stop ignored its context and hung on a blocking disconnect hook")
+	}
+}
+
+// --- Small races (#207 P2) ---
+
+// Reusing an in-flight request ID must cancel the previously-registered
+// request. Otherwise the old cancel func is silently overwritten in the
+// requests map, and the shadowed request's context leaks until the whole
+// connection closes. (#207 P2)
+func TestRegisterRequestIDCollisionCancelsPrevious(t *testing.T) {
+	tc := NewTestPushConn(2)
+	c := tc.Conn
+
+	var firstCause error
+	firstCanceled := false
+	c.registerRequest("dup", func(cause error) {
+		firstCanceled = true
+		firstCause = cause
+	})
+	c.registerRequest("dup", func(cause error) {})
+
+	if !firstCanceled {
+		t.Fatal("reusing an in-flight request ID must cancel the shadowed request to avoid a leak")
+	}
+	if firstCause != ErrClientCanceled {
+		t.Errorf("shadowed request cancel cause = %v, want ErrClientCanceled", firstCause)
+	}
+}
+
+// SetUserID racing a disconnect (disassociateUser) must not be a data race on
+// Conn.userID. This is primarily a guard for `go test -race` in CI; it should
+// always pass otherwise. (#207 P2)
+func TestSetUserIDConcurrentWithDisassociate(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&IntegrationHandlers{})
+	server := NewServer(registry)
+	defer server.Stop(context.Background())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		conn := &Conn{
+			server:   server,
+			requests: make(map[string]context.CancelCauseFunc),
+			id:       uint64(i + 1),
+		}
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			conn.SetUserID("u")
+		}()
+		go func() {
+			defer wg.Done()
+			server.disassociateUser(conn)
+		}()
+	}
+	wg.Wait()
+}

--- a/server.go
+++ b/server.go
@@ -270,15 +270,21 @@ func (s *Server) associateUser(conn *Conn, userID string) {
 
 // disassociateUser removes a connection from user tracking.
 func (s *Server) disassociateUser(conn *Conn) {
+	// Read userID under the connection's own lock (it is written there by
+	// SetUserID); reading it under s.mu alone is a data race. UserID() takes
+	// c.mu and returns before we acquire s.mu, so the two locks never nest.
+	userID := conn.UserID()
+	if userID == "" {
+		return
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if conn.userID != "" {
-		if conns, ok := s.userConns[conn.userID]; ok {
-			delete(conns, conn)
-			if len(conns) == 0 {
-				delete(s.userConns, conn.userID)
-			}
+	if conns, ok := s.userConns[userID]; ok {
+		delete(conns, conn)
+		if len(conns) == 0 {
+			delete(s.userConns, userID)
 		}
 	}
 }
@@ -337,6 +343,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Run connect hooks before starting message processing
 	if err := s.runConnectHooks(ctx, conn); err != nil {
+		// A hook may have called SetUserID before a later hook rejected the
+		// connection; undo that association so a dead conn can't linger in
+		// userConns and have a later PushToUser block on its send buffer.
+		s.disassociateUser(conn)
 		// Send rejection directly before pumps start
 		sendConnectionRejectedWS(ws, err)
 		ws.Close()
@@ -346,7 +356,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Send config directly before pumps start
 	sendConfigWS(ws, s.options)
 
-	s.register <- conn
+	// Register the connection, but don't block forever if the server has
+	// already shut down (run() has exited and will never read s.register).
+	select {
+	case s.register <- conn:
+	case <-s.done:
+		s.disassociateUser(conn)
+		ws.Close()
+		return
+	}
 
 	go wst.writePump()
 	wst.readPump(conn)
@@ -389,6 +407,14 @@ func (s *Server) run() {
 	for {
 		select {
 		case conn := <-s.register:
+			if s.stopping.Load() {
+				// This connection registered after Stop's close sweep, so it
+				// would otherwise never be closed and would keep run() from
+				// ever seeing an empty connection set. Close it and don't
+				// track it; its pumps tear down on their own.
+				conn.close()
+				continue
+			}
 			s.mu.Lock()
 			s.conns[conn] = struct{}{}
 			s.mu.Unlock()
@@ -462,10 +488,15 @@ func (s *Server) Stop(ctx context.Context) error {
 
 	// Signal run() to exit
 	s.stopOnce.Do(func() { close(s.stopCh) })
-	// Wait for run() to finish processing remaining unregister events
-	<-s.done
-
-	return nil
+	// Wait for run() to finish processing remaining unregister events, but
+	// don't ignore the caller's deadline — a pathological disconnect hook or
+	// a wedged connection must not be able to hang Stop forever.
+	select {
+	case <-s.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Registry returns the server's handler registry.

--- a/sse_handler.go
+++ b/sse_handler.go
@@ -87,6 +87,10 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Run connect hooks
 	if err := h.server.runConnectHooks(r.Context(), conn); err != nil {
+		// A hook may have called SetUserID before a later hook rejected the
+		// connection; undo that association so a dead conn can't linger in
+		// userConns and have a later PushToUser block on its send buffer.
+		h.server.disassociateUser(conn)
 		code := CodeConnectionRejected
 		var message string
 		var errData any
@@ -131,7 +135,18 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	h.connections[connectionID] = conn
 	h.mu.Unlock()
 
-	h.server.register <- conn
+	// Register, but don't block forever if the server has already shut down
+	// (run() has exited and will never read s.register).
+	select {
+	case h.server.register <- conn:
+	case <-h.server.done:
+		h.server.disassociateUser(conn)
+		h.mu.Lock()
+		delete(h.connections, connectionID)
+		h.mu.Unlock()
+		sseT.Close()
+		return
+	}
 
 	// Keep-alive loop, blocks until client disconnects
 	keepAlive := time.NewTicker(15 * time.Second)

--- a/subscription.go
+++ b/subscription.go
@@ -37,9 +37,20 @@ func newSubscriptionManager() *subscriptionManager {
 	}
 }
 
-func (sm *subscriptionManager) register(sub *subscription) {
+// register adds a subscription to the indexes. It reports whether the
+// subscription was added; it refuses connections that have already been
+// closed, so a subscribe handler that races a disconnect cannot leave a
+// subscription that outlives its connection (re-executing forever and
+// writing to a dead transport). The closed check holds sm.mu while reading
+// the conn's lock; this never nests against close(), which releases the
+// conn lock before calling unregisterConn.
+func (sm *subscriptionManager) register(sub *subscription) bool {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+
+	if sub.conn.isClosed() {
+		return false
+	}
 
 	connID := sub.conn.id
 
@@ -56,6 +67,7 @@ func (sm *subscriptionManager) register(sub *subscription) {
 		}
 		sm.byKey[key][sub] = struct{}{}
 	}
+	return true
 }
 
 func (sm *subscriptionManager) unregister(connID uint64, subID string) {
@@ -143,6 +155,20 @@ func (sm *subscriptionManager) updateKeys(connID uint64, subID string, newKeys m
 			sm.byKey[key] = make(map[*subscription]struct{})
 		}
 		sm.byKey[key][sub] = struct{}{}
+	}
+}
+
+// updateParams replaces the stored raw params for a subscription. Called when
+// a client re-subscribes with the same ID but different params, so that
+// server-driven re-execution uses the latest params rather than stale ones.
+func (sm *subscriptionManager) updateParams(connID uint64, subID string, params jsontext.Value) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if connSubs, ok := sm.byConn[connID]; ok {
+		if sub, ok := connSubs[subID]; ok {
+			sub.params = params
+		}
 	}
 }
 


### PR DESCRIPTION
Implements the **P2 runtime correctness (connection/server lifecycle)** findings from #207. Every fix was developed test-first — each bug has a regression test that failed before the fix (the Stop-hang tests deadlocked for 5s, the leak tests left state behind, the collision test never canceled the shadowed request).

All new tests live in `lifecycle_test.go`. `go test ./...` and `gofmt`/`go vet` are clean. (Local `-race` is blocked by a ThreadSanitizer-on-Windows allocation limitation; CI runs `-race` on Linux.)

## Fixes

- **Request registered concurrently with close is never canceled** — `registerRequest` now checks `c.closed` and cancels immediately, so a handler blocking on `ctx.Done()` can't run forever holding `requestsWg` and stalling `Server.Stop`.
- **`Server.Stop` can hang forever / late register** — `run()` now closes (and does not track) a connection that registers after shutdown began, `ServeHTTP` and the SSE handler `select` on `s.done` instead of blocking forever on `s.register` after `run()` has exited, and `Stop`'s final drain wait honors the caller's context.
- **Connect-hook rejection after `SetUserID` leaks the conn in `userConns`** — both the WS and SSE rejection paths now call `disassociateUser`, so a rejected conn can't linger and have a later `PushToUser` block on its send buffer (which is the precondition for the P0-1 deadlock).
- **Subscription registered after `unregisterConn` leaks permanently** — `subscriptionManager.register` now refuses already-closed connections (returning a bool), closing the window between the `ctx.Err()` guard and `register` in `handleSubscribe`. Lock order is `sm.mu → c.mu`, which never nests against `close()` (it releases `c.mu` before calling `unregisterConn`).
- **Re-subscribe with the same ID keeps stale params** — re-subscribe now updates the stored `params` (new `updateParams`), so server-driven refreshes replay the latest params.
- **Small races** — `disassociateUser` reads `Conn.userID` under the connection lock instead of racing `SetUserID`; client-controlled request-ID collisions now cancel the shadowed request instead of orphaning its cancel func.

## Notes

No public API changes and no new struct tags — these are internal correctness fixes, so README/doc.go/APROT_AI.md need no updates. `Server.Stop`'s documented contract ("returns ctx.Err() if the context expires") is now actually honored on the final wait.

Remaining #207 work after this: P2 codegen drift, remaining tasks/ items, and P3 hygiene / e2e gaps.

Closes part of #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)