### PR TITLE
Surface response marshal failures as internal errors instead of silently dropping the frame

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -273,6 +273,8 @@ return aprot.ErrInternal(err)                     // -32603
 registry.RegisterError(sql.ErrNoRows, "NotFound") // → ApiError.isNotFound() in TS
 ```
 
+A handler result that can't be JSON-encoded (e.g. `NaN`/`Inf` floats) becomes a `-32603` internal error response instead of a silently dropped frame; error/stream-end frames with an unencodable `Data` payload are resent without the payload.
+
 ### Client-side: `ApiError` vs `ConnectionError`
 Two distinct error types on the generated TS client:
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ func (h *Handlers) CreateUser(ctx context.Context, req *CreateUserRequest) (*Cre
 
 Parameters are positional — each Go parameter becomes a separate TypeScript argument. Names are extracted from Go source via AST parsing.
 
+Results are serialized as JSON. A result that can't be encoded (e.g. a `NaN`/`Inf` float) is reported to the client as an internal error response rather than silently dropped, so the request never hangs.
+
 ### 2. Create the server
 
 ```go

--- a/connection.go
+++ b/connection.go
@@ -278,6 +278,11 @@ func (c *Conn) sendJSON(v any) error {
 	if err != nil {
 		return err
 	}
+	return c.sendRaw(data)
+}
+
+// sendRaw sends pre-marshaled bytes on the transport.
+func (c *Conn) sendRaw(data []byte) error {
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
@@ -312,7 +317,14 @@ func (c *Conn) sendResponse(id string, result any) {
 		ID:     id,
 		Result: result,
 	}
-	_ = c.sendJSON(msg)
+	data, err := marshalJSON(msg)
+	if err != nil {
+		// A result that cannot be marshaled (e.g. a NaN float) must not leave
+		// the request pending forever: surface it as an internal error instead.
+		c.sendError(id, CodeInternalError, "failed to encode response: "+err.Error())
+		return
+	}
+	_ = c.sendRaw(data)
 }
 
 // errorCode maps a handler error to the protocol code that sendError /
@@ -349,7 +361,15 @@ func (c *Conn) sendProtocolError(id string, perr *ProtocolError) {
 		Message: perr.Message,
 		Data:    perr.Data,
 	}
-	_ = c.sendJSON(msg)
+	data, err := marshalJSON(msg)
+	if err != nil {
+		// An unmarshalable Data payload must not swallow the error frame:
+		// resend without it. The remaining fields are plain strings and ints,
+		// so this marshal cannot fail.
+		msg.Data = nil
+		data, _ = marshalJSON(msg)
+	}
+	_ = c.sendRaw(data)
 }
 
 func (c *Conn) sendProgress(id string, current, total int, message string) {
@@ -745,7 +765,14 @@ func (c *Conn) sendStreamEnd(reqID string, err error) {
 			msg.Message = err.Error()
 		}
 	}
