### PR TITLE
Add CORS middleware for SSE & REST transports (#224)

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -37,6 +37,8 @@ Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{Max
 
 **Cookie-auth deployments must set an origin check** (default allows all origins — CSWSH risk): `server.SetCheckOrigin(func(r *http.Request) bool { return r.Header.Get("Origin") == "https://app.example.com" })`.
 
+**CORS for SSE/REST** (plain HTTP, so origin check doesn't apply): wrap the transport with `aprot.CORS(aprot.CORSOptions{AllowedOrigins, AllowedMethods, AllowedHeaders, ExposedHeaders, AllowCredentials, MaxAge})` — a `func(http.Handler) http.Handler` closed by default. Handles `OPTIONS` preflight (204). `AllowCredentials: true` must pair with explicit (non-`*`) origins; with `*`+credentials it echoes the concrete origin. E.g. `http.Handle("/api/", http.StripPrefix("/api", cors(rest)))`, `http.Handle("/sse", cors(server.HTTPTransport()))`.
+
 ### 3. TypeScript Generation
 ```go
 gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
 - **Connection hardening** — per-request panic recovery, inbound message size limits, write timeouts that drop stalled clients, WebSocket keepalive pings, and per-connection / server-wide concurrency and subscription caps — all configurable via `ServerOptions`
+- **Cross-origin control** — WebSocket origin checking (`SetCheckOrigin`) plus a closed-by-default `CORS` middleware for the SSE and REST HTTP transports
 - **Automatic reconnection** — page visibility + network-aware, with exponential backoff; supports dynamic URL functions for token refresh on reconnect
 - **Struct validation** — opt-in server-side validation via `go-playground/validator` struct tags, automatically enforced before handler dispatch
 - **Input transformation** — declarative `transform` struct tags (`trim`, `trimleft`, `trimright`, `uppercase`, `lowercase`, `removeempty`) normalize fields before validation runs
@@ -765,6 +766,25 @@ server.SetCheckOrigin(func(r *http.Request) bool {
 ```
 
 Token-based auth (e.g. a token passed via the connection URL) is not affected by this, but setting an origin check is still good hygiene for browser-facing deployments.
+
+### CORS for SSE & REST (cross-origin browser clients)
+
+The SSE and REST endpoints are plain HTTP, so a cross-origin browser app calling them needs CORS response headers and `OPTIONS` preflight handling — the HTTP-transport counterpart to WebSocket origin checking. `aprot.CORS` returns a standard `func(http.Handler) http.Handler` wrapper you can put in front of any transport:
+
+```go
+cors := aprot.CORS(aprot.CORSOptions{
+    AllowedOrigins:   []string{"https://app.example.com"},
+    AllowCredentials: true, // required for cookie-authenticated browsers
+    // AllowedMethods / AllowedHeaders / ExposedHeaders / MaxAge optional
+})
+
+http.Handle("/api/", http.StripPrefix("/api", cors(rest)))   // REST adapter
+http.Handle("/sse", cors(server.HTTPTransport()))            // SSE handler
+```
+
+- **Closed by default** — construct the wrapper only where you want cross-origin access; nothing is loosened otherwise. An `Origin` that isn't allowed receives no CORS headers, so the browser blocks the response while same-origin and non-browser clients are unaffected.
+- **Credentials caveat** — cookie/`Authorization` requests need `AllowCredentials: true` **paired with explicit origins**. The browser rejects `Access-Control-Allow-Origin: *` alongside credentials, so `CORS` echoes the exact matched origin instead of `*` in that case (same class of concern as the CSWSH note above).
+- **Preflight** — `OPTIONS` requests carrying `Access-Control-Request-Method` are answered directly (`204`) with the allowed methods/headers and `Access-Control-Max-Age`; they never reach your handlers.
 
 ## REST Adapter
 

--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,157 @@
+package aprot
+
+import (
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// CORSOptions configures the [CORS] middleware.
+//
+// The zero value allows no cross-origin requests. CORS is opt-in: nothing is
+// loosened unless you construct the middleware and mount it, mirroring the
+// closed-by-default posture of [Server.SetCheckOrigin] for WebSocket.
+type CORSOptions struct {
+	// AllowedOrigins lists the origins permitted to make cross-origin requests,
+	// each matched exactly (scheme + host + optional port) against the request's
+	// Origin header. The special value "*" allows any origin. An empty list
+	// allows none. When AllowCredentials is true, "*" cannot be sent verbatim
+	// per the Fetch standard, so the matched origin is echoed back instead.
+	AllowedOrigins []string
+	// AllowedMethods lists the HTTP methods permitted for cross-origin requests,
+	// advertised in preflight responses. Defaults to GET, POST, PUT, PATCH,
+	// DELETE, OPTIONS when empty.
+	AllowedMethods []string
+	// AllowedHeaders lists the request headers a client may send. Defaults to
+	// {"Content-Type"} when empty. The special value "*" allows any header (for
+	// credentialed requests the browser's requested headers are echoed, since
+	// "*" is not honored alongside credentials).
+	AllowedHeaders []string
+	// ExposedHeaders lists response headers the browser may expose to client
+	// JavaScript beyond the CORS-safelisted set.
+	ExposedHeaders []string
+	// AllowCredentials sets Access-Control-Allow-Credentials: true, required for
+	// cross-origin requests that carry cookies or Authorization. It must be
+	// paired with explicit (non-"*") origins; see AllowedOrigins.
+	AllowCredentials bool
+	// MaxAge is how long, in seconds, a browser may cache a preflight response.
+	// Zero omits the header (the browser uses its default).
+	MaxAge int
+}
+
+// defaultCORSMethods is advertised in preflight when AllowedMethods is empty.
+var defaultCORSMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+
+// CORS returns middleware that adds CORS response headers and answers OPTIONS
+// preflight requests. It is a standard func(http.Handler) http.Handler wrapper,
+// so it composes with any of the three transports — the REST adapter
+// ([RESTAdapter]), the SSE handler ([Server.HTTPTransport]), or the WebSocket
+// handler ([Server.WebSocket]):
+//
+//	cors := aprot.CORS(aprot.CORSOptions{
+//	    AllowedOrigins:   []string{"https://app.example.com"},
+//	    AllowCredentials: true, // needed for cookie-authenticated browsers
+//	})
+//	http.Handle("/api/", http.StripPrefix("/api", cors(rest)))
+//	http.Handle("/sse", cors(server.HTTPTransport()))
+//
+// It is closed by default: a request whose Origin is not allowed receives no
+// CORS headers, so the browser blocks the cross-origin response. Same-origin
+// and non-browser clients are unaffected because the wrapped handler still runs
+// for non-preflight requests.
+//
+// For cookie-authenticated deployments, set AllowCredentials and list the exact
+// origins — never rely on "*", which browsers reject alongside credentials.
+// This is the HTTP-transport analogue of restricting WebSocket origins with
+// [Server.SetCheckOrigin].
+func CORS(opts CORSOptions) func(http.Handler) http.Handler {
+	methods := opts.AllowedMethods
+	if len(methods) == 0 {
+		methods = defaultCORSMethods
+	}
+	allowMethods := strings.Join(methods, ", ")
+
+	headers := opts.AllowedHeaders
+	if len(headers) == 0 {
+		headers = []string{"Content-Type"}
+	}
+	allowHeaders := strings.Join(headers, ", ")
+	wildcardHeaders := slices.Contains(headers, "*")
+
+	exposeHeaders := strings.Join(opts.ExposedHeaders, ", ")
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			// Not a cross-origin request — leave it untouched.
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allowOrigin, ok := opts.resolveOrigin(origin)
+
+			// Vary on Origin whenever the response depends on it, so shared
+			// caches don't serve one origin's response to another.
+			w.Header().Add("Vary", "Origin")
+
+			isPreflight := r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != ""
+
+			if ok {
+				w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+				if opts.AllowCredentials {
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
+				if exposeHeaders != "" {
+					w.Header().Set("Access-Control-Expose-Headers", exposeHeaders)
+				}
+			}
+
+			if !isPreflight {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Preflight: answer directly and never reach the wrapped handler.
+			w.Header().Add("Vary", "Access-Control-Request-Method")
+			w.Header().Add("Vary", "Access-Control-Request-Headers")
+			if ok {
+				w.Header().Set("Access-Control-Allow-Methods", allowMethods)
+				// With credentials the literal "*" isn't honored for headers, so
+				// reflect exactly what the browser asked to send.
+				if wildcardHeaders && opts.AllowCredentials {
+					if reqHeaders := r.Header.Get("Access-Control-Request-Headers"); reqHeaders != "" {
+						w.Header().Set("Access-Control-Allow-Headers", reqHeaders)
+					}
+				} else {
+					w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
+				}
+				if opts.MaxAge > 0 {
+					w.Header().Set("Access-Control-Max-Age", strconv.Itoa(opts.MaxAge))
+				}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
+}
+
+// resolveOrigin decides the Access-Control-Allow-Origin value for a request's
+// Origin, and whether the origin is allowed at all. A wildcard match echoes the
+// concrete origin when credentials are enabled (the Fetch standard forbids "*"
+// with credentials) and otherwise returns "*".
+func (opts CORSOptions) resolveOrigin(origin string) (allow string, ok bool) {
+	for _, o := range opts.AllowedOrigins {
+		if o == origin {
+			return origin, true
+		}
+		if o == "*" {
+			if opts.AllowCredentials {
+				return origin, true
+			}
+			return "*", true
+		}
+	}
+	return "", false
+}

--- a/cors.go
+++ b/cors.go
@@ -62,9 +62,15 @@ var defaultCORSMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTI
 // for non-preflight requests.
 //
 // For cookie-authenticated deployments, set AllowCredentials and list the exact
-// origins — never rely on "*", which browsers reject alongside credentials.
-// This is the HTTP-transport analogue of restricting WebSocket origins with
-// [Server.SetCheckOrigin].
+// origins. Avoid combining AllowCredentials with AllowedOrigins ["*"]: browsers
+// forbid a literal "*" alongside credentials, so the wrapper instead reflects
+// whichever origin is calling — effectively allow-any-origin *with* credentials,
+// which is rarely intended. An explicit allowlist is the HTTP-transport analogue
+// of restricting WebSocket origins with [Server.SetCheckOrigin].
+//
+// Wrapping [Server.WebSocket] is harmless but usually unnecessary: a WS upgrade
+// isn't subject to CORS, and its origin control is [Server.SetCheckOrigin]. CORS
+// belongs on the SSE and REST HTTP transports.
 func CORS(opts CORSOptions) func(http.Handler) http.Handler {
 	methods := opts.AllowedMethods
 	if len(methods) == 0 {

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,178 @@
+package aprot
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// okHandler records whether it was called and always writes 200.
+type okHandler struct{ called bool }
+
+func (h *okHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.called = true
+	w.WriteHeader(http.StatusOK)
+}
+
+func doReq(t *testing.T, handler http.Handler, method, origin string, extra map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(method, "/api/things", nil)
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	for k, v := range extra {
+		r.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, r)
+	return rec
+}
+
+// An allowed origin gets Access-Control-Allow-Origin and the request still
+// reaches the wrapped handler.
+func TestCORS_AllowedOrigin(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"https://app.example.com"}})(next)
+
+	rec := doReq(t, h, http.MethodGet, "https://app.example.com", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want the request origin", got)
+	}
+	if !next.called {
+		t.Error("wrapped handler should be called for a simple (non-preflight) request")
+	}
+	if got := rec.Header().Get("Vary"); got == "" {
+		t.Error("expected Vary: Origin so caches don't serve one origin's response to another")
+	}
+}
+
+// A disallowed origin gets no CORS headers; the request still passes through
+// (the browser is what blocks the response), so behavior for same-origin and
+// non-browser clients is unchanged.
+func TestCORS_DisallowedOrigin(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"https://app.example.com"}})(next)
+
+	rec := doReq(t, h, http.MethodGet, "https://evil.example.com", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty for a disallowed origin", got)
+	}
+	if !next.called {
+		t.Error("wrapped handler should still be called; the browser enforces the block")
+	}
+}
+
+// A preflight OPTIONS request is answered directly (204) with the allow-* headers
+// and never reaches the wrapped handler.
+func TestCORS_Preflight(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{
+		AllowedOrigins: []string{"https://app.example.com"},
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedHeaders: []string{"Content-Type", "X-Custom"},
+		MaxAge:         600,
+	})(next)
+
+	rec := doReq(t, h, http.MethodOptions, "https://app.example.com", map[string]string{
+		"Access-Control-Request-Method":  "POST",
+		"Access-Control-Request-Headers": "Content-Type",
+	})
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("preflight status = %d, want 204", rec.Code)
+	}
+	if next.called {
+		t.Error("preflight must not reach the wrapped handler")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST" {
+		t.Errorf("Access-Control-Allow-Methods = %q, want \"GET, POST\"", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != "Content-Type, X-Custom" {
+		t.Errorf("Access-Control-Allow-Headers = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Max-Age"); got != "600" {
+		t.Errorf("Access-Control-Max-Age = %q, want 600", got)
+	}
+}
+
+// With credentials enabled and an explicit origin, the exact origin is echoed
+// (never "*") and Allow-Credentials is set.
+func TestCORS_Credentials(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{
+		AllowedOrigins:   []string{"https://app.example.com"},
+		AllowCredentials: true,
+	})(next)
+
+	rec := doReq(t, h, http.MethodGet, "https://app.example.com", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want the exact origin", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want true", got)
+	}
+}
+
+// A wildcard origin without credentials responds with "*".
+func TestCORS_WildcardNoCredentials(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"*"}})(next)
+
+	rec := doReq(t, h, http.MethodGet, "https://anything.example.com", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want *", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Error("Allow-Credentials must not be set without AllowCredentials")
+	}
+}
+
+// A wildcard origin WITH credentials must echo the concrete origin, never "*"
+// (the Fetch spec forbids "*" with credentials).
+func TestCORS_WildcardWithCredentials(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"*"}, AllowCredentials: true})(next)
+
+	rec := doReq(t, h, http.MethodGet, "https://anything.example.com", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://anything.example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want the concrete origin (not *) with credentials", got)
+	}
+}
+
+// A request without an Origin header is not a CORS request; no CORS headers are
+// added and the request passes through untouched.
+func TestCORS_NoOrigin(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"*"}})(next)
+
+	rec := doReq(t, h, http.MethodGet, "", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty for a non-CORS request", got)
+	}
+	if !next.called {
+		t.Error("non-CORS request should reach the wrapped handler")
+	}
+}
+
+// An OPTIONS request that is not a preflight (no Access-Control-Request-Method)
+// is passed through rather than short-circuited.
+func TestCORS_NonPreflightOptions(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"https://app.example.com"}})(next)
+
+	rec := doReq(t, h, http.MethodOptions, "https://app.example.com", nil)
+
+	if !next.called {
+		t.Error("a non-preflight OPTIONS should reach the wrapped handler")
+	}
+	_ = rec
+}

