### PR TITLE
Add Server.ServeStream and injectable TS ClientTransport

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -8,7 +8,7 @@ This guide is a fast-reference for agents. The authoritative overview is `doc.go
 
 - **Registry** — collects handler groups, push events, enums, custom errors, and a validator.
 - **Handlers** — methods on a struct; one TypeScript file per group.
-- **Transports** — WebSocket (`/ws`), SSE+HTTP (`/sse`), and optional REST (`NewRESTAdapter`).
+- **Transports** — WebSocket (`/ws`), SSE+HTTP (`/sse`), byte streams (`server.ServeStream` — stdio/pipes/sockets, NDJSON framing), and optional REST (`NewRESTAdapter`).
 - **Middleware** — `func(next) Handler` wrappers; server-level or per-handler-group.
 - **Tasks** — hierarchical progress and output streaming (request-scoped or shared).
 - **Subscription Refresh** — query handlers register trigger keys; mutations fire them to push fresh results.
@@ -41,6 +41,8 @@ Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{Max
 
 **First-message auth** (token over the connection, not the URL): `server.OnAuth(func(ctx, conn *aprot.Conn, token string) error { ...; conn.SetUserID(id); return nil })` — return `aprot.ErrAuthFailed(msg)` (code -32005) to reject. Registering a hook makes every new connection **pending**: it must send `{"type":"auth","token":"..."}` and get `auth_ok` before any request/subscribe runs; earlier frames get `auth_error`; a connection unauthenticated within `ServerOptions.AuthTimeout` (default 10s, `-1` disables) is closed. The same auth frame on a live connection refreshes identity (a failed refresh keeps the session — no downgrade). WebSocket sends the frame directly; SSE sends it in the first `POST /rpc` body (`{type:"auth",connectionId,token}`), with `auth_ok`/`auth_error` over the stream. No hook → unchanged (URL-token via `OnConnect` still works). TS client: `new ApiClient(url, {getAuthToken: () => token})` and `client.refreshAuth(token)`; `err.isAuthFailed()`.
 
+**Byte-stream transport** (Electron/desktop embedding, stdio, Unix sockets, named pipes): `server.ServeStream(ctx, rw io.ReadWriteCloser, aprot.ConnInfo{...})` serves one connection over any byte stream using newline-delimited JSON (one protocol message per line, both directions). Blocks until the connection ends; returns nil on normal close (EOF/ctx cancel/Stop), or the rejection error (connect hook / `ErrServerShutdown`). Full feature parity: hooks, first-message auth, middleware, subscriptions, streaming, push. Caller supplies `ConnInfo` (all fields optional — no HTTP request exists). `MaxMessageSize` bounds line length; `PingInterval`/`PongTimeout`/`WriteTimeout` do NOT apply (no ping frames or write deadlines on raw streams — liveness is the stream's lifetime). stdio: `server.ServeStream(ctx, struct{io.Reader; io.WriteCloser}{os.Stdin, os.Stdout}, aprot.ConnInfo{})`; listener: `go server.ServeStream(ctx, c, aprot.ConnInfo{RemoteAddr: c.RemoteAddr().String()})` per `Accept()`. TS side: `ApiClientOptions.transport` accepts a custom `ClientTransport` instance (exported interface) in addition to `'websocket' | 'sse'` — implement it to bridge e.g. an Electron MessagePort to the Go child's stdio.
+
 **Observability**: set `ServerOptions.Observer` to an `aprot.Observer` (embed `aprot.NoopObserver`, override what you need) — nil disables it with zero hot-path cost. Events: `ConnectionOpened/Closed(*Conn)`, `RequestCompleted(RequestEvent{Method, Subscribe, Duration, Code})` (Code 0 = success; fires for client requests/subscribes, not server refreshes), `SubscriptionRegistered/Unregistered(*Conn, method, id)`, `RefreshFanout(key, matched)`, `SendBufferFull(*Conn)` (backpressure; frame not dropped), `WriteTimedOut(*Conn)`. Callbacks are synchronous on hot paths + may run concurrently — keep them fast/non-blocking. Pull-based gauges: `server.Stats()` → `ServerStats{Connections, Subscriptions}`. Streaming handlers hold their slot until stream end; `RequestCompleted.Duration` spans the full iteration.
 
 ### 3. TypeScript Generation
@@ -69,6 +71,8 @@ client.connect(); // REQUIRED once. `await` optional: requests issued while conn
 ```
 
 React: create the client at module scope, call `client.connect()` there (or in a `useEffect`), then mount `<ApiClientProvider value={client}>`. `connect()` is a no-op when already connected/connecting; after the first successful call, auto-reconnect handles drops — never call it again for reconnection.
