### PR TITLE
Add per-connection and server-wide concurrency caps (#222)

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -33,7 +33,7 @@ http.Handle("/sse/", server.HTTPTransport())
 http.Handle("/api/", aprot.NewRESTAdapter(registry)) // optional REST
 ```
 
-Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{MaxMessageSize, WriteTimeout, PingInterval, PongTimeout}` — inbound size limit (default 4 MiB), stalled-peer write timeout (30s), WS keepalive ping (30s) and pong timeout (60s). Handler panics are recovered per request and returned as internal errors.
+Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{MaxMessageSize, WriteTimeout, PingInterval, PongTimeout, MaxConcurrentRequests, MaxServerConcurrentRequests, MaxSubscriptions}` — inbound size limit (default 4 MiB), stalled-peer write timeout (30s), WS keepalive ping (30s) and pong timeout (60s), in-flight requests per connection (256) and server-wide (10000), and active subscriptions per connection (1024). Exceeding a concurrency cap rejects the frame with `CodeTooManyRequests` (-32004; client `err.isTooManyRequests()`) instead of spawning unbounded goroutines; a streaming handler holds its request slot until the stream ends. Handler panics are recovered per request and returned as internal errors.
 
 **Cookie-auth deployments must set an origin check** (default allows all origins — CSWSH risk): `server.SetCheckOrigin(func(r *http.Request) bool { return r.Header.Get("Origin") == "https://app.example.com" })`.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Request cancellation** — clients cancel via AbortController; handlers see cancel cause
 - **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
-- **Connection hardening** — per-request panic recovery, inbound message size limits, write timeouts that drop stalled clients, and WebSocket keepalive pings — all configurable via `ServerOptions`
+- **Connection hardening** — per-request panic recovery, inbound message size limits, write timeouts that drop stalled clients, WebSocket keepalive pings, and per-connection / server-wide concurrency and subscription caps — all configurable via `ServerOptions`
 - **Automatic reconnection** — page visibility + network-aware, with exponential backoff; supports dynamic URL functions for token refresh on reconnect
 - **Struct validation** — opt-in server-side validation via `go-playground/validator` struct tags, automatically enforced before handler dispatch
 - **Input transformation** — declarative `transform` struct tags (`trim`, `trimleft`, `trimright`, `uppercase`, `lowercase`, `removeempty`) normalize fields before validation runs
@@ -739,6 +739,10 @@ server := aprot.NewServer(registry, aprot.ServerOptions{
     WriteTimeout:   10 * time.Second, // drop peers that stop reading (default 30s)
     PingInterval:   30 * time.Second, // WebSocket keepalive ping interval (default 30s)
     PongTimeout:    60 * time.Second, // drop peers with no inbound traffic (default 60s)
+
+    MaxConcurrentRequests:       256,   // in-flight requests per connection (default 256)
+    MaxServerConcurrentRequests: 10000, // in-flight requests across all connections (default 10000)
+    MaxSubscriptions:            1024,  // active subscriptions per connection (default 1024)
 })
 ```
 
@@ -748,6 +752,7 @@ Set any of these to `-1` to disable it. Defaults apply when the field is zero.
 - **Message size limits** — oversized WebSocket frames close the connection; oversized SSE RPC bodies get HTTP 413.
 - **Write timeout** — a client that stops reading is disconnected once a write blocks longer than `WriteTimeout`, so it cannot back-pressure broadcasts or other connections.
 - **Keepalive** — the server pings on `PingInterval` and drops connections with no inbound traffic for `PongTimeout`, so half-open connections (NATs, dropped Wi-Fi) are cleaned up. `PongTimeout` must exceed `PingInterval`; if it's set lower, `NewServer` clamps it to `2*PingInterval` rather than dropping healthy connections.
+- **Concurrency caps** — a single connection can otherwise pin unbounded work: every inbound frame runs on its own goroutine and a connection can register unlimited subscriptions (each amplifying server-side `TriggerRefresh` fan-out). `MaxConcurrentRequests` bounds in-flight requests per connection, `MaxServerConcurrentRequests` bounds them across the whole server, and `MaxSubscriptions` bounds active subscriptions per connection. A frame over a cap is rejected with `CodeTooManyRequests` (`-32004`; the TS client exposes `err.isTooManyRequests()`) rather than spawning more goroutines. A streaming handler holds its request slot until the stream ends.
 
 ### Origin checking (cross-site WebSocket hijacking)
 

--- a/connection.go
+++ b/connection.go
@@ -32,6 +32,10 @@ type Conn struct {
 	valuesMu  sync.RWMutex    // guards values map (separate from mu to avoid contention with sendJSON/requests)
 	values    map[any]any     // connection-scoped key-value store (lazy init)
 	ctx       context.Context // Context from HTTP request
+	// reqSem bounds the number of in-flight requests this connection may run
+	// concurrently. It is a counting semaphore (one buffer slot per allowed
+	// request); nil when MaxConcurrentRequests disables the per-connection cap.
+	reqSem chan struct{}
 }
 
 // SetUserID associates this connection with a user ID.
@@ -140,7 +144,7 @@ func (c *Conn) RemoteAddr() string {
 }
 
 func newConn(t transport, server *Server, id uint64, r *http.Request, ctx context.Context) *Conn {
-	return &Conn{
+	c := &Conn{
 		transport: t,
 		server:    server,
 		requests:  make(map[string]context.CancelCauseFunc),
@@ -154,6 +158,79 @@ func newConn(t transport, server *Server, id uint64, r *http.Request, ctx contex
 			Host:       r.Host,
 		},
 	}
+	if server.options.MaxConcurrentRequests > 0 {
+		c.reqSem = make(chan struct{}, server.options.MaxConcurrentRequests)
+	}
+	return c
+}
+
+// acquireRequestSlot reserves one in-flight-request slot against both the
+// per-connection and server-wide caps. It never blocks: if either cap is at
+// capacity it rolls back any slot already taken and returns false, so the
+// caller can reject the request with CodeTooManyRequests. A nil semaphore means
+// that cap is disabled. Each successful acquire must be paired with exactly one
+// releaseRequestSlot once the request finishes.
+func (c *Conn) acquireRequestSlot() bool {
+	if c.reqSem != nil {
+		select {
+		case c.reqSem <- struct{}{}:
+		default:
+			return false
+		}
+	}
+	if c.server.reqSem != nil {
+		select {
+		case c.server.reqSem <- struct{}{}:
+		default:
+			// Roll back the per-connection slot taken above.
+			if c.reqSem != nil {
+				<-c.reqSem
+			}
+			return false
+		}
+	}
+	return true
+}
+
+// releaseRequestSlot returns the slots reserved by acquireRequestSlot.
+func (c *Conn) releaseRequestSlot() {
+	if c.reqSem != nil {
+		<-c.reqSem
+	}
+	if c.server.reqSem != nil {
+		<-c.server.reqSem
+	}
+}
+
+// dispatchRequest reserves an in-flight slot and runs handleRequest on its own
+// goroutine, or rejects the request with CodeTooManyRequests when the
+// connection or server is at capacity. The acquire and its paired release both
+// live here (the release fires when the handler goroutine returns), so the
+// handlers stay callable in isolation and both transports share one correct
+// path.
+func (c *Conn) dispatchRequest(msg IncomingMessage) {
+	if !c.acquireRequestSlot() {
+		c.sendError(msg.ID, CodeTooManyRequests, "too many concurrent requests")
+		return
+	}
+	c.server.requestsWg.Add(1)
+	go func() {
+		defer c.releaseRequestSlot()
+		c.handleRequest(msg)
+	}()
+}
+
+// dispatchSubscribe is dispatchRequest's counterpart for subscribe frames.
+func (c *Conn) dispatchSubscribe(msg IncomingMessage) {
+	if !c.acquireRequestSlot() {
+		c.sendError(msg.ID, CodeTooManyRequests, "too many concurrent requests")
+		return
+	}
+	c.server.requestsWg.Add(1)
+	go func() {
+		defer c.releaseRequestSlot()
+		c.handleSubscribe(msg)
+	}()
 }
 
 // ServerBroadcaster returns the server as a Broadcaster.
@@ -313,11 +390,9 @@ func (c *Conn) handleIncomingMessage(data []byte) {
 
 	switch msg.Type {
 	case TypeRequest:
-		c.server.requestsWg.Add(1)
-		go c.handleRequest(msg)
+		c.dispatchRequest(msg)
 	case TypeSubscribe:
-		c.server.requestsWg.Add(1)
-		go c.handleSubscribe(msg)
+		c.dispatchSubscribe(msg)
 	case TypeUnsubscribe:
 		c.cancelRequest(msg.ID)
 		c.handleUnsubscribe(msg.ID)
@@ -607,16 +682,21 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 			// Re-subscribe with the same ID may carry new params; refresh them
 			// so server-driven re-execution doesn't replay the stale ones.
 			c.server.subscriptions.updateParams(c.id, msg.ID, msg.Params)
-		} else if !c.server.subscriptions.register(&subscription{
+		} else if ok, limited := c.server.subscriptions.register(&subscription{
 			conn:   c,
 			id:     msg.ID,
 			method: msg.Method,
 			keys:   keys,
 			params: msg.Params,
-		}) {
-			// The connection closed while the handler was running; the
-			// subscription was refused so it can't outlive the conn. Don't
-			// send a response — the transport is gone.
+		}); !ok {
+			if limited {
+				// The connection is at its subscription cap; tell the client so
+				// it can back off rather than silently dropping the subscribe.
+				c.sendError(msg.ID, CodeTooManyRequests, "subscription limit reached")
+			}
+			// Otherwise the connection closed while the handler was running; the
+			// subscription was refused so it can't outlive the conn. Either way,
+			// don't send a success response.
 			return
 		}
 	}

--- a/doc.go
+++ b/doc.go
@@ -255,12 +255,23 @@
 //	    WriteTimeout:   10 * time.Second, // drop peers that stop reading (default 30s)
 //	    PingInterval:   30 * time.Second, // WebSocket keepalive ping interval (default 30s)
 //	    PongTimeout:    60 * time.Second, // drop peers with no inbound traffic (default 60s)
+//
+//	    MaxConcurrentRequests:       256,   // in-flight requests per connection (default 256)
+//	    MaxServerConcurrentRequests: 10000, // in-flight requests across all connections (default 10000)
+//	    MaxSubscriptions:            1024,  // active subscriptions per connection (default 1024)
 //	})
 //
 // Set a field to -1 to disable that limit; zero applies the default.
 // Handler panics are recovered per request and surfaced to the client as
 // internal errors, mirroring net/http — one buggy handler cannot take down
 // the process.
+//
+// The concurrency caps bound the work a single connection (or the whole
+// fleet) can pin at once: each inbound request or subscribe frame takes one
+// in-flight slot for the duration of its handler, and each connection may hold
+// only MaxSubscriptions active subscriptions (which also bounds refresh
+// fan-out). A frame that would exceed a cap is rejected with
+// [CodeTooManyRequests] rather than spawning unbounded goroutines.
 //
 // # Security
 //

--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,7 @@ const (
 	CodeUnauthorized       = -32001
 	CodeConnectionRejected = -32002
 	CodeForbidden          = -32003
+	CodeTooManyRequests    = -32004
 )
 
 // ProtocolError represents an error that can be sent to the client.
@@ -78,6 +79,14 @@ func ErrForbidden(message string) *ProtocolError {
 // ErrConnectionRejected returns a connection rejected error.
 func ErrConnectionRejected(message string) *ProtocolError {
 	return NewError(CodeConnectionRejected, message)
+}
+
+// ErrTooManyRequests returns a rate/concurrency-limit error. The server sends
+// this when a connection exceeds its in-flight request or subscription cap
+// (see [ServerOptions.MaxConcurrentRequests], [ServerOptions.MaxSubscriptions],
+// and [ServerOptions.MaxServerConcurrentRequests]).
+func ErrTooManyRequests(message string) *ProtocolError {
+	return NewError(CodeTooManyRequests, message)
 }
 
 // CancelReason represents why a request context was canceled.

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -20,6 +20,7 @@ export const ErrorCode = {
     Unauthorized: -32001,
     ConnectionRejected: -32002,
     Forbidden: -32003,
+    TooManyRequests: -32004,
 } as const;
 
 export type ErrorCodeType = typeof ErrorCode[keyof typeof ErrorCode];
@@ -61,6 +62,7 @@ export class ApiError extends Error {
     isValidationFailed(): boolean { return this.code === ErrorCode.ValidationFailed; }
     isCanceled(): boolean { return this.code === ErrorCode.Canceled; }
     isConnectionRejected(): boolean { return this.code === ErrorCode.ConnectionRejected; }
+    isTooManyRequests(): boolean { return this.code === ErrorCode.TooManyRequests; }
 }
 
 // getValidationErrors returns the structured FieldError list when err is a

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -13,6 +13,7 @@ export const ErrorCode = {
     Unauthorized: -32001,
     ConnectionRejected: -32002,
     Forbidden: -32003,
+    TooManyRequests: -32004,
 } as const;
 
 export type ErrorCodeType = typeof ErrorCode[keyof typeof ErrorCode];
@@ -54,6 +55,7 @@ export class ApiError extends Error {
     isValidationFailed(): boolean { return this.code === ErrorCode.ValidationFailed; }
     isCanceled(): boolean { return this.code === ErrorCode.Canceled; }
     isConnectionRejected(): boolean { return this.code === ErrorCode.ConnectionRejected; }
+    isTooManyRequests(): boolean { return this.code === ErrorCode.TooManyRequests; }
 }
 
 // getValidationErrors returns the structured FieldError list when err is a

--- a/server.go
+++ b/server.go
@@ -53,6 +53,24 @@ type ServerOptions struct {
 	// it up to 2*PingInterval so healthy connections aren't dropped. Only
 	// effective while pings are enabled. Set to -1 to disable. Default: 60s.
 	PongTimeout time.Duration
+	// MaxConcurrentRequests caps the number of in-flight requests a single
+	// connection may run at once. Each inbound request/subscribe frame occupies
+	// one slot for the duration of its handler (a streaming handler holds its
+	// slot until the stream ends). When a connection is at the cap, further
+	// requests are rejected with CodeTooManyRequests instead of spawning an
+	// unbounded number of goroutines. Set to -1 to disable. Default: 256.
+	MaxConcurrentRequests int
+	// MaxServerConcurrentRequests caps the total number of in-flight requests
+	// across all connections, bounding server-wide goroutine and memory growth
+	// from a fleet of connections. Requests over the cap are rejected with
+	// CodeTooManyRequests. Set to -1 to disable. Default: 10000.
+	MaxServerConcurrentRequests int
+	// MaxSubscriptions caps the number of active subscriptions a single
+	// connection may hold. A subscribe beyond the cap is rejected with
+	// CodeTooManyRequests. This also bounds refresh fan-out amplification, since
+	// a server-side TriggerRefresh re-executes every matching subscription on a
+	// connection. Set to -1 to disable. Default: 1024.
+	MaxSubscriptions int
 }
 
 func defaultServerOptions() ServerOptions {
@@ -64,6 +82,10 @@ func defaultServerOptions() ServerOptions {
 		WriteTimeout:         30 * time.Second,
 		PingInterval:         30 * time.Second,
 		PongTimeout:          60 * time.Second,
+
+		MaxConcurrentRequests:       256,
+		MaxServerConcurrentRequests: 10000,
+		MaxSubscriptions:            1024,
 	}
 }
 
@@ -88,6 +110,10 @@ type Server struct {
 	done            chan struct{} // closed by run() when it finishes
 	requestsWg      sync.WaitGroup
 	subscriptions   *subscriptionManager
+	// reqSem bounds the total in-flight requests across all connections. It is
+	// a counting semaphore (one buffer slot per allowed request); nil when
+	// MaxServerConcurrentRequests disables the server-wide cap.
+	reqSem chan struct{}
 }
 
 // NewServer creates a new WebSocket server with the given registry.
@@ -119,6 +145,15 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		if opt.PongTimeout != 0 {
 			options.PongTimeout = opt.PongTimeout
 		}
+		if opt.MaxConcurrentRequests != 0 {
+			options.MaxConcurrentRequests = opt.MaxConcurrentRequests
+		}
+		if opt.MaxServerConcurrentRequests != 0 {
+			options.MaxServerConcurrentRequests = opt.MaxServerConcurrentRequests
+		}
+		if opt.MaxSubscriptions != 0 {
+			options.MaxSubscriptions = opt.MaxSubscriptions
+		}
 	}
 
 	// PongTimeout is the inbound read deadline; pings fire every PingInterval.
@@ -146,6 +181,9 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		stopCh:        make(chan struct{}),
 		done:          make(chan struct{}),
 		subscriptions: newSubscriptionManager(),
+	}
+	if options.MaxServerConcurrentRequests > 0 {
+		s.reqSem = make(chan struct{}, options.MaxServerConcurrentRequests)
 	}
 	// Run OnServerInit hooks (used by tasks/ to set up taskManager, middleware, etc.)
 	for _, hook := range registry.serverInitHooks {

--- a/server_concurrency_test.go
+++ b/server_concurrency_test.go
@@ -91,14 +91,29 @@ func TestMaxConcurrentRequestsRejectsOverCap(t *testing.T) {
 		t.Fatalf("expected CodeTooManyRequests error for over-cap request, got type=%q code=%d", over.Type, over.Code)
 	}
 
-	// Releasing the blocked handlers frees slots; a new request now succeeds.
+	// Releasing the blocked handlers frees their slots, after which a new
+	// request succeeds. The slot is returned in the dispatch goroutine just
+	// after the handler sends its response, so poll for reuse rather than
+	// racing that window (a request sent before the slot frees is legitimately
+	// rejected).
 	close(h.release)
-	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "after", Method: "gateHandlers.Block"}); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
-	after := readUntilID(t, ws, "after", 3*time.Second)
-	if after.Type != TypeResponse {
-		t.Fatalf("expected successful response after a slot freed, got type=%q code=%d", after.Type, after.Code)
+	deadline := time.Now().Add(3 * time.Second)
+	for attempt := 0; ; attempt++ {
+		id := fmt.Sprintf("after-%d", attempt)
+		if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: id, Method: "gateHandlers.Block"}); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		reply := readUntilID(t, ws, id, 3*time.Second)
+		if reply.Type == TypeResponse {
+			break // a slot freed and was reused
+		}
+		if reply.Code != CodeTooManyRequests {
+			t.Fatalf("unexpected reply for %s: type=%q code=%d", id, reply.Type, reply.Code)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no slot freed within timeout after releasing blocked handlers")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/server_concurrency_test.go
+++ b/server_concurrency_test.go
@@ -1,0 +1,189 @@
+package aprot
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/gorilla/websocket"
+)
+
+// gateHandlers exposes a blocking unary handler and a subscribe-able handler so
+// concurrency-cap tests can pin a controllable number of requests in flight.
+type gateHandlers struct {
+	entered chan struct{} // signaled when Block starts executing
+	release chan struct{} // closed by the test to let Block return
+}
+
+func (h *gateHandlers) Block(ctx context.Context) (*EchoResponse, error) {
+	// entered is buffered wider than any test's fan-out, so this send never
+	// blocks and every invocation is observable.
+	h.entered <- struct{}{}
+	select {
+	case <-h.release:
+	case <-ctx.Done():
+	}
+	return &EchoResponse{Message: "ok"}, nil
+}
+
+// Sub registers a trigger key so the subscribe path actually creates a
+// subscription (subscriptions with no keys are never registered).
+func (h *gateHandlers) Sub(ctx context.Context) (*EchoResponse, error) {
+	RegisterRefreshTrigger(ctx, "k")
+	return &EchoResponse{Message: "ok"}, nil
+}
+
+func setupGateServer(t *testing.T, opts ServerOptions) (*httptest.Server, *gateHandlers) {
+	t.Helper()
+	registry := NewRegistry()
+	h := &gateHandlers{entered: make(chan struct{}, 128), release: make(chan struct{})}
+	registry.Register(h)
+	server := NewServer(registry, opts)
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+	return ts, h
+}
+
+// readUntilID reads frames until one carrying the given ID arrives, returning
+// it (as the ErrorMessage superset). Fails on timeout.
+func readUntilID(t *testing.T, ws *websocket.Conn, id string, timeout time.Duration) ErrorMessage {
+	t.Helper()
+	_ = ws.SetReadDeadline(time.Now().Add(timeout))
+	defer ws.SetReadDeadline(time.Time{})
+	for {
+		var msg ErrorMessage
+		if err := ws.ReadJSON(&msg); err != nil {
+			t.Fatalf("reading frame for ID %q: %v", id, err)
+		}
+		if msg.ID == id {
+			return msg
+		}
+	}
+}
+
+// A connection that already has MaxConcurrentRequests in flight must have
+// further requests rejected with CodeTooManyRequests, while the in-flight ones
+// keep running and a slot becomes reusable once one completes.
+func TestMaxConcurrentRequestsRejectsOverCap(t *testing.T) {
+	ts, h := setupGateServer(t, ServerOptions{MaxConcurrentRequests: 2})
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// Fill both slots with blocking requests and wait until both execute.
+	for i := 0; i < 2; i++ {
+		if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: fmt.Sprintf("block-%d", i), Method: "gateHandlers.Block"}); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		<-h.entered
+	}
+
+	// A third concurrent request exceeds the cap and is rejected outright.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "over", Method: "gateHandlers.Block"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	over := readUntilID(t, ws, "over", 3*time.Second)
+	if over.Type != TypeError || over.Code != CodeTooManyRequests {
+		t.Fatalf("expected CodeTooManyRequests error for over-cap request, got type=%q code=%d", over.Type, over.Code)
+	}
+
+	// Releasing the blocked handlers frees slots; a new request now succeeds.
+	close(h.release)
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "after", Method: "gateHandlers.Block"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	after := readUntilID(t, ws, "after", 3*time.Second)
+	if after.Type != TypeResponse {
+		t.Fatalf("expected successful response after a slot freed, got type=%q code=%d", after.Type, after.Code)
+	}
+}
+
+// The server-wide cap bounds total in-flight requests across all connections,
+// independent of the per-connection cap.
+func TestMaxServerConcurrentRequestsRejectsOverCap(t *testing.T) {
+	// Disable the per-connection cap so the server-wide cap is the only limit.
+	ts, h := setupGateServer(t, ServerOptions{MaxConcurrentRequests: -1, MaxServerConcurrentRequests: 2})
+
+	ws1 := connectWS(t, ts)
+	defer ws1.Close()
+	ws2 := connectWS(t, ts)
+	defer ws2.Close()
+
+	// One blocking request on each connection fills the server-wide budget.
+	if err := ws1.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "a", Method: "gateHandlers.Block"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := ws2.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "b", Method: "gateHandlers.Block"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	<-h.entered
+	<-h.entered
+
+	// A third request on either connection is rejected server-wide.
+	if err := ws1.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "over", Method: "gateHandlers.Block"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	over := readUntilID(t, ws1, "over", 3*time.Second)
+	if over.Type != TypeError || over.Code != CodeTooManyRequests {
+		t.Fatalf("expected CodeTooManyRequests for server-wide over-cap request, got type=%q code=%d", over.Type, over.Code)
+	}
+	close(h.release)
+}
+
+// A connection may hold at most MaxSubscriptions active subscriptions; the next
+// subscribe is rejected with CodeTooManyRequests.
+func TestMaxSubscriptionsRejectsOverCap(t *testing.T) {
+	ts, _ := setupGateServer(t, ServerOptions{MaxSubscriptions: 2})
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// Two subscriptions register successfully (read each response before the
+	// next so registration order is deterministic).
+	for i := 0; i < 2; i++ {
+		id := fmt.Sprintf("sub-%d", i)
+		if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: id, Method: "gateHandlers.Sub"}); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		resp := readUntilID(t, ws, id, 3*time.Second)
+		if resp.Type != TypeResponse {
+			t.Fatalf("expected subscription %s to succeed, got type=%q code=%d", id, resp.Type, resp.Code)
+		}
+	}
+
+	// The third subscription exceeds the cap.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "sub-over", Method: "gateHandlers.Sub"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	over := readUntilID(t, ws, "sub-over", 3*time.Second)
+	if over.Type != TypeError || over.Code != CodeTooManyRequests {
+		t.Fatalf("expected CodeTooManyRequests for over-cap subscription, got type=%q code=%d", over.Type, over.Code)
+	}
+}
+
+// With the caps disabled (-1), many concurrent requests all run without any
+// being rejected.
+func TestConcurrencyCapsDisabled(t *testing.T) {
+	ts, h := setupGateServer(t, ServerOptions{MaxConcurrentRequests: -1, MaxServerConcurrentRequests: -1})
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: fmt.Sprintf("r-%d", i), Method: "gateHandlers.Block", Params: jsontext.Value(`[]`)}); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+	// All n must reach the handler; none rejected.
+	for i := 0; i < n; i++ {
+		select {
+		case <-h.entered:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("only %d/%d requests reached the handler; some were rejected with caps disabled", i, n)
+		}
+	}
+	close(h.release)
+}