-	_ = c.sendJSON(msg)
+	data, merr := marshalJSON(msg)
+	if merr != nil {
+		// An unmarshalable Data payload must not swallow the terminal frame:
+		// resend without it (see sendProtocolError).
+		msg.Data = nil
+		data, _ = marshalJSON(msg)
+	}
+	_ = c.sendRaw(data)
 }
 
 func (c *Conn) handleSubscribe(msg IncomingMessage) {

--- a/doc.go
+++ b/doc.go
@@ -436,6 +436,12 @@
 //	registry.RegisterError(sql.ErrNoRows, "NotFound")
 //	// In TypeScript: err.isNotFound(), ErrorCode.NotFound
 //
+// A handler result that cannot be encoded as JSON (for example a float
+// carrying NaN or Inf, which JSON rejects) is surfaced to the client as an
+// internal error (-32603) rather than leaving the request pending. Likewise,
+// an error or stream-end frame whose Data payload cannot be encoded is resent
+// without the payload so the terminal frame always reaches the client.
+//
 // # Connection Errors (TypeScript Client)
 //
 // Connection-level failures surface as a structured ConnectionError on the

--- a/marshal_error_test.go
+++ b/marshal_error_test.go
@@ -1,0 +1,96 @@
+package aprot
+
+import (
+	"context"
+	"math"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Handlers used by the marshal-failure tests.
+type MarshalHandlers struct{}
+
+type NaNResponse struct {
+	Value float64 `json:"value"`
+}
+
+func (h *MarshalHandlers) NaN(ctx context.Context, req *EchoRequest) (*NaNResponse, error) {
+	return &NaNResponse{Value: math.NaN()}, nil
+}
+
+func (h *MarshalHandlers) Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error) {
+	return &EchoResponse{Message: req.Message}, nil
+}
+
+func (h *MarshalHandlers) SubscribeNaN(ctx context.Context) (*NaNResponse, error) {
+	return &NaNResponse{Value: math.NaN()}, nil
+}
+
+func setupMarshalServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	registry := NewRegistry()
+	registry.Register(&MarshalHandlers{})
+	server := NewServer(registry)
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// A result that cannot be marshaled (NaN is rejected by JSON) must surface as
+// an internal error response instead of silently dropping the frame and
+// leaving the client's request pending forever.
+func TestResponseMarshalFailureSendsError(t *testing.T) {
+	ts := setupMarshalServer(t)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "MarshalHandlers.NaN", Params: jsontext.Value(`[{"message":"hi"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	errMsg := readMessageOfType(t, ws, TypeError, 3*time.Second)
+	if errMsg.ID != "1" {
+		t.Errorf("expected error for request 1, got %q", errMsg.ID)
+	}
+	if errMsg.Code != CodeInternalError {
+		t.Errorf("expected CodeInternalError, got %d", errMsg.Code)
+	}
+	if !strings.Contains(errMsg.Message, "encode") {
+		t.Errorf("expected encode mention in message, got %q", errMsg.Message)
+	}
+
+	// The same connection must still work.
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "2", Method: "MarshalHandlers.Echo", Params: jsontext.Value(`[{"message":"still alive"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	resp := readMessageOfType(t, ws, TypeResponse, 3*time.Second)
+	if resp.ID != "2" {
+		t.Errorf("expected response for request 2, got %q", resp.ID)
+	}
+}
+
+// The subscription initial response goes through the same send path and must
+// fail the same way.
+func TestSubscribeMarshalFailureSendsError(t *testing.T) {
+	ts := setupMarshalServer(t)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeSubscribe, ID: "s1", Method: "MarshalHandlers.SubscribeNaN"}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	errMsg := readMessageOfType(t, ws, TypeError, 3*time.Second)
+	if errMsg.ID != "s1" {
+		t.Errorf("expected error for subscription s1, got %q", errMsg.ID)
+	}
+	if errMsg.Code != CodeInternalError {
+		t.Errorf("expected CodeInternalError, got %d", errMsg.Code)
+	}
+}


### PR DESCRIPTION
## Problem

All outbound frames are serialized with `go-json-experiment/json`, which rejects values JSON cannot represent (e.g. `NaN`/`Inf` floats). `sendResponse` discarded the marshal error (`_ = c.sendJSON(msg)`), so a handler returning such a result produced **no frame at all** — the client received neither a response nor an error, and the request hung until timeout. The same silent-drop applied to error and stream-end frames whose `Data` payload failed to marshal.

## Fix

- `sendResponse` (used by both unary requests and subscription initial responses) now marshals up front; on failure it sends a `CodeInternalError` error frame (`failed to encode response: ...`) so the client always gets a terminal frame.
- `sendProtocolError` and `sendStreamEnd` resend without the `Data` payload when the payload is what fails to marshal — the remaining fields are plain strings/ints and cannot fail.
- Extracted a `sendRaw` helper so callers can marshal separately from transport send.

The stream-item path already handled marshal failures correctly (aborts iteration and sends an error-bearing `stream_end`); it is unchanged.

## Tests

TDD: both tests written first and confirmed to time out (no frame received) before the fix.

- `TestResponseMarshalFailureSendsError` — NaN result → `CodeInternalError` error frame with matching request ID; connection still usable afterwards.
- `TestSubscribeMarshalFailureSendsError` — same via the subscribe path.

Full `go test ./...` passes.

## Docs

Behavioral note added to `doc.go` (Error Handling), `README.md`, and `APROT_AI.md` per repo conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)