### PR TITLE
e2e: cover REST adapter and validation round-trip (#207)

### DIFF
--- a/e2e/e2eapi/handlers.go
+++ b/e2e/e2eapi/handlers.go
@@ -1,0 +1,69 @@
+// Package e2eapi adds REST and validation handlers to the e2e server so the
+// REST adapter (typed scalar path params and sql.Null response marshaling) and
+// the validation -> getValidationErrors round-trip get end-to-end coverage.
+// These surfaces had no e2e tests, which is how the typed-path-param REST bug
+// (#207 P1) survived.
+package e2eapi
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/marrasen/aprot"
+)
+
+// EchoHandlers is exposed over REST to exercise typed scalar path params and
+// sql.Null response marshaling.
+type EchoHandlers struct{}
+
+// EchoResult is the REST response. Note is a sql.NullString so the test can
+// confirm the REST transport unwraps it to a bare string / null (matching
+// WS/SSE), not the {"String":…,"Valid":…} object.
+type EchoResult struct {
+	Count int            `json:"count"`
+	Flag  bool           `json:"flag"`
+	Label string         `json:"label"`
+	Note  sql.NullString `json:"note"`
+}
+
+// GetEcho echoes its typed path params. Before #207 P1, the int and bool path
+// params returned 400 InvalidParams over REST because the raw path string did
+// not decode into the Go scalar.
+func (h *EchoHandlers) GetEcho(ctx context.Context, count int, flag bool, label string) (*EchoResult, error) {
+	note := sql.NullString{}
+	if label != "" {
+		note = sql.NullString{String: "hi-" + label, Valid: true}
+	}
+	return &EchoResult{Count: count, Flag: flag, Label: label, Note: note}, nil
+}
+
+// SignupHandlers is registered over WebSocket to exercise the validation ->
+// getValidationErrors round-trip from the generated client.
+type SignupHandlers struct{}
+
+// SignupRequest carries validate tags spanning several rule kinds so the
+// structured FieldError payload has multiple entries to assert on.
+type SignupRequest struct {
+	Name  string `json:"name"  validate:"required,min=2,max=20"`
+	Email string `json:"email" validate:"required,email"`
+	Age   int    `json:"age"   validate:"gte=13,lte=120"`
+}
+
+// SignupResult is the success payload.
+type SignupResult struct {
+	OK bool `json:"ok"`
+}
+
+// Signup succeeds for any input that passes validation.
+func (h *SignupHandlers) Signup(ctx context.Context, req *SignupRequest) (*SignupResult, error) {
+	return &SignupResult{OK: true}, nil
+}
+
+// Register wires the e2e-only REST and validation handlers onto an existing
+// registry and turns on request validation. Existing handlers without validate
+// tags are unaffected (validation is a no-op for them).
+func Register(registry *aprot.Registry) {
+	registry.RegisterREST(&EchoHandlers{})
+	registry.Register(&SignupHandlers{})
+	registry.SetValidator(aprot.NewPlaygroundValidator())
+}

--- a/e2e/generate/main.go
+++ b/e2e/generate/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/marrasen/aprot"
+	"github.com/marrasen/aprot/e2e/e2eapi"
 	"github.com/marrasen/aprot/example/vanilla/api"
 )
 
@@ -15,6 +16,9 @@ func main() {
 	state := api.NewSharedState(tokenStore)
 	authMiddleware := api.AuthMiddleware(tokenStore)
 	registry := api.NewRegistry(state, authMiddleware)
+
+	// Add REST + validation handlers so the generated client includes them.
+	e2eapi.Register(registry)
 
 	gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
 		OutputDir: "../api",

--- a/e2e/server/main.go
+++ b/e2e/server/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/marrasen/aprot"
+	"github.com/marrasen/aprot/e2e/e2eapi"
 	"github.com/marrasen/aprot/example/vanilla/api"
 )
 