--- a/sse_handler.go
+++ b/sse_handler.go
@@ -205,28 +205,27 @@ func (h *sseHandler) handleRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Dispatch based on message type
+	// Dispatch based on message type. dispatchRequest/dispatchSubscribe reserve
+	// an in-flight slot (rejecting with CodeTooManyRequests over the SSE stream
+	// when a concurrency cap is exceeded) and manage requestsWg, so the acquire
+	// stays paired with the release in the handler.
 	switch req.Type {
 	case "subscribe":
-		msg := IncomingMessage{
+		conn.dispatchSubscribe(IncomingMessage{
 			Type:   TypeSubscribe,
 			ID:     req.ID,
 			Method: req.Method,
 			Params: req.Params,
-		}
-		h.server.requestsWg.Add(1)
-		go conn.handleSubscribe(msg)
+		})
 	case "unsubscribe":
 		conn.handleUnsubscribe(req.ID)
 	default:
-		msg := IncomingMessage{
+		conn.dispatchRequest(IncomingMessage{
 			Type:   TypeRequest,
 			ID:     req.ID,
 			Method: req.Method,
 			Params: req.Params,
-		}
-		h.server.requestsWg.Add(1)
-		go conn.handleRequest(msg)
+		})
 	}
 
 	w.WriteHeader(http.StatusAccepted)

