### PR TITLE
Fix duplicate request ID unregister deleting the replacement (#225)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -279,10 +279,19 @@ func (c *Conn) registerRequest(id string, cancel context.CancelCauseFunc) {
 	}
 }
 
-func (c *Conn) unregisterRequest(id string) {
+// unregisterRequest removes the request's cancel func from the map, but only
+// if it is still the one this handler registered. A client may reuse an
+// in-flight request ID, in which case registerRequest replaces the map entry
+// and cancels the shadowed request. When that shadowed handler later unwinds,
+// its deferred unregister must not delete the replacement's cancel func — doing
+// so would make the still-running replacement uncancelable via cancel,
+// unsubscribe, or connection-close bookkeeping. (#225)
+func (c *Conn) unregisterRequest(id string, cancel context.CancelCauseFunc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.requests, id)
+	if reflect.ValueOf(c.requests[id]).Pointer() == reflect.ValueOf(cancel).Pointer() {
+		delete(c.requests, id)
+	}
 }
 
 func (c *Conn) cancelRequest(id string) {
@@ -338,7 +347,7 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	c.registerRequest(msg.ID, cancel)
 	defer func() {
-		c.unregisterRequest(msg.ID)
+		c.unregisterRequest(msg.ID, cancel)
 		cancel(nil)
 	}()
 
@@ -536,7 +545,7 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	c.registerRequest(msg.ID, cancel)
 	defer func() {
-		c.unregisterRequest(msg.ID)
+		c.unregisterRequest(msg.ID, cancel)
 		cancel(nil)
 	}()
 
@@ -641,7 +650,7 @@ func (c *Conn) refreshSubscription(sub *subscription) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	c.registerRequest(sub.id, cancel)
 	defer func() {
-		c.unregisterRequest(sub.id)
+		c.unregisterRequest(sub.id, cancel)
 		cancel(nil)
 	}()
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -431,6 +431,41 @@ func TestRegisterRequestIDCollisionCancelsPrevious(t *testing.T) {
 	}
 }
 
+// When a shadowed request unwinds after its replacement (same ID) has been
+// registered, its deferred unregister must not delete the replacement's cancel
+// func. Otherwise the replacement can no longer be canceled via cancel,
+// unsubscribe, or connection-close bookkeeping, leaking its goroutine until it
+// finishes naturally and stalling graceful shutdown. (#225)
+func TestUnregisterRequestKeepsReplacement(t *testing.T) {
+	tc := NewTestPushConn(2)
+	c := tc.Conn
+
+	first := func(cause error) {}
+	c.registerRequest("dup", first)
+
+	replacementCanceled := false
+	replacement := func(cause error) { replacementCanceled = true }
+	c.registerRequest("dup", replacement)
+
+	// The shadowed (first) handler unwinds and runs its deferred unregister
+	// with its own cancel func. This must be a no-op because the map now holds
+	// the replacement.
+	c.unregisterRequest("dup", first)
+
+	c.mu.Lock()
+	got, exists := c.requests["dup"]
+	c.mu.Unlock()
+	if !exists {
+		t.Fatal("replacement request was unregistered by the shadowed handler's deferred unregister")
+	}
+
+	// The retained entry must be the replacement, and canceling it must work.
+	got(ErrClientCanceled)
+	if !replacementCanceled {
+		t.Error("retained cancel func is not the replacement's")
+	}
+}
+
 // SetUserID racing a disconnect (disassociateUser) must not be a data race on
 // Conn.userID. This is primarily a guard for `go test -race` in CI; it should
 // always pass otherwise. (#207 P2)


### PR DESCRIPTION
Fixes #225.

## Problem

`Conn.registerRequest` intentionally supports a client reusing an in-flight request/subscription ID: it replaces the map entry and cancels the shadowed request. But `unregisterRequest` did an unconditional `delete(c.requests, id)`. When the shadowed handler later unwound, its deferred `unregisterRequest` deleted the **replacement's** cancel func.

The still-running replacement could then no longer be canceled via `cancel`, `unsubscribe`, connection-close bookkeeping, or graceful shutdown — leaking its goroutine until it finished naturally and stalling shutdown paths that wait on all request goroutines.

## Fix

`unregisterRequest` now takes the handler's own `cancel` func and deletes the map entry only when it still matches the registered one:

```go
func (c *Conn) unregisterRequest(id string, cancel context.CancelCauseFunc) {
    c.mu.Lock()
    defer c.mu.Unlock()
    if reflect.ValueOf(c.requests[id]).Pointer() == reflect.ValueOf(cancel).Pointer() {
        delete(c.requests, id)
    }
}
```

Note: the issue's suggested `c.requests[id] == cancel` doesn't compile — Go func values aren't comparable with `==`. Compared via `reflect.Pointer` instead (`reflect` is already imported). Nil/missing entries compare to 0 and safely skip the delete.

The three deferred call sites now pass their own `cancel`: `handleRequest`, `handleSubscribe`, `refreshSubscription`.

## Test

`TestUnregisterRequestKeepsReplacement` (red-green TDD): registers a duplicate ID, runs the shadowed handler's deferred unregister, and asserts the replacement is retained and still cancelable. Confirmed failing before the fix, passing after. Full suite (`go test ./...`) passes.

No doc/README updates — `unregisterRequest` is unexported with no user-facing API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)