### PR TITLE
Fix shared enum/type file colliding with same-named handler file (#206)

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -47,6 +47,7 @@ gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
 })
 gen.Generate()
 ```
+Output is split: `client.ts` (base), one file per handler group, and a `{pkg}.ts` file per Go package for types/enums shared across groups. If a package's shared file would collide with a handler file (package `settings` + handler `Settings` both → `settings.ts`), the shared file is emitted as `{pkg}.types.ts` instead so neither silently overwrites the other.
 
 ### 4. Progress & Tasks
 - Simple: `aprot.Progress(ctx).Update(current, total, message)`.

--- a/doc.go
+++ b/doc.go
@@ -431,6 +431,10 @@
 //
 // The generator creates split files: client.ts (base client), one file per
 // handler group, and optional shared type files for types used across groups.
+// A shared file is named after its Go package (e.g. api.ts); if that name
+// would collide with a handler file (package "settings" and handler "Settings"
+// both map to settings.ts), the shared file is emitted as {pkg}.types.ts
+// instead so neither overwrites the other.
 // Use [NamingPlugin] to customize TypeScript name conventions.
 //
 // Setting [GeneratorOptions.Zod] emits a companion `.schema.ts` file for

--- a/generate.go
+++ b/generate.go
@@ -573,6 +573,27 @@ func (g *Generator) Generate() (map[string]string, error) {
 	}
 	sort.Strings(sortedPkgs)
 
+	// Shared package files live in the same flat output directory as handler
+	// files. If a package's short name resolves to the same file as a handler
+	// (e.g. package "settings" + handler "Settings" both -> "settings.ts"), the
+	// handler file — written later — would silently overwrite the shared file,
+	// dropping its type/enum definitions and leaving every referencing file
+	// importing a type nobody defines (issue #206). Give any colliding shared
+	// file a distinct "{pkg}.types" base instead. A kebab-cased handler file
+	// name can never contain a dot, so the alternate base is collision-free.
+	handlerFileNames := make(map[string]bool)
+	for _, group := range g.registry.Groups() {
+		handlerFileNames[g.naming().FileName(group.Name)] = true
+	}
+	pkgBase := make(map[string]string, len(sortedPkgs))
+	for _, pkg := range sortedPkgs {
+		base := pkg
+		if handlerFileNames[base] {
+			base = pkg + ".types"
+		}
+		pkgBase[pkg] = base
+	}
+
 	// Pass 1: build pkgData for every shared package and accumulate
 	// sharedTypeNames across all of them. Rendering is deferred so that Pass 2
 	// can resolve cross-package references using the complete name map —
@@ -598,12 +619,12 @@ func (g *Generator) Generate() (map[string]string, error) {
 
 		pkgData := &templateData{
 			StructName: pkg,
-			FileName:   pkg + ".ts",
+			FileName:   pkgBase[pkg] + ".ts",
 		}
 		pkgData.Interfaces = g.buildInterfaces()
 		pkgData.Enums = g.buildEnums()
 
-		module := "./" + pkg
+		module := "./" + pkgBase[pkg]
 		for _, iface := range pkgData.Interfaces {
 			sharedTypeNames[iface.Name] = module
 		}
@@ -619,7 +640,7 @@ func (g *Generator) Generate() (map[string]string, error) {
 	// are excluded so a file never imports from itself.
 	for _, pkg := range sortedPkgs {
 		pkgData := pkgDataByPkg[pkg]
-		selfModule := "./" + pkg
+		selfModule := "./" + pkgBase[pkg]
 		selfNames := make(map[string]bool, len(pkgData.Interfaces)+len(pkgData.Enums))
 		for _, iface := range pkgData.Interfaces {
 			selfNames[iface.Name] = true

--- a/generate_test.go
+++ b/generate_test.go
@@ -3388,6 +3388,85 @@ func TestGenerateSharedFileCrossPackageImports(t *testing.T) {
 	}
 }
 
+// --- Shared enum file vs. handler file name collision (aprot issue #206) ---
+//
+// When an enum lives in a Go package whose short name matches a handler's
+// generated TypeScript file name, the shared per-package file ("gentestpkg.ts")
+// collides with the handler file for group "Gentestpkg". The handler phase runs
+// last and silently overwrites the shared file, dropping the enum definition and
+// leaving every referencing file importing a type nobody defines.
+
+// Gentestpkg is a handler group whose name kebab-cases to "gentestpkg", the same
+// base name as the shared file emitted for package internal/gentestpkg.
+type Gentestpkg struct{}
+
+func (h *Gentestpkg) GetColor(ctx context.Context) (gentestpkg.Color, error) { return "", nil }
+
+// GentestpkgWriter is a second group using the same enum, so Color is promoted
+// to the shared per-package file rather than staying handler-local.
+type GentestpkgWriter struct{}
+
+func (h *GentestpkgWriter) SetColor(ctx context.Context, c gentestpkg.Color) error { return nil }
+
+func TestGenerateSharedEnumFileHandlerNameCollision(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&Gentestpkg{})
+	registry.Register(&GentestpkgWriter{})
+	registry.RegisterEnum(gentestpkg.ColorValues())
+
+	gen := NewGenerator(registry)
+	files, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// The Color enum must be defined exactly once. The bug silently drops it
+	// because the shared file (gentestpkg.ts) is overwritten by the handler file
+	// for group "Gentestpkg".
+	defFiles := make([]string, 0)
+	for name, content := range files {
+		if strings.Contains(content, "export type ColorType") {
+			defFiles = append(defFiles, name)
+		}
+	}
+	if len(defFiles) != 1 {
+		t.Fatalf("expected ColorType defined in exactly one file, found in %v\nfiles: %v", defFiles, mapKeys(files))
+	}
+	defModule := "./" + strings.TrimSuffix(defFiles[0], ".ts")
+
+	// Every import of ColorType must resolve to the defining file, and no file
+	// may import ColorType from itself.
+	for name, content := range files {
+		selfModule := "./" + strings.TrimSuffix(name, ".ts")
+		for _, line := range strings.Split(content, "\n") {
+			if !strings.HasPrefix(line, "import") || !containsTypeName(line, "ColorType") {
+				continue
+			}
+			module := importModule(line)
+			if module == selfModule {
+				t.Errorf("%s imports ColorType from itself (%q):\n%s", name, module, content)
+			}
+			if module != defModule {
+				t.Errorf("%s imports ColorType from %q, but ColorType is defined in %q", name, module, defModule)
+			}
+		}
+	}
+}
+
+// importModule extracts the single-quoted module specifier from a generated
+// TypeScript import line, e.g. `import type { X } from './api';` -> "./api".
+func importModule(line string) string {
+	i := strings.LastIndex(line, "from '")
+	if i < 0 {
+		return ""
+	}
+	rest := line[i+len("from '"):]
+	if j := strings.IndexByte(rest, '\''); j >= 0 {
+		return rest[:j]
+	}
+	return ""
+}
+
 // TrickyStatus exercises enum values whose capitalized forms are not valid
 // TypeScript identifiers: empty string, a hyphenated value, and a
 // leading-digit value. The codegen must still produce syntactically valid TS.


### PR DESCRIPTION
@
Fixes #206.

## Problem

A shared per-package TypeScript file is named `{pkg}.ts`, the same map key a handler file uses (`naming().FileName(group.Name) + ".ts"`). When a Go package short name matched a handler name — e.g. package `settings` (holding an enum used by 2+ handlers) and handler `Settings` — both resolved to `settings.ts`.

The handler phase runs **after** the shared phase, so the handler file silently overwrote the shared file in the results map. The promoted enum/type definition was dropped, but the cross-file import resolution from the shared pass had already emitted `import ... from "./settings"` into every referencing file — including `settings.ts` importing from **itself**. `tsc` then failed on the dangling import. The collision was silent: no error, no warning.

## Fix

Detect the collision up front (compare each shared package base name against the set of handler file names) and emit the shared file as `{pkg}.types.ts`, with a matching `./{pkg}.types` import module, so neither file overwrites the other. The base name flows through both the file-name and import-module derivation consistently, so handler files import the enum from the renamed module and no file imports from itself.

A kebab-cased handler file name can never contain a dot, so the `{pkg}.types` alternate base is always collision-free. Non-colliding packages keep their existing `{pkg}.ts` name — no change to existing output.

## Test

Added `TestGenerateSharedEnumFileHandlerNameCollision`: registers an enum in `internal/gentestpkg` used by two groups, one named `Gentestpkg` (kebabs to `gentestpkg`, colliding with the shared `gentestpkg.ts`). Asserts the enum is defined in exactly one file and that every `ColorType` import resolves to the defining file with no self-imports. Red before the fix (enum defined in zero files), green after.

Also updated `doc.go` and `APROT_AI.md` to document the `{pkg}.types.ts` naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@