--- a/subscription.go
+++ b/subscription.go
@@ -37,22 +37,41 @@ func newSubscriptionManager() *subscriptionManager {
 	}
 }
 
-// register adds a subscription to the indexes. It reports whether the
-// subscription was added; it refuses connections that have already been
-// closed, so a subscribe handler that races a disconnect cannot leave a
-// subscription that outlives its connection (re-executing forever and
-// writing to a dead transport). The closed check holds sm.mu while reading
-// the conn's lock; this never nests against close(), which releases the
-// conn lock before calling unregisterConn.
-func (sm *subscriptionManager) register(sub *subscription) bool {
+// register adds a subscription to the indexes. The ok result reports whether
+// the subscription was added; limited reports that it was refused because the
+// connection is already at its MaxSubscriptions cap (so the caller can reply
+// with CodeTooManyRequests rather than treating it as a closed connection).
+//
+// It refuses connections that have already been closed, so a subscribe handler
+// that races a disconnect cannot leave a subscription that outlives its
+// connection (re-executing forever and writing to a dead transport). The closed
+// check holds sm.mu while reading the conn's lock; this never nests against
+// close(), which releases the conn lock before calling unregisterConn.
+//
+// The per-connection cap is enforced here, under sm.mu, so concurrent subscribe
+// handlers on the same connection cannot race past the limit.
+func (sm *subscriptionManager) register(sub *subscription) (ok bool, limited bool) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	if sub.conn.isClosed() {
-		return false
+		return false, false
 	}
 
 	connID := sub.conn.id
+
+	// Enforce the per-connection subscription cap. A test conn may have no
+	// server; that path is uncapped. Only a brand-new subscription ID counts —
+	// re-registering an existing ID (the caller's update path) is never
+	// rejected.
+	if sub.conn.server != nil {
+		if max := sub.conn.server.options.MaxSubscriptions; max > 0 {
+			existing := sm.byConn[connID]
+			if _, isReReg := existing[sub.id]; !isReReg && len(existing) >= max {
+				return false, true
+			}
+		}
+	}
 
 	// Add to conn index
 	if sm.byConn[connID] == nil {
@@ -67,7 +86,7 @@ func (sm *subscriptionManager) register(sub *subscription) bool {
 		}
 		sm.byKey[key][sub] = struct{}{}
 	}
-	return true
+	return true, false
 }
 
 func (sm *subscriptionManager) unregister(connID uint64, subID string) {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -13,6 +13,7 @@ export const ErrorCode = {
     Unauthorized: -32001,
     ConnectionRejected: -32002,
     Forbidden: -32003,
+    TooManyRequests: -32004,
 {{- range .CustomErrorCodes}}
     {{.Name}}: {{.Code}},
 {{- end}}
@@ -57,6 +58,7 @@ export class ApiError extends Error {
     isValidationFailed(): boolean { return this.code === ErrorCode.ValidationFailed; }
     isCanceled(): boolean { return this.code === ErrorCode.Canceled; }
     isConnectionRejected(): boolean { return this.code === ErrorCode.ConnectionRejected; }
+    isTooManyRequests(): boolean { return this.code === ErrorCode.TooManyRequests; }
 {{- range .CustomErrorCodes}}
     {{.MethodName}}(): boolean { return this.code === ErrorCode.{{.Name}}; }
 {{- end}}


### PR DESCRIPTION
@
Fixes #222.

## Problem

A single connection could pin unbounded work:
- Every inbound request/subscribe frame was dispatched on a bare goroutine, so one client could hold unlimited concurrent in-flight requests.
- A connection could register unlimited subscriptions, and a server-side `TriggerRefresh` fans out across **all** matching subscriptions — so one client amplifies a single trigger into arbitrary work.

No per-connection backpressure, cap, or rejection path existed. Same DoS blast-radius class as the P0 issues fixed in #208, but originating from *volume* rather than a stalled peer.

## What this adds

Three `ServerOptions` caps, following the existing convention (`0` = default, `-1` = disable, positive = override):

| Option | Default | Bounds |
|--------|---------|--------|
| `MaxConcurrentRequests` | 256 | in-flight requests per connection |
| `MaxServerConcurrentRequests` | 10000 | in-flight requests across all connections |
| `MaxSubscriptions` | 1024 | active subscriptions per connection (also bounds refresh fan-out) |

Each request/subscribe frame reserves one slot (per-connection + server-wide counting semaphores) for the duration of its handler; a **streaming handler holds its slot until the stream ends**. A frame that would exceed a cap is **rejected with a new `CodeTooManyRequests` (-32004)** rather than spawning more goroutines.

### Design decisions (confirmed up front)
- **On exceed → reject** with `CodeTooManyRequests` (connection stays up; other requests unaffected).
- **Enabled by default** with generous limits, matching the `MaxMessageSize`/`WriteTimeout` convention.
- **Per-connection + server-wide** scope.

### Implementation notes
- The subscription cap is enforced **atomically inside `subscriptionManager.register`** (under `sm.mu`), so concurrent subscribe handlers on one connection cannot race past the limit.
- The acquire/release lifecycle lives entirely in `dispatchRequest`/`dispatchSubscribe`, shared by the **WebSocket and SSE** transports, so the handlers stay callable in isolation and the acquire is always paired with the release.
- Server-initiated subscription **refreshes are intentionally ungated** — `MaxSubscriptions` is the lever that bounds their fan-out; gating refresh would risk silently dropping updates.

## Tests

New `server_concurrency_test.go`:
- `TestMaxConcurrentRequestsRejectsOverCap` — fills the per-connection budget with blocking handlers, asserts the next request gets `CodeTooManyRequests`, and that a slot becomes reusable once one completes.
- `TestMaxServerConcurrentRequestsRejectsOverCap` — two connections fill the server-wide budget; a third request on either is rejected.
- `TestMaxSubscriptionsRejectsOverCap` — the (N+1)th subscribe is rejected.
- `TestConcurrencyCapsDisabled` — with `-1`, 50 concurrent requests all run.

Full suite + `go vet` pass. TS client regenerated (`ErrorCode.TooManyRequests`, `err.isTooManyRequests()`); React client `tsc --noEmit` passes.

## Docs
Updated `README.md`, `doc.go`, `APROT_AI.md`, and regenerated example clients.

## Follow-ups (out of scope)
Configurable behavior beyond reject (queue/close), and per-user rather than per-connection caps, if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@