### PR TITLE
P3 hygiene: security CI, Dependabot, CHANGELOG, PongTimeout clamp (#207)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+updates:
+  # Go modules — one entry per module in the repo. Minor/patch bumps are
+  # grouped into a single weekly PR per module to keep the noise down; majors
+  # are raised individually so they can be reviewed on their own.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: gomod
+    directory: /example/vanilla
+    schedule:
+      interval: weekly
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: gomod
+    directory: /example/react
+    schedule:
+      interval: weekly
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: gomod
+    directory: /example/task-middleware
+    schedule:
+      interval: weekly
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: gomod
+    directory: /e2e
+    schedule:
+      interval: weekly
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]
+
+  # GitHub Actions used by the CI workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # npm packages for the example/e2e clients (only directories with a lockfile).
+  - package-ecosystem: npm
+    directory: /e2e
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: npm
+    directory: /example/react/client
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,34 @@ jobs:
           version: v2.10
           working-directory: e2e
 
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  gosec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run gosec
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          gosec ./...
+
   typescript-compile:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file was introduced at v0.44.0; for the history of earlier releases see the
+[git tags](https://github.com/marrasen/aprot/tags) and GitHub releases.
+
+## [Unreleased]
+
+### Added
+
+- Task lifecycle middleware: `tasks.Enable(registry, tasks.WithTaskMiddleware(mw))`,
+  with `TaskMiddleware` / `TaskInfo` and ctx propagation through nested subtasks (#205, #211).
+- Configurable request-param logging in the vanilla `LoggingMiddleware` (#212).
+- Server hardening options on `ServerOptions` — `MaxMessageSize`, `WriteTimeout`,
+  `PingInterval`, `PongTimeout` — plus WebSocket ping/pong keepalive (`-1` disables) (#208).
+- Runtime JSON unwrapping for generic `sql.Null[T]` for the common `T`
+  (`string`, `int`, `int64`, `int32`, `int16`, `float64`, `bool`, `time.Time`) (#213).
+- CI: `govulncheck` and `gosec` jobs, and a Dependabot config for the Go modules,
+  GitHub Actions, and the e2e / react-client npm packages (#207 P3).
+
+### Changed
+
+- TypeScript type mapping: a bare pointer `*T` (no `json:,omitempty`) now maps to
+  `T | null` (required), `map[bool]V` to `Partial<Record<"true" | "false", V>>`,
+  and `json.RawMessage` to `unknown` (#213).
+- OpenAPI output is now valid 3.0.3: boolean `exclusiveMinimum`/`exclusiveMaximum`
+  paired with `minimum`/`maximum`, `minItems`/`maxItems` for slice bounds, and
+  `arg0`/`arg1` fallback path-param names matching the REST adapter (#213).
+- `NewServer` clamps a misconfigured `PongTimeout` (≤ `PingInterval`) up to
+  `2*PingInterval` so healthy connections aren't dropped (#207 P3).
+- `SetCheckOrigin` (CSWSH mitigation) is now documented in README, doc.go, and APROT_AI.md (#208).
+
+### Fixed
+
+- Stalled-client deadlock (per-frame write timeout; sends snapshotted outside the
+  server lock), handler panic recovery on request/subscribe/refresh paths, and
+  inbound size limits for WebSocket and SSE (#208).
+- REST scalar path params and `sql.Null`-aware REST response marshaling (#208).
+- Detached shared tasks (`context.WithoutCancel`) no longer auto-finalized (#208).
+- Runtime lifecycle correctness: late-register races, `Server.Stop` hang, `userConns`
+  leak on connect-hook rejection, subscription re-register / stale params, and small
+  data races (#209).
+- `tasks/` subpackage: `lastProgress` leak + trailing-flush, `ensureRoot` race,
+  nil `*Task` on the REST path, `SharedSubTask` duplicate node, and owner-only
+  shared-task cancel (#210).
+- Zod codegen: unescaped string injection (enum values, `contains`/`startswith`/`endswith`),
+  kind-aware `gt`/`lt`/`min`/`max`, `oneof` honored, and recursive schemas via `z.lazy()` (#213).
+- Codegen rejects `time.Duration` fields at generation time (no default JSON
+  representation in the v2 encoder) unless a `format:` option is set (#213).
+- Kebab/camel acronym digit handling (`API2Handlers`) (#213).
+- Invalid TypeScript identifiers are sanitized: non-identifier field keys are quoted,
+  reserved-word param names are suffixed, and instantiated generic type names
+  (`Box[int]`) are folded into valid identifiers everywhere they are emitted (#213).
+
+### Security
+
+- Static analysis (`gosec`) and vulnerability scanning (`govulncheck`) added to CI (#207 P3).
+
+[Unreleased]: https://github.com/marrasen/aprot/compare/v0.44.0...HEAD

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ Set any of these to `-1` to disable it. Defaults apply when the field is zero.
 - **Panic recovery** — a panic in a handler (or middleware) is recovered per request and sent to the client as an internal error, mirroring `net/http`. One buggy handler cannot take down the process.
 - **Message size limits** — oversized WebSocket frames close the connection; oversized SSE RPC bodies get HTTP 413.
 - **Write timeout** — a client that stops reading is disconnected once a write blocks longer than `WriteTimeout`, so it cannot back-pressure broadcasts or other connections.
-- **Keepalive** — the server pings on `PingInterval` and drops connections with no inbound traffic for `PongTimeout`, so half-open connections (NATs, dropped Wi-Fi) are cleaned up.
+- **Keepalive** — the server pings on `PingInterval` and drops connections with no inbound traffic for `PongTimeout`, so half-open connections (NATs, dropped Wi-Fi) are cleaned up. `PongTimeout` must exceed `PingInterval`; if it's set lower, `NewServer` clamps it to `2*PingInterval` rather than dropping healthy connections.
 
 ### Origin checking (cross-site WebSocket hijacking)
 

--- a/connection.go
+++ b/connection.go
@@ -717,7 +717,7 @@ func (c *Conn) close() {
 	}
 	c.mu.Unlock()
 	c.server.subscriptions.unregisterConn(c.id)
-	c.transport.Close()
+	_ = c.transport.Close()
 }
 
 func (c *Conn) closeGracefully() {

--- a/generate.go
+++ b/generate.go
@@ -734,12 +734,15 @@ func (g *Generator) Generate() (map[string]string, error) {
 
 	// Write to files if OutputDir is set
 	if g.options.OutputDir != "" {
-		if err := os.MkdirAll(g.options.OutputDir, 0755); err != nil {
+		// Generated TypeScript client source is non-sensitive and meant to be
+		// read by the developer's toolchain (and usually committed), so the
+		// conventional world-readable source perms are intentional here.
+		if err := os.MkdirAll(g.options.OutputDir, 0o755); err != nil { // #nosec G301 -- generated client source dir, not sensitive
 			return nil, err
 		}
 		for filename, content := range results {
 			path := filepath.Join(g.options.OutputDir, filename)
-			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil { // #nosec G306 -- generated client source file, not sensitive
 				return nil, err
 			}
 		}

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -13,6 +13,60 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+func TestNewServer_ClampsPongTimeout(t *testing.T) {
+	tests := []struct {
+		name            string
+		ping, pong      time.Duration
+		wantPongAtLeast time.Duration // 0 means "don't assert a lower bound"
+		wantPongExact   time.Duration // 0 means "don't assert exact"
+	}{
+		{
+			name:            "pong below ping is clamped above ping",
+			ping:            30 * time.Second,
+			pong:            10 * time.Second,
+			wantPongAtLeast: 30*time.Second + time.Nanosecond,
+		},
+		{
+			name:            "pong equal to ping is clamped above ping",
+			ping:            30 * time.Second,
+			pong:            30 * time.Second,
+			wantPongAtLeast: 30*time.Second + time.Nanosecond,
+		},
+		{
+			name:          "valid pong is left untouched",
+			ping:          30 * time.Second,
+			pong:          90 * time.Second,
+			wantPongExact: 90 * time.Second,
+		},
+		{
+			name:          "disabled keepalive is not clamped",
+			ping:          -1,
+			pong:          5 * time.Second,
+			wantPongExact: 5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer(NewRegistry(), ServerOptions{PingInterval: tt.ping, PongTimeout: tt.pong})
+			defer s.Stop(context.Background())
+
+			got := s.options.PongTimeout
+			if tt.wantPongExact != 0 && got != tt.wantPongExact {
+				t.Errorf("PongTimeout = %v, want exactly %v", got, tt.wantPongExact)
+			}
+			if tt.wantPongAtLeast != 0 {
+				if got < tt.wantPongAtLeast {
+					t.Errorf("PongTimeout = %v, want >= %v (must exceed PingInterval %v)", got, tt.wantPongAtLeast, s.options.PingInterval)
+				}
+				if got <= s.options.PingInterval {
+					t.Errorf("PongTimeout %v must exceed PingInterval %v", got, s.options.PingInterval)
+				}
+			}
+		})
+	}
+}
+
 // userConnCount returns the number of connections tracked for a user.
 func userConnCount(s *Server, userID string) int {
 	s.mu.RLock()

--- a/server.go
+++ b/server.go
@@ -360,7 +360,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.disassociateUser(conn)
 		// Send rejection directly before pumps start
 		sendConnectionRejectedWS(ws, err)
-		ws.Close()
+		_ = ws.Close()
 		return
 	}
 
@@ -373,7 +373,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case s.register <- conn:
 	case <-s.done:
 		s.disassociateUser(conn)
-		ws.Close()
+		_ = ws.Close()
 		return
 	}
 

--- a/server.go
+++ b/server.go
@@ -48,8 +48,10 @@ type ServerOptions struct {
 	PingInterval time.Duration
 	// PongTimeout is how long a WebSocket connection may go without any
 	// inbound traffic (data or pong) before it is considered dead and
-	// closed. Must be larger than PingInterval. Only effective while pings
-	// are enabled. Set to -1 to disable. Default: 60s.
+	// closed. Must be larger than PingInterval; if it is set to a value less
+	// than or equal to PingInterval (while both are enabled), NewServer clamps
+	// it up to 2*PingInterval so healthy connections aren't dropped. Only
+	// effective while pings are enabled. Set to -1 to disable. Default: 60s.
 	PongTimeout time.Duration
 }
 
@@ -117,6 +119,15 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		if opt.PongTimeout != 0 {
 			options.PongTimeout = opt.PongTimeout
 		}
+	}
+
+	// PongTimeout is the inbound read deadline; pings fire every PingInterval.
+	// If the deadline isn't comfortably longer than the ping period, a healthy
+	// connection is closed before its next ping/pong can refresh the deadline.
+	// When both are enabled but misconfigured, clamp PongTimeout up to twice the
+	// ping interval rather than silently dropping live connections.
+	if options.PingInterval > 0 && options.PongTimeout > 0 && options.PongTimeout <= options.PingInterval {
+		options.PongTimeout = 2 * options.PingInterval
 	}
 
 	s := &Server{

--- a/sse_handler.go
+++ b/sse_handler.go
@@ -144,7 +144,7 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 		h.mu.Lock()
 		delete(h.connections, connectionID)
 		h.mu.Unlock()
-		sseT.Close()
+		_ = sseT.Close()
 		return
 	}
 
@@ -157,7 +157,7 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 		case <-r.Context().Done():
 			// Client disconnected — close transport first to drain in-flight writes
 			// before the HTTP server finalizes the response writer.
-			sseT.Close()
+			_ = sseT.Close()
 			h.mu.Lock()
 			delete(h.connections, connectionID)
 			h.mu.Unlock()

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -71,7 +71,7 @@ func (t *wsTransport) CloseGracefully() error {
 func (t *wsTransport) readPump(conn *Conn) {
 	defer func() {
 		conn.server.unregister <- conn
-		t.ws.Close()
+		_ = t.ws.Close()
 	}()
 
 	if t.opts.MaxMessageSize > 0 {


### PR DESCRIPTION
Implements the **P3 — docs/CI/hygiene** items from #207, plus the minor `PongTimeout` validation surfaced in the #208 review.

### Security CI
- New CI jobs run **govulncheck** and **gosec** on the root module.
- To make gosec pass cleanly: the previously-ignored `Close()` errors on connection-teardown paths are now handled with `_ =` (behavior-preserving), and the generated-client file/dir permissions (intentionally world-readable source) carry justified `// #nosec G301/G306` directives.

### Dependabot
- `.github/dependabot.yml` covering all Go modules, GitHub Actions, and the e2e / react-client npm packages. Minor/patch bumps are grouped weekly to limit PR noise; majors are raised individually.

### CHANGELOG
- New `CHANGELOG.md` (Keep a Changelog format) with an `[Unreleased]` section capturing everything since v0.44.0 — the #207 P0–P3 work plus the task-middleware and logging-param features. Earlier history stays in the git tags / GitHub releases (backfilling 44 versions wasn't practical).

### PongTimeout clamp (minor, from the #208 review)
- `PongTimeout` is the inbound read deadline and pings fire every `PingInterval`; a `PongTimeout <= PingInterval` silently drops healthy connections. The doc said it "must be larger" but nothing enforced it. `NewServer` now clamps a misconfigured value up to `2*PingInterval` (only when both are enabled). Test-first with a table-driven regression test; documented in the `ServerOptions` godoc and README.

All local checks pass: `go test -race ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `gosec` (0 issues), `govulncheck` (only stdlib advisories already fixed in the go1.26.1 toolchain CI resolves from go.mod).

After this, the remaining #207 items are the **e2e coverage gaps** (REST adapter, validation round-trip, React hooks) and the **missing-features** list (per-connection concurrency cap, observability hooks, CORS guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)