### PR TITLE
Add Observer hooks + Stats() for metrics/observability (#223)

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -39,6 +39,8 @@ Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{Max
 
 **CORS for SSE/REST** (plain HTTP, so origin check doesn't apply): wrap the transport with `aprot.CORS(aprot.CORSOptions{AllowedOrigins, AllowedMethods, AllowedHeaders, ExposedHeaders, AllowCredentials, MaxAge})` — a `func(http.Handler) http.Handler` closed by default. Handles `OPTIONS` preflight (204). `AllowCredentials: true` must pair with explicit (non-`*`) origins; with `*`+credentials it echoes the concrete origin. E.g. `http.Handle("/api/", http.StripPrefix("/api", cors(rest)))`, `http.Handle("/sse", cors(server.HTTPTransport()))`.
 
+**Observability**: set `ServerOptions.Observer` to an `aprot.Observer` (embed `aprot.NoopObserver`, override what you need) — nil disables it with zero hot-path cost. Events: `ConnectionOpened/Closed(*Conn)`, `RequestCompleted(RequestEvent{Method, Subscribe, Duration, Code})` (Code 0 = success; fires for client requests/subscribes, not server refreshes), `SubscriptionRegistered/Unregistered(*Conn, method, id)`, `RefreshFanout(key, matched)`, `SendBufferFull(*Conn)` (backpressure; frame not dropped), `WriteTimedOut(*Conn)`. Callbacks are synchronous on hot paths + may run concurrently — keep them fast/non-blocking. Pull-based gauges: `server.Stats()` → `ServerStats{Connections, Subscriptions}`. Streaming handlers hold their slot until stream end; `RequestCompleted.Duration` spans the full iteration.
+
 ### 3. TypeScript Generation
 ```go
 gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
 - **Connection hardening** — per-request panic recovery, inbound message size limits, write timeouts that drop stalled clients, WebSocket keepalive pings, and per-connection / server-wide concurrency and subscription caps — all configurable via `ServerOptions`
 - **Cross-origin control** — WebSocket origin checking (`SetCheckOrigin`) plus a closed-by-default `CORS` middleware for the SSE and REST HTTP transports
+- **Observability** — opt-in `Observer` hooks (connections, request latency/errors, subscriptions, refresh fan-out, send-buffer pressure) plus a pull-based `Stats()` snapshot, with zero hot-path cost when unset
 - **Automatic reconnection** — page visibility + network-aware, with exponential backoff; supports dynamic URL functions for token refresh on reconnect
 - **Struct validation** — opt-in server-side validation via `go-playground/validator` struct tags, automatically enforced before handler dispatch
 - **Input transformation** — declarative `transform` struct tags (`trim`, `trimleft`, `trimright`, `uppercase`, `lowercase`, `removeempty`) normalize fields before validation runs
@@ -785,6 +786,28 @@ http.Handle("/sse", cors(server.HTTPTransport()))            // SSE handler
 - **Closed by default** — construct the wrapper only where you want cross-origin access; nothing is loosened otherwise. An `Origin` that isn't allowed receives no CORS headers, so the browser blocks the response while same-origin and non-browser clients are unaffected.
 - **Credentials caveat** — cookie/`Authorization` requests need `AllowCredentials: true` **paired with explicit origins**. The browser rejects `Access-Control-Allow-Origin: *` alongside credentials, so `CORS` echoes the exact matched origin instead of `*` in that case (same class of concern as the CSWSH note above).
 - **Preflight** — `OPTIONS` requests carrying `Access-Control-Request-Method` are answered directly (`204`) with the allowed methods/headers and `Access-Control-Max-Age`; they never reach your handlers.
+
+## Observability
+
+Wire aprot into Prometheus, OpenTelemetry, or structured logs by registering an `Observer` — aprot takes no dependency on a metrics library, it just calls your callbacks on key events. Observation is **opt-in**: with no observer the hot path allocates nothing.
+
+```go
+type metrics struct{ aprot.NoopObserver } // embed NoopObserver, override what you need
+
+func (metrics) RequestCompleted(e aprot.RequestEvent) {
+    requestDuration.WithLabelValues(e.Method, strconv.Itoa(e.Code)).Observe(e.Duration.Seconds())
+}
+func (metrics) SendBufferFull(*aprot.Conn) { sendBufferFull.Inc() } // early backpressure signal
+
+server := aprot.NewServer(registry, aprot.ServerOptions{Observer: metrics{}})
+```
+
+Events: `ConnectionOpened` / `ConnectionClosed`, `RequestCompleted` (method, subscribe flag, duration, error code), `SubscriptionRegistered` / `SubscriptionUnregistered`, `RefreshFanout` (trigger key + fan-out size), `SendBufferFull` (slow-consumer backpressure — the precursor to a stalled-client drop), and `WriteTimedOut`.
+
+- **Embed `NoopObserver`** so you implement only the events you care about and stay forward-compatible as new ones are added.
+- **Hot-path discipline** — callbacks run synchronously on the server's hot paths and may fire concurrently, so keep them fast and non-blocking; offload heavy work to a goroutine.
+- **Cardinality** — `Method` is bounded by your handler set, but per-user / per-connection labels can explode a metrics backend; aggregate those.
+- **Gauges** — `server.Stats()` returns a pull-based snapshot (`Connections`, `Subscriptions`) for periodic scraping, rather than tracking those from events.
 
 ## REST Adapter
 

--- a/connection.go
+++ b/connection.go
@@ -731,7 +731,11 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	}
 
 	// If the client unsubscribed while the handler was running, don't register.
+	// The context can be canceled in the window after the check above, so report
+	// this as canceled (not the default success) to match that sibling branch;
+	// no response is sent because the subscriber is already gone.
 	if ctx.Err() != nil {
+		reqCode = CodeCanceled
 		return
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/go-json-experiment/json"
 )
@@ -300,6 +301,22 @@ func (c *Conn) sendResponse(id string, result any) {
 	_ = c.sendJSON(msg)
 }
 
+// errorCode maps a handler error to the protocol code that sendError /
+// sendProtocolError / sendStreamEnd would send for it, so the observer can
+// report the same code the client receives. Returns 0 for a nil error.
+func (c *Conn) errorCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if perr, ok := err.(*ProtocolError); ok {
+		return perr.Code
+	}
+	if code, found := c.server.registry.LookupError(err); found {
+		return code
+	}
+	return CodeInternalError
+}
+
 func (c *Conn) sendError(id string, code int, message string) {
 	msg := ErrorMessage{
 		Type:    TypeError,
@@ -405,16 +422,35 @@ func (c *Conn) handleIncomingMessage(data []byte) {
 
 func (c *Conn) handleRequest(msg IncomingMessage) {
 	defer c.server.requestsWg.Done()
+
+	// Report the completed request to the observer (if any). reqCode is updated
+	// at each terminal branch; this defer runs after the panic-recovery defer
+	// below, so a panicking handler is still reported as CodeInternalError.
+	observer := c.server.observer
+	reqCode := 0
+	if observer != nil {
+		start := time.Now()
+		defer func() {
+			observer.RequestCompleted(RequestEvent{
+				Method:   msg.Method,
+				Duration: time.Since(start),
+				Code:     reqCode,
+			})
+		}()
+	}
+
 	// Each request runs on its own goroutine, so an unrecovered panic would
 	// kill the whole process, not just this request (unlike net/http).
 	defer func() {
 		if r := recover(); r != nil {
+			reqCode = CodeInternalError
 			c.sendError(msg.ID, CodeInternalError, fmt.Sprintf("handler panicked: %v", r))
 		}
 	}()
 
 	info, ok := c.server.registry.Get(msg.Method)
 	if !ok {
+		reqCode = CodeMethodNotFound
 		c.sendError(msg.ID, CodeMethodNotFound, "method not found: "+msg.Method)
 		return
 	}
@@ -462,11 +498,13 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 
 	// Check if context was canceled
 	if ctx.Err() == context.Canceled {
+		reqCode = CodeCanceled
 		c.sendError(msg.ID, CodeCanceled, "request canceled")
 		return
 	}
 
 	if err != nil {
+		reqCode = c.errorCode(err)
 		if perr, ok := err.(*ProtocolError); ok {
 			c.sendProtocolError(msg.ID, perr)
 		} else if code, found := c.server.registry.LookupError(err); found {
@@ -481,7 +519,7 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 	// iter.Seq / iter.Seq2. Drive iteration now that middleware has returned.
 	if info.Kind == HandlerKindStream || info.Kind == HandlerKindStream2 {
 		seqVal, _ := result.(reflect.Value)
-		c.streamIterator(ctx, msg.ID, seqVal, info, sHooks)
+		reqCode = c.errorCode(c.streamIterator(ctx, msg.ID, seqVal, info, sHooks))
 		c.server.processRefreshQueue(rq)
 		return
 	}
@@ -505,13 +543,16 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 // as the sentinel the context carries (ErrClientCanceled,
 // ErrConnectionClosed, or ErrServerShutdown), so logging middleware
 // can distinguish client disconnect from server shutdown.
-func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Value, info *HandlerInfo, hooks *streamHooks) {
+// streamIterator returns the terminal error sent on the StreamEndMessage (nil
+// for a clean end or client cancellation), so the caller can report the stream's
+// outcome code to the observer.
+func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Value, info *HandlerInfo, hooks *streamHooks) error {
 	if !seq.IsValid() || seq.Kind() == reflect.Func && seq.IsNil() {
 		c.sendStreamEnd(reqID, nil)
 		if hooks != nil {
 			hooks.run(nil, 0)
 		}
-		return
+		return nil
 	}
 
 	yieldType := seq.Type().In(0)
@@ -571,9 +612,10 @@ func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Val
 	// the client's point of view — no error payload on the end message.
 	if streamErr != nil && ctx.Err() == nil && streamErr != ErrConnectionClosed {
 		c.sendStreamEnd(reqID, streamErr)
-	} else {
-		c.sendStreamEnd(reqID, nil)
+		return streamErr
 	}
+	c.sendStreamEnd(reqID, nil)
+	return nil
 }
 
 // sendStreamEnd sends a terminal StreamEndMessage for the given request ID.
@@ -598,14 +640,33 @@ func (c *Conn) sendStreamEnd(reqID string, err error) {
 
 func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	defer c.server.requestsWg.Done()
+
+	// Report the completed subscribe to the observer (if any). See handleRequest
+	// for the defer-ordering rationale.
+	observer := c.server.observer
+	reqCode := 0
+	if observer != nil {
+		start := time.Now()
+		defer func() {
+			observer.RequestCompleted(RequestEvent{
+				Method:    msg.Method,
+				Subscribe: true,
+				Duration:  time.Since(start),
+				Code:      reqCode,
+			})
+		}()
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
+			reqCode = CodeInternalError
 			c.sendError(msg.ID, CodeInternalError, fmt.Sprintf("handler panicked: %v", r))
 		}
 	}()
 
 	info, ok := c.server.registry.Get(msg.Method)
 	if !ok {
+		reqCode = CodeMethodNotFound
 		c.sendError(msg.ID, CodeMethodNotFound, "method not found: "+msg.Method)
 		return
 	}
@@ -613,6 +674,7 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	// Subscriptions require a reproducible unary result to re-send on refresh;
 	// streaming handlers can't satisfy that contract.
 	if info.Kind != HandlerKindUnary {
+		reqCode = CodeInvalidRequest
 		c.sendError(msg.ID, CodeInvalidRequest, "streaming handlers cannot be subscribed: "+msg.Method)
 		return
 	}
@@ -651,11 +713,13 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 	result, err := handler(ctx, req)
 
 	if ctx.Err() == context.Canceled {
+		reqCode = CodeCanceled
 		c.sendError(msg.ID, CodeCanceled, "request canceled")
 		return
 	}
 
 	if err != nil {
+		reqCode = c.errorCode(err)
 		if perr, ok := err.(*ProtocolError); ok {
 			c.sendProtocolError(msg.ID, perr)
 		} else if code, found := c.server.registry.LookupError(err); found {
@@ -692,12 +756,15 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 			if limited {
 				// The connection is at its subscription cap; tell the client so
 				// it can back off rather than silently dropping the subscribe.
+				reqCode = CodeTooManyRequests
 				c.sendError(msg.ID, CodeTooManyRequests, "subscription limit reached")
 			}
 			// Otherwise the connection closed while the handler was running; the
 			// subscription was refused so it can't outlive the conn. Either way,
 			// don't send a success response.
 			return
+		} else if observer != nil {
+			observer.SubscriptionRegistered(c, msg.Method, msg.ID)
 		}
 	}
 

--- a/doc.go
+++ b/doc.go
@@ -322,6 +322,25 @@
 // targeting ([Server.PushToUser]). It is not a security boundary — use the
 // stored principal for authorization decisions.
 //
+// # Observability
+//
+// Register an [Observer] via [ServerOptions.Observer] to receive connection,
+// request, subscription, refresh-fan-out, and send-buffer-pressure events, and
+// map them onto Prometheus, OpenTelemetry, or structured logs — aprot takes no
+// dependency on a metrics library. Observation is opt-in: with no observer the
+// hot path allocates nothing. Embed [NoopObserver] to implement only the events
+// you need and stay forward-compatible:
+//
+//	type metrics struct{ aprot.NoopObserver }
+//	func (metrics) RequestCompleted(e aprot.RequestEvent) {
+//	    requestDuration.WithLabelValues(e.Method, strconv.Itoa(e.Code)).Observe(e.Duration.Seconds())
+//	}
+//	server := aprot.NewServer(registry, aprot.ServerOptions{Observer: metrics{}})
+//
+// Observer methods run synchronously on hot paths, so implementations must be
+// fast and non-blocking. For gauge-style values, [Server.Stats] returns a
+// pull-based snapshot of active connection and subscription counts.
+//
 // # Push Events
 //
 // Push events are server-to-client messages broadcast to all connected clients

--- a/observer.go
+++ b/observer.go
@@ -1,0 +1,100 @@
+package aprot
+
+import "time"
+
+// Observer receives server lifecycle and per-request events, letting a
+// deployment wire aprot into Prometheus, OpenTelemetry, structured logging, or
+// any other telemetry system without aprot depending on those libraries.
+//
+// Register one via [ServerOptions.Observer]. All methods are called
+// synchronously on the server's hot paths and may run concurrently from many
+// goroutines, so implementations must be fast, non-blocking, and safe for
+// concurrent use — offload any heavy work (I/O, aggregation) to a background
+// goroutine. When no observer is registered the server skips this bookkeeping
+// entirely, keeping the hot path allocation-free.
+//
+// Prefer high-cardinality-safe labels: Method is bounded by the handler set,
+// but per-user or per-connection dimensions can explode a metrics backend's
+// cardinality — aggregate those rather than emitting one series each.
+//
+// Embed [NoopObserver] to implement only the events you need and remain
+// forward-compatible as new methods are added to this interface:
+//
+//	type myMetrics struct{ aprot.NoopObserver }
+//	func (m *myMetrics) RequestCompleted(e aprot.RequestEvent) { /* ... */ }
+type Observer interface {
+	// ConnectionOpened fires after a connection is accepted, cleared by connect
+	// hooks, and registered. ConnectionClosed fires once when it is torn down;
+	// conn.UserID() is still valid at that point.
+	ConnectionOpened(conn *Conn)
+	ConnectionClosed(conn *Conn)
+
+	// RequestCompleted fires once per client-initiated request or subscribe
+	// after its handler (and, for streaming handlers, the full iteration)
+	// finishes. Server-driven subscription refreshes are reported via
+	// RefreshFanout, not here.
+	RequestCompleted(event RequestEvent)
+
+	// SubscriptionRegistered and SubscriptionUnregistered bracket an active
+	// subscription's lifetime. Unregister fires on explicit unsubscribe and on
+	// disconnect — once per subscription still active at close.
+	SubscriptionRegistered(conn *Conn, method, id string)
+	SubscriptionUnregistered(conn *Conn, method, id string)
+
+	// RefreshFanout fires once per trigger key flushed by a server-side refresh,
+	// reporting how many subscriptions matched that key (the fan-out size). A
+	// large fan-out for a single trigger is an amplification signal.
+	RefreshFanout(key string, matched int)
+
+	// SendBufferFull fires when a connection's outbound WebSocket buffer is full
+	// at enqueue time — an early backpressure / slow-consumer signal and the
+	// precursor to a stalled-client write timeout. The frame is not dropped: the
+	// send blocks until room frees or the write times out.
+	SendBufferFull(conn *Conn)
+
+	// WriteTimedOut fires when an outbound WebSocket write exceeds
+	// [ServerOptions.WriteTimeout] and the connection is dropped.
+	WriteTimedOut(conn *Conn)
+}
+
+// RequestEvent describes a completed request or subscribe, passed to
+// [Observer.RequestCompleted].
+type RequestEvent struct {
+	// Method is the wire method name, e.g. "Users.GetUser".
+	Method string
+	// Subscribe is true when the client sent a subscribe frame rather than a
+	// one-shot request.
+	Subscribe bool
+	// Duration is the wall-clock time from dispatch to completion. For streaming
+	// handlers it spans the full iteration.
+	Duration time.Duration
+	// Code is the protocol error code sent to the client, or 0 on success.
+	Code int
+}
+
+// ServerStats is a point-in-time snapshot of gauge-style server metrics,
+// returned by [Server.Stats] for pull-based collection.
+type ServerStats struct {
+	// Connections is the number of active connections.
+	Connections int
+	// Subscriptions is the number of active subscriptions across all connections.
+	Subscriptions int
+}
+
+// NoopObserver implements [Observer] with methods that do nothing. Embed it in
+// your observer to implement only the events you care about and stay
+// forward-compatible as new events are added to the interface.
+type NoopObserver struct{}
+
+// Compile-time check that NoopObserver satisfies Observer (and thus that
+// embedding it satisfies the interface too).
+var _ Observer = NoopObserver{}
+
+func (NoopObserver) ConnectionOpened(*Conn)                         {}
+func (NoopObserver) ConnectionClosed(*Conn)                         {}
+func (NoopObserver) RequestCompleted(RequestEvent)                  {}
+func (NoopObserver) SubscriptionRegistered(*Conn, string, string)   {}
+func (NoopObserver) SubscriptionUnregistered(*Conn, string, string) {}
+func (NoopObserver) RefreshFanout(string, int)                      {}
+func (NoopObserver) SendBufferFull(*Conn)                           {}
+func (NoopObserver) WriteTimedOut(*Conn)                            {}

--- a/observer_test.go
+++ b/observer_test.go
@@ -117,6 +117,12 @@ func (obsHandlers) Slow(ctx context.Context) (*EchoResponse, error) {
 	return &EchoResponse{Message: "slow"}, nil
 }
 
+// Panic exercises the panic-recovery path so the observer must report
+// CodeInternalError (the recovery defer runs before the observer defer).
+func (obsHandlers) Panic(ctx context.Context) (*EchoResponse, error) {
+	panic("boom")
+}
+
 // Watch registers a trigger key so a subscription is created for it.
 func (obsHandlers) Watch(ctx context.Context) (*EchoResponse, error) {
 	RegisterRefreshTrigger(ctx, "watched")
@@ -244,6 +250,51 @@ func TestObserver_SubscriptionLifecycleAndFanout(t *testing.T) {
 		defer obs.mu.Unlock()
 		return len(obs.subUnreg) == 1 && obs.subUnreg[0] == "obsHandlers.Watch/s1"
 	})
+}
+
+// A panicking handler is recovered and reported to the observer as
+// CodeInternalError — verifies the panic-recovery defer runs before (and sets
+// the code seen by) the observer defer.
+func TestObserver_PanicReportsInternalError(t *testing.T) {
+	obs := newRecordingObserver()
+	ts, _ := setupObserverServer(t, obs)
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "p", Method: "obsHandlers.Panic"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeError, 3*time.Second)
+
+	eventually(t, 3*time.Second, func() bool { return len(obs.snapshotRequests()) == 1 })
+	if e := obs.snapshotRequests()[0]; e.Code != CodeInternalError {
+		t.Errorf("panicking handler reported Code=%d, want CodeInternalError(%d)", e.Code, CodeInternalError)
+	}
+}
+
+// Re-subscribing with the same ID goes through the update path, so
+// SubscriptionRegistered must fire only once (not once per subscribe frame).
+func TestObserver_ResubscribeFiresRegisteredOnce(t *testing.T) {
+	obs := newRecordingObserver()
+	ts, _ := setupObserverServer(t, obs)
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// The register event fires inside the handler before its response is sent,
+	// so once both responses are read both subscribe attempts have completed.
+	for i := 0; i < 2; i++ {
+		if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "s1", Method: "obsHandlers.Watch"}); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	}
+
+	obs.mu.Lock()
+	n := len(obs.subReg)
+	obs.mu.Unlock()
+	if n != 1 {
+		t.Errorf("SubscriptionRegistered fired %d times for resubscribe with same ID, want 1", n)
+	}
 }
 
 // Disconnecting with an active subscription fires SubscriptionUnregistered for

--- a/observer_test.go
+++ b/observer_test.go
@@ -1,0 +1,339 @@
+package aprot
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// recordingObserver captures observer callbacks for assertions. It embeds
+// NoopObserver so it satisfies Observer even as events are added, and guards all
+// state with a mutex since callbacks fire from many goroutines.
+type recordingObserver struct {
+	NoopObserver
+	mu           sync.Mutex
+	opened       int
+	closed       int
+	requests     []RequestEvent
+	subReg       []string // "method/id"
+	subUnreg     []string // "method/id"
+	fanouts      map[string]int
+	bufferFull   int
+	writeTimeout int
+}
+
+func newRecordingObserver() *recordingObserver {
+	return &recordingObserver{fanouts: make(map[string]int)}
+}
+
+func (o *recordingObserver) ConnectionOpened(*Conn) {
+	o.mu.Lock()
+	o.opened++
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) ConnectionClosed(*Conn) {
+	o.mu.Lock()
+	o.closed++
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) RequestCompleted(e RequestEvent) {
+	o.mu.Lock()
+	o.requests = append(o.requests, e)
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) SubscriptionRegistered(_ *Conn, method, id string) {
+	o.mu.Lock()
+	o.subReg = append(o.subReg, method+"/"+id)
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) SubscriptionUnregistered(_ *Conn, method, id string) {
+	o.mu.Lock()
+	o.subUnreg = append(o.subUnreg, method+"/"+id)
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) RefreshFanout(key string, matched int) {
+	o.mu.Lock()
+	o.fanouts[key] += matched
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) SendBufferFull(*Conn) {
+	o.mu.Lock()
+	o.bufferFull++
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) WriteTimedOut(*Conn) {
+	o.mu.Lock()
+	o.writeTimeout++
+	o.mu.Unlock()
+}
+
+func (o *recordingObserver) snapshotRequests() []RequestEvent {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]RequestEvent(nil), o.requests...)
+}
+
+// eventually polls cond until it is true or the deadline passes.
+func eventually(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}
+
+// obsHandlers exercise the request/subscribe/refresh observer paths.
+type obsHandlers struct{}
+
+func (obsHandlers) Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error) {
+	return &EchoResponse{Message: req.Message}, nil
+}
+
+func (obsHandlers) Fail(ctx context.Context) (*EchoResponse, error) {
+	return nil, NewError(CodeInvalidParams, "nope")
+}
+
+// Slow sleeps a known amount so the observed Duration is deterministically
+// positive (an instant handler can measure exactly 0 on coarse clocks).
+func (obsHandlers) Slow(ctx context.Context) (*EchoResponse, error) {
+	time.Sleep(5 * time.Millisecond)
+	return &EchoResponse{Message: "slow"}, nil
+}
+
+// Watch registers a trigger key so a subscription is created for it.
+func (obsHandlers) Watch(ctx context.Context) (*EchoResponse, error) {
+	RegisterRefreshTrigger(ctx, "watched")
+	return &EchoResponse{Message: "watching"}, nil
+}
+
+// Touch fires a refresh for the "watched" key.
+func (obsHandlers) Touch(ctx context.Context) (*EchoResponse, error) {
+	TriggerRefresh(ctx, "watched")
+	return &EchoResponse{Message: "touched"}, nil
+}
+
+func setupObserverServer(t *testing.T, obs Observer) (*httptest.Server, *Server) {
+	t.Helper()
+	registry := NewRegistry()
+	registry.Register(&obsHandlers{})
+	server := NewServer(registry, ServerOptions{Observer: obs})
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+	return ts, server
+}
+
+func TestObserver_ConnectDisconnect(t *testing.T) {
+	obs := newRecordingObserver()
+	ts, _ := setupObserverServer(t, obs)
+
+	ws := connectWS(t, ts)
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return obs.opened == 1
+	})
+
+	ws.Close()
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return obs.closed == 1
+	})
+}
+
+func TestObserver_RequestCompleted(t *testing.T) {
+	obs := newRecordingObserver()
+	ts, _ := setupObserverServer(t, obs)
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// Successful request.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "obsHandlers.Echo", Params: jsontext.Value(`[{"message":"hi"}]`)}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+
+	// Failing request (returns a ProtocolError with CodeInvalidParams).
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "2", Method: "obsHandlers.Fail"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeError, 3*time.Second)
+
+	// Slow request — its handler sleeps, so the Duration is deterministically
+	// positive.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "3", Method: "obsHandlers.Slow"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+
+	eventually(t, 3*time.Second, func() bool { return len(obs.snapshotRequests()) == 3 })
+
+	byMethod := make(map[string]RequestEvent)
+	for _, e := range obs.snapshotRequests() {
+		byMethod[e.Method] = e
+	}
+	if e := byMethod["obsHandlers.Echo"]; e.Code != 0 {
+		t.Errorf("Echo code = %d, want 0 (success)", e.Code)
+	}
+	if e, ok := byMethod["obsHandlers.Fail"]; !ok || e.Code != CodeInvalidParams {
+		t.Errorf("Fail event = %+v, want Code=%d", e, CodeInvalidParams)
+	}
+	if e := byMethod["obsHandlers.Slow"]; e.Duration < time.Millisecond {
+		t.Errorf("Slow Duration = %v, want >= 1ms (handler sleeps 5ms)", e.Duration)
+	}
+}
+
+func TestObserver_SubscriptionLifecycleAndFanout(t *testing.T) {
+	obs := newRecordingObserver()
+	ts, server := setupObserverServer(t, obs)
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	// Subscribe to Watch — registers a subscription on key "watched".
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "s1", Method: "obsHandlers.Watch"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return len(obs.subReg) == 1 && obs.subReg[0] == "obsHandlers.Watch/s1"
+	})
+
+	// Stats reflects the active connection and subscription.
+	if st := server.Stats(); st.Connections != 1 || st.Subscriptions != 1 {
+		t.Errorf("Stats = %+v, want Connections=1 Subscriptions=1", st)
+	}
+
+	// A request that triggers "watched" fans out to the one subscription.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "t1", Method: "obsHandlers.Touch"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return obs.fanouts["watched"] >= 1
+	})
+
+	// Unsubscribe fires the unregister event.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeUnsubscribe, ID: "s1"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return len(obs.subUnreg) == 1 && obs.subUnreg[0] == "obsHandlers.Watch/s1"
+	})
+}
+
+// Disconnecting with an active subscription fires SubscriptionUnregistered for
+// the remaining subscription (via subscriptionManager.unregisterConn).
+func TestObserver_SubscriptionUnregisteredOnDisconnect(t *testing.T) {
+	obs := newRecordingObserver()
+	ts, _ := setupObserverServer(t, obs)
+	ws := connectWS(t, ts)
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "s1", Method: "obsHandlers.Watch"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return len(obs.subReg) == 1
+	})
+
+	ws.Close()
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return len(obs.subUnreg) == 1 && obs.subUnreg[0] == "obsHandlers.Watch/s1"
+	})
+}
+
+// SendBufferFull fires when the outbound buffer has no free slot at enqueue
+// time. Exercised at the transport level by pre-filling the 256-slot buffer.
+func TestObserver_SendBufferFull(t *testing.T) {
+	obs := newRecordingObserver()
+	registry := NewRegistry()
+	server := NewServer(registry, ServerOptions{Observer: obs})
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	tr := &wsTransport{
+		send: make(chan []byte, 256),
+		done: make(chan struct{}),
+	}
+	tr.conn = &Conn{server: server, transport: tr, id: 1}
+
+	// Fill the buffer so the next enqueue must report backpressure.
+	for i := 0; i < 256; i++ {
+		tr.send <- nil
+	}
+
+	sent := make(chan error, 1)
+	go func() { sent <- tr.Send([]byte("x")) }()
+
+	eventually(t, 3*time.Second, func() bool {
+		obs.mu.Lock()
+		defer obs.mu.Unlock()
+		return obs.bufferFull == 1
+	})
+
+	// Drain one slot so the blocked Send can complete.
+	<-tr.send
+	if err := <-sent; err != nil {
+		t.Fatalf("Send returned %v after a slot freed, want nil", err)
+	}
+}
+
+func TestIsTimeoutError(t *testing.T) {
+	if !isTimeoutError(os.ErrDeadlineExceeded) {
+		t.Error("os.ErrDeadlineExceeded should be classified as a timeout")
+	}
+	if !isTimeoutError(&net.OpError{Op: "write", Err: os.ErrDeadlineExceeded}) {
+		t.Error("a net.OpError wrapping a deadline should be a timeout")
+	}
+	if isTimeoutError(context.Canceled) {
+		t.Error("context.Canceled is not a write timeout")
+	}
+	if isTimeoutError(nil) {
+		t.Error("nil is not a timeout")
+	}
+}
+
+// A server with no observer must not panic on any of the instrumented paths.
+func TestObserver_NilObserverIsSafe(t *testing.T) {
+	ts, server := setupObserverServer(t, nil)
+	if server.observer != nil {
+		t.Fatal("expected nil observer")
+	}
+	ws := connectWS(t, ts)
+	defer ws.Close()
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "obsHandlers.Echo", Params: jsontext.Value(`[{"message":"hi"}]`)}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	if st := server.Stats(); st.Connections != 1 {
+		t.Errorf("Stats.Connections = %d, want 1", st.Connections)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -71,6 +71,10 @@ type ServerOptions struct {
 	// a server-side TriggerRefresh re-executes every matching subscription on a
 	// connection. Set to -1 to disable. Default: 1024.
 	MaxSubscriptions int
+	// Observer receives connection, request, subscription, refresh, and
+	// send-buffer events for metrics/observability. Nil (the default) disables
+	// all observation with no hot-path cost. See [Observer].
+	Observer Observer
 }
 
 func defaultServerOptions() ServerOptions {
@@ -114,6 +118,8 @@ type Server struct {
 	// a counting semaphore (one buffer slot per allowed request); nil when
 	// MaxServerConcurrentRequests disables the server-wide cap.
 	reqSem chan struct{}
+	// observer receives lifecycle/metrics events; nil disables observation.
+	observer Observer
 }
 
 // NewServer creates a new WebSocket server with the given registry.
@@ -154,6 +160,9 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		if opt.MaxSubscriptions != 0 {
 			options.MaxSubscriptions = opt.MaxSubscriptions
 		}
+		if opt.Observer != nil {
+			options.Observer = opt.Observer
+		}
 	}
 
 	// PongTimeout is the inbound read deadline; pings fire every PingInterval.
@@ -185,6 +194,7 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 	if options.MaxServerConcurrentRequests > 0 {
 		s.reqSem = make(chan struct{}, options.MaxServerConcurrentRequests)
 	}
+	s.observer = options.Observer
 	// Run OnServerInit hooks (used by tasks/ to set up taskManager, middleware, etc.)
 	for _, hook := range registry.serverInitHooks {
 		hook(s)
@@ -382,6 +392,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	wst := newWSTransport(ws, s.options)
 	conn := newConn(wst, s, connID, r, ctx)
+	// Give the transport a back-reference so it can report send-buffer pressure
+	// and write timeouts to the observer. Set before the pumps start.
+	wst.conn = conn
 
 	// Bound the direct writes below (rejection/config) the same way the
 	// write pump bounds its writes; the pump refreshes the deadline per
@@ -449,6 +462,20 @@ func (s *Server) ConnectionCount() int {
 	return len(s.conns)
 }
 
+// Stats returns a point-in-time snapshot of gauge-style server metrics
+// (active connections and subscriptions). It is safe for concurrent use and is
+// the pull-based companion to the push-based [Observer]; scrape it periodically
+// for gauges rather than tracking those counts from events yourself.
+func (s *Server) Stats() ServerStats {
+	s.mu.RLock()
+	conns := len(s.conns)
+	s.mu.RUnlock()
+	return ServerStats{
+		Connections:   conns,
+		Subscriptions: s.subscriptions.count(),
+	}
+}
+
 func (s *Server) run() {
 	defer close(s.done)
 
@@ -467,6 +494,9 @@ func (s *Server) run() {
 			s.mu.Lock()
 			s.conns[conn] = struct{}{}
 			s.mu.Unlock()
+			if s.observer != nil {
+				s.observer.ConnectionOpened(conn)
+			}
 		case conn := <-s.unregister:
 			s.mu.Lock()
 			_, existed := s.conns[conn]
@@ -480,6 +510,9 @@ func (s *Server) run() {
 				s.runDisconnectHooks(conn) // Before disassociate so UserID() works
 				s.disassociateUser(conn)
 				conn.close()
+				if s.observer != nil {
+					s.observer.ConnectionClosed(conn)
+				}
 			}
 
 			if s.stopping.Load() && empty {

--- a/subscription.go
+++ b/subscription.go
@@ -91,14 +91,15 @@ func (sm *subscriptionManager) register(sub *subscription) (ok bool, limited boo
 
 func (sm *subscriptionManager) unregister(connID uint64, subID string) {
 	sm.mu.Lock()
-	defer sm.mu.Unlock()
 
 	connSubs, ok := sm.byConn[connID]
 	if !ok {
+		sm.mu.Unlock()
 		return
 	}
 	sub, ok := connSubs[subID]
 	if !ok {
+		sm.mu.Unlock()
 		return
 	}
 
@@ -117,18 +118,37 @@ func (sm *subscriptionManager) unregister(connID uint64, subID string) {
 	if len(connSubs) == 0 {
 		delete(sm.byConn, connID)
 	}
+	sm.mu.Unlock()
+
+	// Notify outside the lock so a slow observer can't stall subscription
+	// bookkeeping for other connections.
+	notifySubscriptionUnregistered(sub)
+}
+
+// notifySubscriptionUnregistered fires the observer's SubscriptionUnregistered
+// event for sub, if an observer is registered. Safe to call with a subscription
+// whose connection has no server (unit-test conns).
+func notifySubscriptionUnregistered(sub *subscription) {
+	if sub.conn == nil || sub.conn.server == nil {
+		return
+	}
+	if o := sub.conn.server.observer; o != nil {
+		o.SubscriptionUnregistered(sub.conn, sub.method, sub.id)
+	}
 }
 
 func (sm *subscriptionManager) unregisterConn(connID uint64) {
 	sm.mu.Lock()
-	defer sm.mu.Unlock()
 
 	connSubs, ok := sm.byConn[connID]
 	if !ok {
+		sm.mu.Unlock()
 		return
 	}
 
+	removed := make([]*subscription, 0, len(connSubs))
 	for _, sub := range connSubs {
+		removed = append(removed, sub)
 		for key := range sub.keys {
 			if subs, ok := sm.byKey[key]; ok {
 				delete(subs, sub)
@@ -140,6 +160,12 @@ func (sm *subscriptionManager) unregisterConn(connID uint64) {
 	}
 
 	delete(sm.byConn, connID)
+	sm.mu.Unlock()
+
+	// Notify outside the lock, once per subscription that was still active.
+	for _, sub := range removed {
+		notifySubscriptionUnregistered(sub)
+	}
 }
 
 func (sm *subscriptionManager) updateKeys(connID uint64, subID string, newKeys map[string]struct{}) {
@@ -202,6 +228,18 @@ func (sm *subscriptionManager) has(connID uint64, subID string) bool {
 	return false
 }
 
+// count returns the total number of active subscriptions across all
+// connections. Used by Server.Stats for gauge-style metrics.
+func (sm *subscriptionManager) count() int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	n := 0
+	for _, subs := range sm.byConn {
+		n += len(subs)
+	}
+	return n
+}
+
 // getSubscriptionsForKey returns all subscriptions for a trigger key.
 func (sm *subscriptionManager) getSubscriptionsForKey(key string) []*subscription {
 	sm.mu.RLock()
@@ -251,7 +289,11 @@ func (s *Server) processRefreshQueue(rq *refreshQueue) {
 	seen := make(map[*subscription]struct{})
 	var toRefresh []*subscription
 	for _, key := range keys {
-		for _, sub := range s.subscriptions.getSubscriptionsForKey(key) {
+		subs := s.subscriptions.getSubscriptionsForKey(key)
+		if s.observer != nil {
+			s.observer.RefreshFanout(key, len(subs))
+		}
+		for _, sub := range subs {
 			if _, ok := seen[sub]; !ok {
 				seen[sub] = struct{}{}
 				toRefresh = append(toRefresh, sub)

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -2,6 +2,9 @@ package aprot
 
 import (
 	"context"
+	"errors"
+	"net"
+	"os"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -13,6 +16,19 @@ type wsTransport struct {
 	send chan []byte
 	done chan struct{} // closed once to signal shutdown; makes Send a no-op
 	opts ServerOptions // read limit, write timeout, and keepalive settings
+	// conn is a back-reference used only to report send-buffer pressure and
+	// write timeouts to the server's observer. Set after construction, before
+	// the pumps start; nil in transports created without a connection.
+	conn *Conn
+}
+
+// observer returns the server's observer via the connection back-reference, or
+// nil when there is no connection or no observer registered.
+func (t *wsTransport) observer() Observer {
+	if t.conn == nil || t.conn.server == nil {
+		return nil
+	}
+	return t.conn.server.observer
 }
 
 func newWSTransport(ws *websocket.Conn, opts ServerOptions) *wsTransport {
@@ -36,6 +52,14 @@ func (t *wsTransport) Send(data []byte) error {
 		return ErrConnectionClosed
 	case t.send <- data:
 		return nil
+	default:
+		t.reportBufferFull()
+	}
+	select {
+	case <-t.done:
+		return ErrConnectionClosed
+	case t.send <- data:
+		return nil
 	}
 }
 
@@ -47,6 +71,25 @@ func (t *wsTransport) SendCtx(ctx context.Context, data []byte) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	default:
+		t.reportBufferFull()
+	}
+	select {
+	case <-t.done:
+		return ErrConnectionClosed
+	case t.send <- data:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// reportBufferFull signals send-buffer backpressure to the observer. Called on
+// the enqueue path when the buffer has no free slot; the frame is not dropped,
+// the caller falls back to a blocking send.
+func (t *wsTransport) reportBufferFull() {
+	if o := t.observer(); o != nil {
+		o.SendBufferFull(t.conn)
 	}
 }
 
@@ -134,5 +177,21 @@ func (t *wsTransport) writeMessage(messageType int, data []byte) error {
 	if t.opts.WriteTimeout > 0 {
 		_ = t.ws.SetWriteDeadline(time.Now().Add(t.opts.WriteTimeout))
 	}
-	return t.ws.WriteMessage(messageType, data)
+	err := t.ws.WriteMessage(messageType, data)
+	if err != nil && isTimeoutError(err) {
+		if o := t.observer(); o != nil {
+			o.WriteTimedOut(t.conn)
+		}
+	}
+	return err
+}
+
+// isTimeoutError reports whether err is (or wraps) an I/O deadline timeout,
+// which for a write means the peer stopped reading and WriteTimeout elapsed.
+func isTimeoutError(err error) bool {
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
 }


### PR DESCRIPTION
@
Fixes #223.

## Problem

Key operational signals were unobservable without forking the library: connection counts, request throughput/latency/error rates, subscription counts, `TriggerRefresh` fan-out size, and send-buffer pressure (the precursor to the P0 stalled-client deadlock fixed in #208). There was no first-class way to wire aprot into Prometheus / OpenTelemetry.

## What this adds

A push-based `Observer` interface (set via `ServerOptions.Observer`) **plus** a pull-based `Server.Stats()` snapshot — **no dependency** on any metrics library, and **zero hot-path cost when unset** (every call site is guarded by `if observer != nil`).

### Design decisions (the issue's open questions)
- **Push hooks *and* a pull snapshot** — events for counters/histograms, `Stats()` for gauges.
- **Lives on `ServerOptions.Observer`** (consistent with the other options), nil = disabled.
- **Embed `NoopObserver`** to implement only the events you need and stay forward-compatible as events are added (guarded by a compile-time assertion).
- **Cardinality** called out in the interface doc: `Method` is bounded, per-user/per-connection labels are not — aggregate them.

### Events
| Event | Payload |
|-------|---------|
| `ConnectionOpened` / `ConnectionClosed` | `*Conn` |
| `RequestCompleted` | `RequestEvent{Method, Subscribe, Duration, Code}` — Code 0 = success; client requests/subscribes only (not server refreshes); for streams, Duration spans the full iteration |
| `SubscriptionRegistered` / `SubscriptionUnregistered` | `*Conn, method, id` — unregister fires on unsubscribe and once per remaining sub on disconnect |
| `RefreshFanout` | `key, matched` (fan-out size per trigger key) |
| `SendBufferFull` | `*Conn` — outbound buffer full at enqueue; frame is **not** dropped |
| `WriteTimedOut` | `*Conn` |

```go
type metrics struct{ aprot.NoopObserver }
func (metrics) RequestCompleted(e aprot.RequestEvent) {
    requestDuration.WithLabelValues(e.Method, strconv.Itoa(e.Code)).Observe(e.Duration.Seconds())
}
server := aprot.NewServer(registry, aprot.ServerOptions{Observer: metrics{}})
```

### Implementation notes
- Callbacks fire **synchronously on hot paths** and may run concurrently; the interface doc tells implementers to keep them fast/non-blocking.
- Subscription-unregister events fire **outside** the `subscriptionManager` lock so a slow observer can't stall bookkeeping for other connections.
- `streamIterator` now returns its terminal error so the request observer reports the same code the client received.
- `SendBufferFull` is detected with a non-blocking enqueue try before falling back to the existing blocking send (no behavior change to delivery).

## Tests

New `observer_test.go` with a thread-safe recording observer: connect/disconnect, request completed (success + error code + measured duration), subscription register/unregister (including on-disconnect), refresh fan-out, `Stats()`, `SendBufferFull` (via a pre-filled 256-slot buffer), `isTimeoutError`, and a nil-observer safety test. Stress-ran 10× to shake out timing flakiness. Full suite + `go vet` pass.

## Docs
README (Observability section + feature bullet), `doc.go` (Observability section), `APROT_AI.md`.

## Out of scope (possible follow-ups)
Per-user metric aggregation helpers; a built-in Prometheus/OTel adapter (kept out deliberately to avoid the dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@