+
+Custom transport: `new ApiClient('bridge:', { transport: myClientTransport })` — any object implementing the exported `ClientTransport` interface (`connect(url, onMessage, onClose)`, `send(message)`, `disconnect()`, `isConnected()`). Deliver inbound protocol messages to `onMessage` as JSON strings; call `onClose` exactly once per established connection; instances must be reusable across reconnects.
 
 ### 5. Progress & Tasks
 - Simple: `aprot.Progress(ctx).Update(current, total, message)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Added
+
+- `Server.ServeStream(ctx, rw io.ReadWriteCloser, info ConnInfo)`: a
+  transport-agnostic entry point that serves one connection over any byte
+  stream using newline-delimited JSON framing — the stdio pipes of a child
+  process (e.g. a Go backend embedded in an Electron app), a Unix domain
+  socket, or a Windows named pipe. Stream connections participate fully in
+  connect/disconnect hooks, first-message auth, middleware, subscriptions,
+  streaming, and push. `MaxMessageSize` bounds inbound line length; the
+  WebSocket keepalive/write-timeout options do not apply to raw streams.
+- The generated TypeScript client's `ClientTransport` interface (and
+  `TransportCloseInfo`) is now exported, and `ApiClientOptions.transport`
+  accepts a custom `ClientTransport` instance in addition to
+  `'websocket' | 'sse'` — so the protocol can ride any message channel, such
+  as an Electron preload/MessagePort bridge to a Go child process.
+
 ### Changed
 
 - `Generator.Generate()` now removes stale generated files: top-level `.ts`

--- a/README.md
+++ b/README.md
@@ -888,6 +888,47 @@ oag := aprot.NewOpenAPIGenerator(registry, "My API", "1.0.0").
 
 Validation tags flow into the spec: `validate:"gte=12,lte=110"` → `minimum: 12, maximum: 110`, `validate:"email"` → `format: "email"`.
 
+## Byte-Stream Transport (Electron, stdio, sockets)
+
+`Server.ServeStream` serves a single connection over any `io.ReadWriteCloser` using newline-delimited JSON framing — one protocol message per line, in both directions. It reaches byte streams the HTTP handlers can't: the stdio pipes of a child process, a Unix domain socket, or a Windows named pipe. Stream connections participate fully in hooks, first-message auth, middleware, subscriptions, streaming, and push.
+
+```go
+// stdio: the parent process (e.g. an Electron main process that spawned
+// this binary) is the single client.
+server.ServeStream(ctx, struct {
+    io.Reader
+    io.WriteCloser
+}{os.Stdin, os.Stdout}, aprot.ConnInfo{})
+
+// or one connection per accepted socket (Unix domain socket, named pipe, TCP):
+for {
+    c, err := ln.Accept()
+    if err != nil {
+        break
+    }
+    go server.ServeStream(ctx, c, aprot.ConnInfo{RemoteAddr: c.RemoteAddr().String()})
+}
+```
+
+`ServeStream` blocks until the connection ends: it returns `nil` on a normal close (peer EOF, `ctx` canceled, server `Stop`), or the rejection error when a connect hook refused the connection. `MaxMessageSize` bounds inbound line length, but the WebSocket keepalive/write-timeout options don't apply — a raw byte stream has no ping frames or deadlines, so liveness is the stream's own lifetime (manage the peer process or socket, and cancel `ctx` to end the connection).
+
+On the client side, the generated `ApiClientOptions.transport` accepts a custom `ClientTransport` instance in addition to the `'websocket' | 'sse'` strings, so the same protocol can ride any message channel:
+
+```ts
+import { ApiClient, type ClientTransport } from './api/client';
+
+class BridgeTransport implements ClientTransport {
+    // e.g. forward over an Electron preload/MessagePort bridge to the
+    // Go child process; deliver inbound lines to onMessage as strings.
+    ...
+}
+
+const client = new ApiClient('bridge:', { transport: new BridgeTransport() });
+client.connect();
+```
+
+**Electron note:** a renderer can open `ws://127.0.0.1:<port>` directly, so for most Electron apps the simplest wiring is still a loopback WebSocket to the spawned Go process — pair it with `OnAuth` (a spawn-time random token) and `SetCheckOrigin` so other local processes and browser tabs can't connect. Use `ServeStream` + a custom `ClientTransport` when you want no listening port at all: Go child speaks NDJSON on stdio to the main process, which relays to the renderer over a `MessagePort`.
+
 ## Project Structure
 
 ```

--- a/connection.go
+++ b/connection.go
@@ -12,13 +12,27 @@ import (
 	"github.com/go-json-experiment/json"
 )
 
-// ConnInfo contains HTTP request information captured at connection time.
+// ConnInfo contains connection metadata captured at connection time. For the
+// HTTP transports (WebSocket, SSE) it is populated from the HTTP request; for
+// [Server.ServeStream] connections the caller supplies it, and any or all
+// fields may be zero.
 type ConnInfo struct {
 	RemoteAddr string
 	Header     http.Header
 	Cookies    []*http.Cookie
 	URL        string
 	Host       string
+}
+
+// connInfoFromRequest captures HTTP request information for ConnInfo.
+func connInfoFromRequest(r *http.Request) ConnInfo {
+	return ConnInfo{
+		RemoteAddr: r.RemoteAddr,
+		Header:     r.Header.Clone(),
+		Cookies:    r.Cookies(),
+		URL:        r.URL.String(),
+		Host:       r.Host,
+	}
 }
 
 // Conn represents a single client connection.
@@ -104,8 +118,10 @@ func (c *Conn) Info() ConnInfo {
 	return c.info
 }
 
-// Context returns the context from the HTTP request.
-// This is useful for accessing request-scoped values like zerolog loggers.
+// Context returns the connection's base context: the HTTP request context
+// for WebSocket/SSE connections, or the context passed to
+// [Server.ServeStream]. This is useful for accessing request-scoped values
+// like zerolog loggers.
 func (c *Conn) Context() context.Context {
 	return c.ctx
 }
@@ -158,20 +174,14 @@ func (c *Conn) RemoteAddr() string {
 	return c.info.RemoteAddr
 }
 
-func newConn(t transport, server *Server, id uint64, r *http.Request, ctx context.Context) *Conn {
+func newConn(t transport, server *Server, id uint64, info ConnInfo, ctx context.Context) *Conn {
 	c := &Conn{
 		transport: t,
 		server:    server,
 		requests:  make(map[string]context.CancelCauseFunc),
 		id:        id,
 		ctx:       ctx,
-		info: ConnInfo{
-			RemoteAddr: r.RemoteAddr,
-			Header:     r.Header.Clone(),
-			Cookies:    r.Cookies(),
-			URL:        r.URL.String(),
-			Host:       r.Host,
-		},
+		info:      info,
 	}
 	if server.options.MaxConcurrentRequests > 0 {
 		c.reqSem = make(chan struct{}, server.options.MaxConcurrentRequests)

--- a/doc.go
+++ b/doc.go
@@ -227,6 +227,28 @@
 // [Server.Broadcast], [Server.PushToUser], and [Server.ConnectionCount] work
 // across all connections regardless of transport.
 //
+// For byte streams HTTP can't reach, [Server.ServeStream] serves one
+// connection over any io.ReadWriteCloser using newline-delimited JSON
+// framing (one protocol message per line) — the stdio pipes of a child
+// process, a Unix domain socket, or a Windows named pipe. This is the entry
+// point for embedding a Go backend in a desktop app (e.g. an Electron main
+// process spawning the Go binary and bridging to the renderer):
+//
+//	// stdio: the parent process is the single client.
+//	server.ServeStream(ctx, struct {
+//	    io.Reader
+//	    io.WriteCloser
+//	}{os.Stdin, os.Stdout}, aprot.ConnInfo{})
+//
+//	// or one connection per accepted socket:
+//	go server.ServeStream(ctx, c, aprot.ConnInfo{RemoteAddr: c.RemoteAddr().String()})
+//
+// Stream connections participate fully in hooks, auth, middleware,
+// subscriptions, streaming, and push. On the TypeScript side, the generated
+// client's ApiClientOptions.transport accepts a custom ClientTransport
+// instance to carry the same protocol over any message channel (an Electron
+// preload/MessagePort bridge, for example).
+//
 // Handlers can additionally be exposed over REST/HTTP alongside (or instead
 // of) WebSocket. Use [Registry.RegisterREST] for REST-only handlers, or
 // [Registry.EnableREST] to mark an existing WebSocket handler for REST as

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -155,9 +155,52 @@ export type PushHandler<T> = (data: T) => void;
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
+/**
+ * TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+ * transport up to the client's classification logic. Transports without an
+ * equivalent (SSE, custom transports) may pass an empty object or nothing.
+ */
+export interface TransportCloseInfo {
+    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
+    code?: number;
+    /** WebSocket CloseEvent.reason, when non-empty. */
+    reason?: string;
+    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
+    wasClean?: boolean;
+    /** True when the close was already classified as a server-rejected protocol error. */
+    serverRejected?: boolean;
+}
+
+/**
+ * ClientTransport is the connection layer under ApiClient. Two built-in
+ * implementations exist (WebSocket and SSE, selected via
+ * ApiClientOptions.transport as a string), but an instance implementing this
+ * interface can be passed instead to carry the protocol over any message
+ * channel — for example an Electron preload/MessagePort bridge to a Go
+ * child process, where the renderer cannot open pipes itself.
+ *
+ * Contract:
+ * - connect() resolves once the channel is ready; deliver every inbound
+ *   protocol message to onMessage as a JSON string, and call onClose exactly
+ *   once when the channel ends (after a successful connect).
+ * - send() receives a protocol message object; serialize it (e.g.
+ *   JSON.stringify) onto the channel.
+ * - The client calls connect() again for reconnects; a transport instance
+ *   must be reusable after disconnect()/onClose.
+ */
+export interface ClientTransport {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
+    send(message: object): void;
+    disconnect(): void;
+    isConnected(): boolean;
+}
+
 export interface ApiClientOptions {
-    /** Transport type. Default: 'websocket' */
-    transport?: 'websocket' | 'sse';
+    /**
+     * Transport: 'websocket', 'sse', or a custom ClientTransport instance
+     * (e.g. an Electron IPC/MessagePort bridge). Default: 'websocket'
+     */
+    transport?: 'websocket' | 'sse' | ClientTransport;
     /** Enable auto-reconnect on connection loss. Default: true */
     reconnect?: boolean;
     /** Initial reconnect delay in ms. Default: 1000 */
@@ -213,30 +256,11 @@ export function getSSEUrl(path: string = '/sse'): string {
 
 
 
-// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
-// transport up to the client's classification logic. SSE has no equivalent
-// (the EventSource error event exposes nothing structured), so the SSE
-// transport synthesizes an empty info object — it lands as 'network-error'
-// after offline/manual checks, which is the most accurate bucket browsers
-// will let us name.
-interface TransportCloseInfo {
-    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
-    code?: number;
-    /** WebSocket CloseEvent.reason, when non-empty. */
-    reason?: string;
-    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
-    wasClean?: boolean;
-    /** True when the close was already classified as a server-rejected protocol error. */
-    serverRejected?: boolean;
-}
-
-// Internal transport interface
-interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
-    send(message: object): void;
-    disconnect(): void;
-    isConnected(): boolean;
-}
+// TransportCloseInfo and ClientTransport are defined in the "types" section
+// above. SSE note: the EventSource error event exposes nothing structured,
+// so the SSE transport synthesizes an empty close info — it lands as
+// 'network-error' after offline/manual checks, which is the most accurate
+// bucket browsers will let us name.
 
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
@@ -523,9 +547,11 @@ export class ApiClient {
     constructor(url: ApiClientUrl, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
-        this.transport = this.options.transport === 'sse'
-            ? new SSETransport()
-            : new WebSocketTransport();
+        this.transport = typeof this.options.transport === 'object'
+            ? this.options.transport
+            : this.options.transport === 'sse'
+                ? new SSETransport()
+                : new WebSocketTransport();
     }
 
     /**

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -148,9 +148,52 @@ export type PushHandler<T> = (data: T) => void;
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
+/**
+ * TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+ * transport up to the client's classification logic. Transports without an
+ * equivalent (SSE, custom transports) may pass an empty object or nothing.
+ */
+export interface TransportCloseInfo {
+    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
+    code?: number;
+    /** WebSocket CloseEvent.reason, when non-empty. */
+    reason?: string;
+    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
+    wasClean?: boolean;
+    /** True when the close was already classified as a server-rejected protocol error. */
+    serverRejected?: boolean;
+}
+
+/**
+ * ClientTransport is the connection layer under ApiClient. Two built-in
+ * implementations exist (WebSocket and SSE, selected via
+ * ApiClientOptions.transport as a string), but an instance implementing this
+ * interface can be passed instead to carry the protocol over any message
+ * channel — for example an Electron preload/MessagePort bridge to a Go
+ * child process, where the renderer cannot open pipes itself.
+ *
+ * Contract:
+ * - connect() resolves once the channel is ready; deliver every inbound
+ *   protocol message to onMessage as a JSON string, and call onClose exactly
+ *   once when the channel ends (after a successful connect).
+ * - send() receives a protocol message object; serialize it (e.g.
+ *   JSON.stringify) onto the channel.
+ * - The client calls connect() again for reconnects; a transport instance
+ *   must be reusable after disconnect()/onClose.
+ */
+export interface ClientTransport {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
+    send(message: object): void;
+    disconnect(): void;
+    isConnected(): boolean;
+}
+
 export interface ApiClientOptions {
-    /** Transport type. Default: 'websocket' */
-    transport?: 'websocket' | 'sse';
+    /**
+     * Transport: 'websocket', 'sse', or a custom ClientTransport instance
+     * (e.g. an Electron IPC/MessagePort bridge). Default: 'websocket'
+     */
+    transport?: 'websocket' | 'sse' | ClientTransport;
     /** Enable auto-reconnect on connection loss. Default: true */
     reconnect?: boolean;
     /** Initial reconnect delay in ms. Default: 1000 */
@@ -206,30 +249,11 @@ export function getSSEUrl(path: string = '/sse'): string {
 
 
 
-// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
-// transport up to the client's classification logic. SSE has no equivalent
-// (the EventSource error event exposes nothing structured), so the SSE
-// transport synthesizes an empty info object — it lands as 'network-error'
-// after offline/manual checks, which is the most accurate bucket browsers
-// will let us name.
-interface TransportCloseInfo {
-    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
-    code?: number;
-    /** WebSocket CloseEvent.reason, when non-empty. */
-    reason?: string;
-    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
-    wasClean?: boolean;
-    /** True when the close was already classified as a server-rejected protocol error. */
-    serverRejected?: boolean;
-}
-
-// Internal transport interface
-interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
-    send(message: object): void;
-    disconnect(): void;
-    isConnected(): boolean;
-}
+// TransportCloseInfo and ClientTransport are defined in the "types" section
+// above. SSE note: the EventSource error event exposes nothing structured,
+// so the SSE transport synthesizes an empty close info — it lands as
+// 'network-error' after offline/manual checks, which is the most accurate
+// bucket browsers will let us name.
 
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
@@ -516,9 +540,11 @@ export class ApiClient {
     constructor(url: ApiClientUrl, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
-        this.transport = this.options.transport === 'sse'
-            ? new SSETransport()
-            : new WebSocketTransport();
+        this.transport = typeof this.options.transport === 'object'
+            ? this.options.transport
+            : this.options.transport === 'sse'
+                ? new SSETransport()
+                : new WebSocketTransport();
     }
 
     /**

--- a/server.go
+++ b/server.go
@@ -452,7 +452,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	connID := atomic.AddUint64(&s.nextConnID, 1)
 	ctx := r.Context()
 	wst := newWSTransport(ws, s.options)
-	conn := newConn(wst, s, connID, r, ctx)
+	conn := newConn(wst, s, connID, connInfoFromRequest(r), ctx)
 	// Give the transport a back-reference so it can report send-buffer pressure
 	// and write timeouts to the observer. Set before the pumps start.
 	wst.conn = conn
@@ -655,7 +655,9 @@ func (s *Server) Registry() *Registry {
 
 // sendConnectionRejectedWS sends an error message directly to a WebSocket connection.
 // Used when a connect hook rejects the connection before pumps are started.
-func sendConnectionRejectedWS(ws *websocket.Conn, err error) {
+// connectionRejectedMessage builds the error frame sent to a client whose
+// connection was refused by a connect hook. Shared by all transports.
+func connectionRejectedMessage(err error) ErrorMessage {
 	code := CodeConnectionRejected
 	message := "connection rejected"
 	var errData any
@@ -667,26 +669,34 @@ func sendConnectionRejectedWS(ws *websocket.Conn, err error) {
 		message = err.Error()
 	}
 
-	msg := ErrorMessage{
+	return ErrorMessage{
 		Type:    TypeError,
 		ID:      "",
 		Code:    code,
 		Message: message,
 		Data:    errData,
 	}
-	data, _ := json.Marshal(msg)
+}
+
+// configMessage builds the server-pushed configuration frame sent to every
+// new connection before message processing starts. Shared by all transports.
+func configMessage(opts ServerOptions) ConfigMessage {
+	return ConfigMessage{
+		Type:                 TypeConfig,
+		ReconnectInterval:    opts.ReconnectInterval,
+		ReconnectMaxInterval: opts.ReconnectMaxInterval,
+		ReconnectMaxAttempts: opts.ReconnectMaxAttempts,
+	}
+}
+
+func sendConnectionRejectedWS(ws *websocket.Conn, err error) {
+	data, _ := json.Marshal(connectionRejectedMessage(err))
 	_ = ws.WriteMessage(websocket.TextMessage, data)
 }
 
 // sendConfigWS sends the server configuration directly to a WebSocket connection.
 // Called before the pumps are started.
 func sendConfigWS(ws *websocket.Conn, opts ServerOptions) {
-	msg := ConfigMessage{
-		Type:                 TypeConfig,
-		ReconnectInterval:    opts.ReconnectInterval,
-		ReconnectMaxInterval: opts.ReconnectMaxInterval,
-		ReconnectMaxAttempts: opts.ReconnectMaxAttempts,
-	}
-	data, _ := json.Marshal(msg)
+	data, _ := json.Marshal(configMessage(opts))
 	_ = ws.WriteMessage(websocket.TextMessage, data)
 }

--- a/sse_handler.go
+++ b/sse_handler.go
@@ -83,7 +83,7 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// Create transport and connection
 	sseT := newSSETransport(w, flusher)
 	connID := atomic.AddUint64(&h.server.nextConnID, 1)
-	conn := newConn(sseT, h.server, connID, r, r.Context())
+	conn := newConn(sseT, h.server, connID, connInfoFromRequest(r), r.Context())
 
 	// Run connect hooks
 	if err := h.server.runConnectHooks(r.Context(), conn); err != nil {
@@ -91,23 +91,7 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 		// connection; undo that association so a dead conn can't linger in
 		// userConns and have a later PushToUser block on its send buffer.
 		h.server.disassociateUser(conn)
-		code := CodeConnectionRejected
-		var message string
-		var errData any
-		if perr, ok := err.(*ProtocolError); ok {
-			code = perr.Code
-			message = perr.Message
-			errData = perr.Data
-		} else {
-			message = err.Error()
-		}
-		errMsg := ErrorMessage{
-			Type:    TypeError,
-			Code:    code,
-			Message: message,
-			Data:    errData,
-		}
-		data, _ := json.Marshal(errMsg)
+		data, _ := json.Marshal(connectionRejectedMessage(err))
 		sseT.sendEvent("error", data)
 		return
 	}
@@ -121,13 +105,7 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	sseT.sendEvent("connected", connData)
 
 	// Send config
-	configMsg := ConfigMessage{
-		Type:                 TypeConfig,
-		ReconnectInterval:    h.server.options.ReconnectInterval,
-		ReconnectMaxInterval: h.server.options.ReconnectMaxInterval,
-		ReconnectMaxAttempts: h.server.options.ReconnectMaxAttempts,
-	}
-	configData, _ := json.Marshal(configMsg)
+	configData, _ := json.Marshal(configMessage(h.server.options))
 	sseT.sendEvent("config", configData)
 
 	// Register connection

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -154,9 +154,52 @@ export type PushHandler<T> = (data: T) => void;
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
+/**
+ * TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
+ * transport up to the client's classification logic. Transports without an
+ * equivalent (SSE, custom transports) may pass an empty object or nothing.
+ */
+export interface TransportCloseInfo {
+    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
+    code?: number;
+    /** WebSocket CloseEvent.reason, when non-empty. */
+    reason?: string;
+    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
+    wasClean?: boolean;
+    /** True when the close was already classified as a server-rejected protocol error. */
+    serverRejected?: boolean;
+}
+
+/**
+ * ClientTransport is the connection layer under ApiClient. Two built-in
+ * implementations exist (WebSocket and SSE, selected via
+ * ApiClientOptions.transport as a string), but an instance implementing this
+ * interface can be passed instead to carry the protocol over any message
+ * channel — for example an Electron preload/MessagePort bridge to a Go
+ * child process, where the renderer cannot open pipes itself.
+ *
+ * Contract:
+ * - connect() resolves once the channel is ready; deliver every inbound
+ *   protocol message to onMessage as a JSON string, and call onClose exactly
+ *   once when the channel ends (after a successful connect).
+ * - send() receives a protocol message object; serialize it (e.g.
+ *   JSON.stringify) onto the channel.
+ * - The client calls connect() again for reconnects; a transport instance
+ *   must be reusable after disconnect()/onClose.
+ */
+export interface ClientTransport {
+    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
+    send(message: object): void;
+    disconnect(): void;
+    isConnected(): boolean;
+}
+
 export interface ApiClientOptions {
-    /** Transport type. Default: 'websocket' */
-    transport?: 'websocket' | 'sse';
+    /**
+     * Transport: 'websocket', 'sse', or a custom ClientTransport instance
+     * (e.g. an Electron IPC/MessagePort bridge). Default: 'websocket'
+     */
+    transport?: 'websocket' | 'sse' | ClientTransport;
     /** Enable auto-reconnect on connection loss. Default: true */
     reconnect?: boolean;
     /** Initial reconnect delay in ms. Default: 1000 */
@@ -212,30 +255,11 @@ export function getSSEUrl(path: string = '/sse'): string {
 {{end}}
 
 {{define "api-client-class"}}
-// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
-// transport up to the client's classification logic. SSE has no equivalent
-// (the EventSource error event exposes nothing structured), so the SSE
-// transport synthesizes an empty info object — it lands as 'network-error'
-// after offline/manual checks, which is the most accurate bucket browsers
-// will let us name.
-interface TransportCloseInfo {
-    /** WebSocket CloseEvent.code, when available. 1006 = abnormal (pre-upgrade) closure. */
-    code?: number;
-    /** WebSocket CloseEvent.reason, when non-empty. */
-    reason?: string;
-    /** WebSocket CloseEvent.wasClean — true only if a close handshake completed. */
-    wasClean?: boolean;
-    /** True when the close was already classified as a server-rejected protocol error. */
-    serverRejected?: boolean;
-}
-
-// Internal transport interface
-interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
-    send(message: object): void;
-    disconnect(): void;
-    isConnected(): boolean;
-}
+// TransportCloseInfo and ClientTransport are defined in the "types" section
+// above. SSE note: the EventSource error event exposes nothing structured,
+// so the SSE transport synthesizes an empty close info — it lands as
+// 'network-error' after offline/manual checks, which is the most accurate
+// bucket browsers will let us name.
 
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
@@ -522,9 +546,11 @@ export class ApiClient {
     constructor(url: ApiClientUrl, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
-        this.transport = this.options.transport === 'sse'
-            ? new SSETransport()
-            : new WebSocketTransport();
+        this.transport = typeof this.options.transport === 'object'
+            ? this.options.transport
+            : this.options.transport === 'sse'
+                ? new SSETransport()
+                : new WebSocketTransport();
     }
 
     /**

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -17,22 +17,7 @@ import { useState, useEffect, useCallback, useMemo, useRef, useContext, createCo
 
 {{template "get-websocket-url" .}}
 
-// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
-// transport up to the client's classification logic.
-interface TransportCloseInfo {
-    code?: number;
-    reason?: string;
-    wasClean?: boolean;
-    serverRejected?: boolean;
-}
-
-// Internal transport interface
-interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
-    send(message: object): void;
-    disconnect(): void;
-    isConnected(): boolean;
-}
+// TransportCloseInfo and ClientTransport are defined in the types section above.
 
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
@@ -208,9 +193,11 @@ export class ApiClient {
     constructor(url: string, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
-        this.transport = this.options.transport === 'sse'
-            ? new SSETransport()
-            : new WebSocketTransport();
+        this.transport = typeof this.options.transport === 'object'
+            ? this.options.transport
+            : this.options.transport === 'sse'
+                ? new SSETransport()
+                : new WebSocketTransport();
     }
 
     /**

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -10,22 +10,7 @@
 
 {{template "get-websocket-url" .}}
 
-// TransportCloseInfo carries WebSocket CloseEvent diagnostics from the
-// transport up to the client's classification logic.
-interface TransportCloseInfo {
-    code?: number;
-    reason?: string;
-    wasClean?: boolean;
-    serverRejected?: boolean;
-}
-
-// Internal transport interface
-interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
-    send(message: object): void;
-    disconnect(): void;
-    isConnected(): boolean;
-}
+// TransportCloseInfo and ClientTransport are defined in the types section above.
 
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
@@ -200,9 +185,11 @@ export class ApiClient {
     constructor(url: string, options?: ApiClientOptions) {
         this.url = url;
         this.options = { ...defaultOptions, ...options };
-        this.transport = this.options.transport === 'sse'
-            ? new SSETransport()
-            : new WebSocketTransport();
+        this.transport = typeof this.options.transport === 'object'
+            ? this.options.transport
+            : this.options.transport === 'sse'
+                ? new SSETransport()
+                : new WebSocketTransport();
     }
 
     /**

--- a/transport_sse.go
+++ b/transport_sse.go
@@ -75,7 +75,7 @@ func (t *sseTransport) sendEvent(event string, data []byte) {
 		return
 	}
 	fmt.Fprintf(t.w, "event: %s\n", event)
-	fmt.Fprintf(t.w, "data: %s\n\n", data)
+	fmt.Fprintf(t.w, "data: %s\n\n", data) // #nosec G705 -- data is JSON-marshaled protocol frames in a text/event-stream response; no HTML context, so XSS does not apply
 	t.flusher.Flush()
 }
 

--- a/transport_stream.go
+++ b/transport_stream.go
@@ -1,0 +1,273 @@
+package aprot
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"math"
+	"sync"
+	"sync/atomic"
+
+	"github.com/go-json-experiment/json"
+)
+
+// streamTransport adapts any bidirectional byte stream — stdio pipes to a
+// child process, a Unix domain socket, a Windows named pipe, an arbitrary
+// net.Conn — to the aprot protocol using newline-delimited JSON framing:
+// exactly one protocol message per line, in both directions.
+type streamTransport struct {
+	rw   io.ReadWriteCloser
+	send chan []byte
+	done chan struct{} // closed once to signal shutdown; makes Send a no-op
+	// closeOnce guards done/rw teardown: Close may be called by the server
+	// (Stop, run loop) and by the ctx watcher in ServeStream concurrently.
+	closeOnce sync.Once
+	opts      ServerOptions
+	// conn is a back-reference used only to report send-buffer pressure to
+	// the server's observer. Set after construction, before the pumps start.
+	conn *Conn
+}
+
+func newStreamTransport(rw io.ReadWriteCloser, opts ServerOptions) *streamTransport {
+	return &streamTransport{
+		rw:   rw,
+		send: make(chan []byte, 256),
+		done: make(chan struct{}),
+		opts: opts,
+	}
+}
+
+// observer returns the server's observer via the connection back-reference,
+// or nil when there is no connection or no observer registered.
+func (t *streamTransport) observer() Observer {
+	if t.conn == nil || t.conn.server == nil {
+		return nil
+	}
+	return t.conn.server.observer
+}
+
+func (t *streamTransport) Send(data []byte) error {
+	// Blocking send — waits for room in the buffer, unblocking immediately if
+	// the transport is closed. Same delivery guarantees as the WebSocket
+	// transport: nothing is silently dropped. Unlike WebSocket there is no
+	// write deadline (io.Writer has none), so a peer that stops reading
+	// stalls senders until the stream is closed; local pipe peers are
+	// expected to be managed by the host process.
+	select {
+	case <-t.done:
+		return ErrConnectionClosed
+	case t.send <- data:
+		return nil
+	default:
+		t.reportBufferFull()
+	}
+	select {
+	case <-t.done:
+		return ErrConnectionClosed
+	case t.send <- data:
+		return nil
+	}
+}
+
+func (t *streamTransport) SendCtx(ctx context.Context, data []byte) error {
+	select {
+	case <-t.done:
+		return ErrConnectionClosed
+	case t.send <- data:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		t.reportBufferFull()
+	}
+	select {
+	case <-t.done:
+		return ErrConnectionClosed
+	case t.send <- data:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// reportBufferFull signals send-buffer backpressure to the observer. The
+// frame is not dropped; the caller falls back to a blocking send.
+func (t *streamTransport) reportBufferFull() {
+	if o := t.observer(); o != nil {
+		o.SendBufferFull(t.conn)
+	}
+}
+
+// Close closes the underlying stream, which also unblocks the read loop.
+func (t *streamTransport) Close() error {
+	t.closeOnce.Do(func() {
+		close(t.done)
+		_ = t.rw.Close()
+	})
+	return nil
+}
+
+// CloseGracefully is identical to Close: the framing has no close frame, so
+// the peer detects shutdown via EOF.
+func (t *streamTransport) CloseGracefully() error {
+	return t.Close()
+}
+
+// writePump writes messages from the send channel to the stream, one JSON
+// document per line. It exits when done is closed or a write fails.
+func (t *streamTransport) writePump() {
+	defer t.Close()
+
+	for {
+		select {
+		case <-t.done:
+			return
+		case data := <-t.send:
+			if _, err := t.rw.Write(append(data, '\n')); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// readLoop reads newline-delimited frames and dispatches them to the
+// connection. It returns when the stream is closed or errors (including a
+// line exceeding MaxMessageSize), then unregisters the connection.
+func (t *streamTransport) readLoop(conn *Conn) {
+	defer func() {
+		// Guard with server.done: if run() has already exited, nobody will
+		// ever read unregister and ServeStream would never return.
+		select {
+		case conn.server.unregister <- conn:
+		case <-conn.server.done:
+		}
+		_ = t.Close()
+	}()
+
+	maxSize := t.opts.MaxMessageSize
+	if maxSize <= 0 || maxSize > math.MaxInt32 {
+		maxSize = math.MaxInt32
+	}
+	sc := bufio.NewScanner(t.rw)
+	sc.Buffer(make([]byte, 64*1024), int(maxSize))
+
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		// Copy the line: dispatch runs handlers on their own goroutines with
+		// the raw params aliasing this buffer, and the scanner reuses it on
+		// the next Scan.
+		data := make([]byte, len(line))
+		copy(data, line)
+		conn.handleIncomingMessage(data)
+	}
+}
+
+// writeStreamFrame marshals v and writes it directly to w as one line.
+// Used for the config/rejection frames sent before the write pump starts.
+func writeStreamFrame(w io.Writer, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(data, '\n'))
+	return err
+}
+
+// ServeStream serves a single aprot connection over rw using
+// newline-delimited JSON framing: one protocol message per line, in both
+// directions. It gives the server a transport-agnostic entry point for
+// byte streams the HTTP handlers can't reach — the stdio pipes of a child
+// process (e.g. a Go backend spawned by an Electron or Tauri app), a Unix
+// domain socket, or a Windows named pipe:
+//
+//	// stdio: the parent process is the single client.
+//	err := server.ServeStream(ctx, struct {
+//	    io.Reader
+//	    io.WriteCloser
+//	}{os.Stdin, os.Stdout}, aprot.ConnInfo{})
+//
+//	// listener (Unix domain socket, named pipe, TCP):
+//	for {
+//	    c, err := ln.Accept()
+//	    if err != nil { break }
+//	    go server.ServeStream(ctx, c, aprot.ConnInfo{RemoteAddr: c.RemoteAddr().String()})
+//	}
+//
+// The caller supplies ConnInfo (all fields optional) since there is no HTTP
+// request to capture it from. The connection participates fully in the
+// server: connect/disconnect hooks, first-message auth, middleware,
+// subscriptions, streaming, push, and Stop all behave as they do for
+// WebSocket connections.
+//
+// ServeStream blocks until the connection ends and returns nil on a normal
+// close (peer EOF, ctx canceled, server Stop). It returns an error if the
+// connection was refused: the connect-hook rejection error, or
+// ErrServerShutdown when the server is stopping.
+//
+// Transport notes: MaxMessageSize bounds inbound line length (an oversized
+// line closes the connection), but PingInterval/PongTimeout/WriteTimeout do
+// not apply — a raw byte stream has no ping frames or write deadlines.
+// Liveness is the stream's own lifetime: manage the peer process or socket
+// and cancel ctx (or close rw) to end the connection.
+func (s *Server) ServeStream(ctx context.Context, rw io.ReadWriteCloser, info ConnInfo) error {
+	if s.stopping.Load() {
+		_ = rw.Close()
+		return ErrServerShutdown
+	}
+
+	connID := atomic.AddUint64(&s.nextConnID, 1)
+	st := newStreamTransport(rw, s.options)
+	conn := newConn(st, s, connID, info, ctx)
+	// Back-reference so the transport can report send-buffer pressure to the
+	// observer. Set before the pumps start.
+	st.conn = conn
+
+	// Enqueue the config frame before the connect hooks run, so it is first
+	// on the wire ahead of anything a hook pushes. Enqueuing (rather than a
+	// direct write, as the WS transport does) keeps setup from blocking on a
+	// peer that isn't reading yet — a raw stream has no write deadline to
+	// bound a direct write. The send buffer is empty here, so this never
+	// blocks; the write pump flushes it once the connection is accepted.
+	if cfgData, err := json.Marshal(configMessage(s.options)); err == nil {
+		_ = st.Send(cfgData)
+	}
+
+	if err := s.runConnectHooks(ctx, conn); err != nil {
+		// A hook may have called SetUserID before a later hook rejected the
+		// connection; undo that association so a dead conn can't linger in
+		// userConns and have a later PushToUser block on its send buffer.
+		s.disassociateUser(conn)
+		_ = writeStreamFrame(rw, connectionRejectedMessage(err))
+		_ = rw.Close()
+		return err
+	}
+
+	// Register the connection, but don't block forever if the server has
+	// already shut down (run() has exited and will never read s.register).
+	select {
+	case s.register <- conn:
+	case <-s.done:
+		s.disassociateUser(conn)
+		_ = rw.Close()
+		return ErrServerShutdown
+	}
+
+	// When an auth hook is registered, the connection is pending until it
+	// sends a valid auth frame; close it if that doesn't happen in time.
+	if s.authRequired() {
+		conn.armAuthTimeout(s.options.AuthTimeout)
+	}
+
+	// Tie the connection to ctx: canceling it closes the stream, which
+	// unblocks the read loop below.
+	stop := context.AfterFunc(ctx, func() { conn.close() })
+	defer stop()
+
+	go st.writePump()
+	st.readLoop(conn)
+	return nil
+}

--- a/transport_stream_test.go
+++ b/transport_stream_test.go
@@ -1,0 +1,311 @@
+package aprot
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Handlers used by the ServeStream tests. EchoRequest/EchoResponse and
+// NotificationEvent are shared with the WebSocket integration tests.
+type StreamServeHandlers struct{}
+
+func (h *StreamServeHandlers) Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error) {
+	return &EchoResponse{Message: req.Message}, nil
+}
+
+type streamInfoResponse struct {
+	RemoteAddr string `json:"remoteAddr"`
+}
+
+func (h *StreamServeHandlers) WhoAmI(ctx context.Context) (*streamInfoResponse, error) {
+	conn := Connection(ctx)
+	return &streamInfoResponse{RemoteAddr: conn.Info().RemoteAddr}, nil
+}
+
+// streamTestClient drives the client end of a ServeStream connection using
+// newline-delimited JSON frames, mirroring what an Electron/stdio bridge
+// would send.
+type streamTestClient struct {
+	t    *testing.T
+	conn net.Conn
+	sc   *bufio.Scanner
+}
+
+func newStreamTestClient(t *testing.T, conn net.Conn) *streamTestClient {
+	t.Helper()
+	sc := bufio.NewScanner(conn)
+	sc.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	return &streamTestClient{t: t, conn: conn, sc: sc}
+}
+
+func (c *streamTestClient) send(msg IncomingMessage) {
+	c.t.Helper()
+	data, err := json.Marshal(msg)
+	if err != nil {
+		c.t.Fatalf("marshal frame: %v", err)
+	}
+	_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if _, err := c.conn.Write(append(data, '\n')); err != nil {
+		c.t.Fatalf("write frame: %v", err)
+	}
+}
+
+// readFrame reads the next newline-delimited JSON frame.
+func (c *streamTestClient) readFrame() map[string]any {
+	c.t.Helper()
+	_ = c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if !c.sc.Scan() {
+		c.t.Fatalf("read frame: %v", c.sc.Err())
+	}
+	var frame map[string]any
+	if err := json.Unmarshal(c.sc.Bytes(), &frame); err != nil {
+		c.t.Fatalf("unmarshal frame %q: %v", c.sc.Text(), err)
+	}
+	return frame
+}
+
+// readFrameOfType reads frames until one of the given type arrives, skipping
+// unrelated frames (e.g. config or push frames interleaved with responses).
+func (c *streamTestClient) readFrameOfType(msgType string) map[string]any {
+	c.t.Helper()
+	for i := 0; i < 20; i++ {
+		frame := c.readFrame()
+		if frame["type"] == msgType {
+			return frame
+		}
+	}
+	c.t.Fatalf("no frame of type %q within 20 frames", msgType)
+	return nil
+}
+
+// startStreamServer wires a Server to one end of a net.Pipe via ServeStream
+// and returns the client end plus a channel carrying ServeStream's result.
+func startStreamServer(ctx context.Context, server *Server, info ConnInfo) (net.Conn, chan error) {
+	serverEnd, clientEnd := net.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ServeStream(ctx, serverEnd, info)
+	}()
+	return clientEnd, errCh
+}
+
+func newStreamTestServer(t *testing.T) *Server {
+	t.Helper()
+	registry := NewRegistry()
+	handlers := &StreamServeHandlers{}
+	registry.Register(handlers)
+	registry.RegisterPushEventFor(handlers, &NotificationEvent{})
+	server := NewServer(registry)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Stop(ctx)
+	})
+	return server
+}
+
+func TestServeStreamEcho(t *testing.T) {
+	server := newStreamTestServer(t)
+	clientEnd, _ := startStreamServer(context.Background(), server, ConnInfo{})
+	defer clientEnd.Close()
+	client := newStreamTestClient(t, clientEnd)
+
+	// The first frame must be the config message, matching the WS transport.
+	cfg := client.readFrame()
+	if cfg["type"] != "config" {
+		t.Fatalf("first frame type = %v, want config", cfg["type"])
+	}
+
+	client.send(IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "1",
+		Method: "StreamServeHandlers.Echo",
+		Params: jsontext.Value(`[{"message":"hello"}]`),
+	})
+	resp := client.readFrameOfType("response")
+	if resp["id"] != "1" {
+		t.Errorf("response id = %v, want 1", resp["id"])
+	}
+	result, _ := resp["result"].(map[string]any)
+	if result["message"] != "hello" {
+		t.Errorf("result.message = %v, want hello", result["message"])
+	}
+}
+
+func TestServeStreamConnInfo(t *testing.T) {
+	server := newStreamTestServer(t)
+	clientEnd, _ := startStreamServer(context.Background(), server, ConnInfo{RemoteAddr: "child-process"})
+	defer clientEnd.Close()
+	client := newStreamTestClient(t, clientEnd)
+
+	client.send(IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "1",
+		Method: "StreamServeHandlers.WhoAmI",
+	})
+	resp := client.readFrameOfType("response")
+	result, _ := resp["result"].(map[string]any)
+	if result["remoteAddr"] != "child-process" {
+		t.Errorf("remoteAddr = %v, want child-process", result["remoteAddr"])
+	}
+}
+
+func TestServeStreamConnectHookReject(t *testing.T) {
+	server := newStreamTestServer(t)
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		return ErrForbidden("not welcome")
+	})
+
+	clientEnd, errCh := startStreamServer(context.Background(), server, ConnInfo{})
+	defer clientEnd.Close()
+	client := newStreamTestClient(t, clientEnd)
+
+	frame := client.readFrameOfType("error")
+	if frame["message"] != "not welcome" {
+		t.Errorf("error message = %v, want 'not welcome'", frame["message"])
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Error("ServeStream returned nil, want rejection error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeStream did not return after rejection")
+	}
+}
+
+func TestServeStreamServerStopping(t *testing.T) {
+	server := newStreamTestServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	serverEnd, clientEnd := net.Pipe()
+	defer clientEnd.Close()
+	if err := server.ServeStream(context.Background(), serverEnd, ConnInfo{}); err == nil {
+		t.Error("ServeStream on stopped server returned nil, want error")
+	}
+}
+
+func TestServeStreamPush(t *testing.T) {
+	server := newStreamTestServer(t)
+	clientEnd, _ := startStreamServer(context.Background(), server, ConnInfo{})
+	defer clientEnd.Close()
+	client := newStreamTestClient(t, clientEnd)
+
+	// Read the config frame so the connection is known to be registered
+	// before broadcasting.
+	client.readFrameOfType("config")
+	waitForConnections(t, server, 1)
+
+	server.Broadcast(&NotificationEvent{Message: "ping"})
+	frame := client.readFrameOfType("push")
+	data, _ := frame["data"].(map[string]any)
+	if data["message"] != "ping" {
+		t.Errorf("push data.message = %v, want ping", data["message"])
+	}
+}
+
+func TestServeStreamClientClose(t *testing.T) {
+	server := newStreamTestServer(t)
+	clientEnd, errCh := startStreamServer(context.Background(), server, ConnInfo{})
+	client := newStreamTestClient(t, clientEnd)
+	client.readFrameOfType("config")
+	waitForConnections(t, server, 1)
+
+	_ = clientEnd.Close()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("ServeStream returned %v on client close, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeStream did not return after client close")
+	}
+	waitForConnections(t, server, 0)
+}
+
+func TestServeStreamContextCancel(t *testing.T) {
+	server := newStreamTestServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	clientEnd, errCh := startStreamServer(ctx, server, ConnInfo{})
+	defer clientEnd.Close()
+	client := newStreamTestClient(t, clientEnd)
+	client.readFrameOfType("config")
+	waitForConnections(t, server, 1)
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("ServeStream returned %v on ctx cancel, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeStream did not return after ctx cancel")
+	}
+	waitForConnections(t, server, 0)
+}
+
+func TestServeStreamAuth(t *testing.T) {
+	server := newStreamTestServer(t)
+	server.OnAuth(func(ctx context.Context, conn *Conn, token string) error {
+		if token != "sesame" {
+			return ErrAuthFailed("bad token")
+		}
+		return nil
+	})
+
+	clientEnd, _ := startStreamServer(context.Background(), server, ConnInfo{})
+	defer clientEnd.Close()
+	client := newStreamTestClient(t, clientEnd)
+	client.readFrameOfType("config")
+
+	// A request before auth must be rejected with auth_error.
+	client.send(IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "1",
+		Method: "StreamServeHandlers.Echo",
+		Params: jsontext.Value(`[{"message":"early"}]`),
+	})
+	client.readFrameOfType("auth_error")
+
+	// Authenticate, then the same request must succeed.
+	client.send(IncomingMessage{Type: TypeAuth, Token: "sesame"})
+	client.readFrameOfType("auth_ok")
+
+	client.send(IncomingMessage{
+		Type:   TypeRequest,
+		ID:     "2",
+		Method: "StreamServeHandlers.Echo",
+		Params: jsontext.Value(`[{"message":"late"}]`),
+	})
+	resp := client.readFrameOfType("response")
+	result, _ := resp["result"].(map[string]any)
+	if result["message"] != "late" {
+		t.Errorf("result.message = %v, want late", result["message"])
+	}
+}
+
+// waitForConnections polls until the server reports n connections.
+func waitForConnections(t *testing.T, server *Server, n int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if server.ConnectionCount() == n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("connection count = %d, want %d", server.ConnectionCount(), n)
+}


### PR DESCRIPTION
## Summary

Two paired changes that let aprot serve desktop/embedded topologies — e.g. a Go backend spawned by an Electron app — without HTTP, as discussed for Electron integration:

**Go: `Server.ServeStream(ctx, rw io.ReadWriteCloser, info ConnInfo) error`** (`transport_stream.go`)
- Serves one connection over any bidirectional byte stream using newline-delimited JSON framing (one protocol message per line): stdio pipes of a child process, Unix domain sockets, Windows named pipes, arbitrary `net.Conn`s.
- Full feature parity with WS/SSE connections: connect/disconnect hooks, first-message auth (incl. `AuthTimeout`), middleware, subscriptions, streaming handlers, push/broadcast, graceful `Stop`.
- Blocks until the connection ends; returns `nil` on normal close (peer EOF, ctx cancel, server stop) and the rejection error when refused (connect hook, `ErrServerShutdown`).
- `MaxMessageSize` bounds inbound line length. `PingInterval`/`PongTimeout`/`WriteTimeout` deliberately don't apply — a raw stream has no ping frames or write deadlines; liveness is the stream's own lifetime (documented).
- Refactors: `newConn` now takes a `ConnInfo` instead of an `*http.Request` (HTTP callers use `connInfoFromRequest`); the connection-rejected and config frames are built by shared constructors (`connectionRejectedMessage`, `configMessage`) used by all three transports.

**TypeScript: injectable `ClientTransport`** (templates)
- `ClientTransport` and `TransportCloseInfo` are now exported from the generated client (moved into the shared `types` template section, removing two duplicated inline copies).
- `ApiClientOptions.transport` accepts a custom `ClientTransport` instance in addition to `'websocket' | 'sse'`, so the protocol can ride any message channel — e.g. an Electron preload/`MessagePort` bridge to a Go child process speaking NDJSON on stdio.
- Contract documented on the interface: string-based `onMessage` delivery, single `onClose` per established connection, instances reusable across reconnects.

Docs updated in `README.md` (new "Byte-Stream Transport" section with Electron guidance), `doc.go` (`# Server` section), `APROT_AI.md`, and `CHANGELOG.md`.

## Testing

- New `transport_stream_test.go` (written first, TDD): echo request/response, config-frame-first ordering, `ConnInfo` propagation, connect-hook rejection, stopped-server rejection, push/broadcast, client-close and ctx-cancel teardown (incl. unregistration), first-message auth gating — all over `net.Pipe`, passing with `-race`.
- Full `go test -race ./...` green; `go vet` and `gofmt` clean.
- Example clients regenerated (`example/vanilla`, `example/react`); `npx tsc --noEmit` clean on the React client; e2e suite regenerated + all 87 vitest tests pass.

## Possible follow-ups

- An `example/electron` directory demonstrating spawn-from-main + port/token handoff (loopback WS) and the stdio + MessagePort-bridge variant end to end.
- An e2e vitest case driving `ServeStream` from Node over a socket with a custom `ClientTransport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)