--- a/cors_test.go
+++ b/cors_test.go
@@ -176,3 +176,66 @@ func TestCORS_NonPreflightOptions(t *testing.T) {
 	}
 	_ = rec
 }
+
+// The zero value allows no origin: every cross-origin request is fully closed
+// (no CORS headers) yet still passes through to the wrapped handler.
+func TestCORS_ZeroValueClosed(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{})(next)
+
+	rec := doReq(t, h, http.MethodGet, "https://app.example.com", nil)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty for the zero-value (closed) config", got)
+	}
+	if !next.called {
+		t.Error("wrapped handler should still run under the closed config")
+	}
+}
+
+// A preflight from a disallowed origin is short-circuited (204) but must carry
+// no Allow-* headers, so the browser blocks the actual request. Guards against
+// leaking allow-methods/headers to origins that were never permitted.
+func TestCORS_DisallowedOriginPreflight(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{AllowedOrigins: []string{"https://app.example.com"}})(next)
+
+	rec := doReq(t, h, http.MethodOptions, "https://evil.example.com", map[string]string{
+		"Access-Control-Request-Method": "POST",
+	})
+
+	if next.called {
+		t.Error("preflight must not reach the wrapped handler even for a disallowed origin")
+	}
+	for _, header := range []string{
+		"Access-Control-Allow-Origin",
+		"Access-Control-Allow-Methods",
+		"Access-Control-Allow-Headers",
+		"Access-Control-Allow-Credentials",
+	} {
+		if got := rec.Header().Get(header); got != "" {
+			t.Errorf("%s = %q, want empty for a disallowed-origin preflight", header, got)
+		}
+	}
+}
+
+// With wildcard AllowedHeaders and credentials, the preflight must echo the
+// browser's requested headers rather than the literal "*" (which the Fetch
+// standard does not honor alongside credentials).
+func TestCORS_WildcardHeadersWithCredentials(t *testing.T) {
+	next := &okHandler{}
+	h := CORS(CORSOptions{
+		AllowedOrigins:   []string{"https://app.example.com"},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: true,
+	})(next)
+
+	rec := doReq(t, h, http.MethodOptions, "https://app.example.com", map[string]string{
+		"Access-Control-Request-Method":  "POST",
+		"Access-Control-Request-Headers": "X-Custom, Content-Type",
+	})
+
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != "X-Custom, Content-Type" {
+		t.Errorf("Access-Control-Allow-Headers = %q, want the echoed request headers (not \"*\") with credentials", got)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -286,6 +286,19 @@
 //	    return r.Header.Get("Origin") == "https://app.example.com"
 //	})
 //
+// The SSE and REST transports are plain HTTP, so cross-origin browser clients
+// need CORS response headers and OPTIONS preflight handling instead. [CORS]
+// returns a standard func(http.Handler) http.Handler wrapper for that, closed
+// by default and mirroring the SetCheckOrigin guidance above — list exact
+// origins (never "*") whenever AllowCredentials is set for cookie auth:
+//
+//	cors := aprot.CORS(aprot.CORSOptions{
+//	    AllowedOrigins:   []string{"https://app.example.com"},
+//	    AllowCredentials: true,
+//	})
+//	http.Handle("/api/", http.StripPrefix("/api", cors(rest)))
+//	http.Handle("/sse", cors(server.HTTPTransport()))
+//
 // # Connection Lifecycle
 //
 // [Server.OnConnect] and [Server.OnDisconnect] hooks react to connection


### PR DESCRIPTION
@
Fixes #224.

## Problem

The SSE (`/sse`) and REST adapter endpoints are plain HTTP. Cross-origin browser apps calling them need CORS response headers (`Access-Control-Allow-*`) and `OPTIONS` preflight handling. WebSocket already had `SetCheckOrigin`, but SSE/REST had **no cross-origin story** — users had to hand-roll middleware, and it wasn't documented.

## What this adds

`aprot.CORS(CORSOptions)` — a standard `func(http.Handler) http.Handler` wrapper that composes with any of the three transports:

```go
cors := aprot.CORS(aprot.CORSOptions{
    AllowedOrigins:   []string{"https://app.example.com"},
    AllowCredentials: true, // required for cookie-authenticated browsers
})
http.Handle("/api/", http.StripPrefix("/api", cors(rest)))   // REST adapter
http.Handle("/sse", cors(server.HTTPTransport()))            // SSE handler
```

`CORSOptions`: `AllowedOrigins`, `AllowedMethods`, `AllowedHeaders`, `ExposedHeaders`, `AllowCredentials`, `MaxAge`.

### Design decisions (aligned with the issue's leanings)
- **Built-in helper + docs** — not docs-only.
- **Shared `http.Handler` wrapper** — one implementation covers REST, SSE, and even WebSocket, rather than separate `RESTOption` / SSE-option variants that would duplicate logic.
- **Closed by default** — an `Origin` not in `AllowedOrigins` receives no CORS headers, so the browser blocks the cross-origin response. Same-origin and non-browser clients are unaffected (non-preflight requests still reach the handler).

### Behavior details
- **Credentials caveat handled**: with `AllowCredentials` the exact matched origin is echoed, never `*` (which browsers reject alongside credentials) — the HTTP-transport analogue of the CSWSH note for `SetCheckOrigin`. `["*"]` + credentials echoes the concrete request origin.
- **Preflight**: `OPTIONS` carrying `Access-Control-Request-Method` is answered directly (`204`) with allowed methods/headers and `Max-Age`; it never reaches your handlers. A non-preflight `OPTIONS` passes through.
- **`Vary: Origin`** (and the preflight request headers) set so shared caches don't serve one origin's response to another.

## Tests

New `cors_test.go` (8 cases): allowed origin, disallowed origin (pass-through, browser blocks), preflight 204 + short-circuit, credentials echo exact origin, wildcard without/with credentials, no-Origin non-CORS request, and non-preflight OPTIONS pass-through.

Full suite + `go vet` pass.

## Docs
`README.md` (new "CORS for SSE & REST" section + feature bullet), `doc.go` security section, `APROT_AI.md`.

## Out of scope
No changes to the example apps' runtime wiring (the docs recipe covers it); no per-transport option sugar (`WithRESTCORS`) since the shared wrapper subsumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@