@@ -17,12 +18,16 @@ func main() {
 	authMiddleware := api.AuthMiddleware(tokenStore)
 	registry := api.NewRegistry(state, authMiddleware)
 
+	// Add REST + validation handlers for e2e coverage of those surfaces.
+	e2eapi.Register(registry)
+
 	server := aprot.NewServer(registry)
 
 	state.Broadcaster = server
 	state.UserPusher = server
 
 	sseHandler := server.HTTPTransport()
+	restAdapter := aprot.NewRESTAdapter(registry)
 
 	// Rejection server — always rejects connections for e2e testing.
 	rejectRegistry := aprot.NewRegistry()
@@ -36,6 +41,7 @@ func main() {
 	mux.Handle("/ws-reject", rejectServer)
 	mux.Handle("/sse", http.StripPrefix("/sse", sseHandler))
 	mux.Handle("/sse/", http.StripPrefix("/sse", sseHandler))
+	mux.Handle("/api/", http.StripPrefix("/api", restAdapter))
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/e2e/tests/rest.test.ts
+++ b/e2e/tests/rest.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'vitest';
+import { getServerAddr } from './helpers';
+
+// REST adapter end-to-end coverage. The REST surface previously had zero e2e
+// tests, which is how the typed-path-param bug (#207 P1) — int/bool path params
+// returning 400 — survived. These tests hit the adapter over plain HTTP.
+
+function apiUrl(path: string): string {
+    return `http://${getServerAddr()}/api${path}`;
+}
+
+describe('REST adapter', () => {
+    test('typed int and bool path params decode (regression #207 P1)', async () => {
+        const res = await fetch(apiUrl('/echo-handlers/get-echo/42/true/bob'));
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        // count/flag arrive as a real number/boolean, not the raw path strings.
+        expect(body.count).toBe(42);
+        expect(body.flag).toBe(true);
+        expect(body.label).toBe('bob');
+    });
+
+    test('a false bool path param decodes', async () => {
+        const res = await fetch(apiUrl('/echo-handlers/get-echo/7/false/x'));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.count).toBe(7);
+        expect(body.flag).toBe(false);
+    });
+
+    test('sql.NullString is unwrapped to a bare string over REST', async () => {
+        const res = await fetch(apiUrl('/echo-handlers/get-echo/1/true/zed'));
+        const body = await res.json();
+        // Unwrapped string, not the {"String":"hi-zed","Valid":true} object —
+        // the REST transport uses the same sql.Null-aware marshaler as WS/SSE.
+        expect(body.note).toBe('hi-zed');
+        expect(typeof body.note).toBe('string');
+    });
+
+    test('a non-numeric int path param returns 400', async () => {
+        const res = await fetch(apiUrl('/echo-handlers/get-echo/notanint/true/x'));
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe(-32602); // CodeInvalidParams
+    });
+});

--- a/e2e/tests/validation.test.ts
+++ b/e2e/tests/validation.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { wsUrl } from './helpers';
+import { ApiClient, ApiError, getValidationErrors } from '../api/client';
+import { signup } from '../api/signup-handlers';
+
+// Validation -> getValidationErrors() round-trip. Previously the structured
+// FieldError payload and the getValidationErrors() client helper were never
+// exercised end-to-end against a live server.
+
+describe('Validation round-trip (WebSocket)', () => {
+    let client: ApiClient;
+
+    beforeEach(async () => {
+        client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+    });
+
+    afterEach(() => {
+        client.disconnect();
+    });
+
+    test('valid input passes validation', async () => {
+        const res = await signup(client, { name: 'Alice', email: 'alice@example.com', age: 30 });
+        expect(res.ok).toBe(true);
+    });
+
+    test('invalid input throws a structured validation error', async () => {
+        try {
+            await signup(client, { name: 'A', email: 'not-an-email', age: 5 });
+            expect.fail('Should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(ApiError);
+            expect((err as ApiError).isValidationFailed()).toBe(true);
+
+            const fieldErrors = getValidationErrors(err);
+            expect(fieldErrors).not.toBeNull();
+
+            const byField = new Map(fieldErrors!.map((fe) => [fe.field, fe]));
+            // All three fields fail their rules: name(min=2), email(email), age(gte=13).
+            expect(byField.has('name')).toBe(true);
+            expect(byField.has('email')).toBe(true);
+            expect(byField.has('age')).toBe(true);
+
+            // Each entry carries the failing tag and a message.
+            expect(byField.get('name')!.tag).toBe('min');
+            expect(byField.get('email')!.tag).toBe('email');
+            expect(byField.get('age')!.tag).toBe('gte');
+            for (const fe of fieldErrors!) {
+                expect(typeof fe.message).toBe('string');
+                expect(fe.message.length).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    test('getValidationErrors returns null for a non-validation error', () => {
+        expect(getValidationErrors(new Error('nope'))).toBeNull();
+        expect(getValidationErrors(new ApiError(-32601, 'method not found'))).toBeNull();
+    });
+});


### PR DESCRIPTION
Closes two of the three e2e coverage gaps from #207.

### REST adapter (had zero e2e coverage — how #207 P1 survived)
- New `e2e/e2eapi` package adds `EchoHandlers` (REST, with typed int/bool/string path params and a `sql.NullString` response field), wired into the e2e server (REST adapter mounted at `/api/`) and the client generator.
- `rest.test.ts` (plain HTTP via `fetch`):
  - typed int + bool path params decode to a real number/boolean (regression for #207 P1, where they returned 400)
  - `sql.NullString` is unwrapped to a bare string over REST (same marshaler as WS/SSE), not the `{String,Valid}` object
  - a non-numeric int path param returns 400 with `CodeInvalidParams`

### Validation → getValidationErrors() round-trip (never exercised live)
- `SignupHandlers` (validate tags spanning `min`/`email`/`gte`) registered over WS, with a validator enabled.
- `validation.test.ts` (generated client over WebSocket):
  - valid input passes
  - invalid input throws an `ApiError` whose `getValidationErrors()` yields per-field failures (`name`/`email`/`age` with their tags and messages)
  - `getValidationErrors()` returns null for non-validation errors

The generated `e2e/api/` client is gitignored and regenerated by CI, so the new `echo-handlers.ts` / `signup-handlers.ts` are produced in the e2e job automatically. Adding a validator is a no-op for the existing handlers (they have no validate tags), so the existing suite is unaffected.

### Not included
The third gap — **executing React hooks** (currently only type-checked) — needs a dedicated harness (React + @testing-library/react + a jsdom environment, and a second React-mode generated client). That's a materially larger and flakier addition, so it's left for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)