### PR TITLE
Stream chunking: batch streamed items into stream_chunk frames (#239)

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -111,6 +111,8 @@ func (h *H) ListUsers(ctx context.Context) (iter.Seq[*User], error) {
 ```
 Streaming handlers cannot be exposed via REST (panics at registration). For SSE/WS only. To observe real stream end from middleware, use `aprot.OnStreamComplete(ctx, fn)` — it fires once with `(err, items)`.
 
+**Chunked delivery (#239):** by default each yielded item is one wire frame. `aprot.ServerOptions{StreamChunking: &aprot.StreamChunking{MaxItems: 128, MaxBytes: 64 << 10, MaxDelay: 20 * time.Millisecond}}` batches consecutive items into `stream_chunk` frames — flushed when *any* threshold is hit; `MaxDelay` bounds added latency for slow producers. `&aprot.StreamChunking{}` = all defaults; nil = disabled (per-item frames). Transparent to the generated `AsyncIterable`, but requires a client generated from the same aprot version (older clients don't know `stream_chunk`). Server-wide, applies to all streaming handlers.
+
 ## Input Transformation
 
 `transform:"…"` ops run after JSON decoding, before validation. Statically checked at `Register` time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Added
+
+- `ServerOptions.StreamChunking`: opt-in batching of streamed items. Instead
+  of one wire frame per yielded item, consecutive items are batched into
+  `stream_chunk` frames, flushed when any of three thresholds is reached —
+  `MaxItems` (default 128), `MaxBytes` of marshaled items (default 64 KiB),
+  or `MaxDelay` after the first buffered item (default 20ms), so a slow
+  producer never holds delivered items back. This makes streaming viable for
+  large collections (thousands of small records) where per-item framing and
+  syscall overhead dominate. Batching is transparent to the generated
+  TypeScript client's `AsyncIterable`, which still yields one item at a time,
+  but enabling it requires a client generated from this aprot version — older
+  generated clients do not understand `stream_chunk` frames. Nil (the
+  default) keeps the existing per-item `stream_item` frames (#239).
+
 ### Fixed
 
 - Fixed-size array fields (`[N]T`) no longer degrade to `any` in the generated

--- a/README.md
+++ b/README.md
@@ -547,6 +547,22 @@ Cancellation works exactly like any other request: break out of the `for await` 
 
 Streaming handlers are WebSocket/SSE only. Registering one via `RegisterREST` panics at registration time since REST cannot deliver multi-message responses over a single HTTP request.
 
+### Chunked delivery for large streams
+
+By default every yielded item is its own wire frame, which is wasteful when a handler streams thousands of small records (framing and syscall overhead dwarf the payload). Enable **stream chunking** to batch consecutive items into single `stream_chunk` frames:
+
+```go
+server := aprot.NewServer(registry, aprot.ServerOptions{
+    StreamChunking: &aprot.StreamChunking{
+        MaxItems: 128,       // flush after this many items (default 128)
+        MaxBytes: 64 << 10,  // ... or this many marshaled bytes (default 64 KiB)
+        MaxDelay: 20 * time.Millisecond, // ... or this long after the first buffered item (default 20ms)
+    },
+})
+```
+
+A chunk is flushed as soon as *any* threshold is reached, and `MaxDelay` bounds the extra latency for slow producers: a stalled iterator never holds already-yielded items back for more than that long. `&aprot.StreamChunking{}` enables chunking with all defaults. Batching is completely transparent to the generated client — the `AsyncIterable` still yields one item at a time — but it does require a client generated from the same aprot version, since older generated clients don't understand `stream_chunk` frames. Chunking applies to every streaming handler on the server; leave `StreamChunking` nil to keep per-item frames.
+
 ### Middleware and streaming handlers
 
 Middleware sees a streaming handler return as soon as the iterator value is in hand — *not* after every row has been streamed. For unary handlers that's the normal post-handler hook point; for streams, the duration and success you see at that moment reflect the time it took to produce the iterator, not the time to drain it. To observe the real end of a stream (duration, item count, cancellation cause, panic), register a callback via `aprot.OnStreamComplete(ctx, fn)`:

--- a/connection.go
+++ b/connection.go
@@ -698,6 +698,10 @@ func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Val
 	yieldType := seq.Type().In(0)
 	var streamErr error
 	itemCount := 0
+	var chunker *streamChunker
+	if cfg := c.server.options.StreamChunking; cfg != nil {
+		chunker = newStreamChunker(ctx, c, reqID, *cfg)
+	}
 	yieldFn := reflect.MakeFunc(yieldType, func(args []reflect.Value) []reflect.Value {
 		if ctx.Err() != nil {
 			return []reflect.Value{reflect.ValueOf(false)}
@@ -708,11 +712,17 @@ func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Val
 		} else {
 			item = args[0].Interface()
 		}
-		if err := c.sendJSONCtx(ctx, StreamItemMessage{
-			Type: TypeStreamItem,
-			ID:   reqID,
-			Item: item,
-		}); err != nil {
+		var err error
+		if chunker != nil {
+			err = chunker.add(item)
+		} else {
+			err = c.sendJSONCtx(ctx, StreamItemMessage{
+				Type: TypeStreamItem,
+				ID:   reqID,
+				Item: item,
+			})
+		}
+		if err != nil {
 			streamErr = err
 			return []reflect.Value{reflect.ValueOf(false)}
 		}
@@ -728,6 +738,16 @@ func (c *Conn) streamIterator(ctx context.Context, reqID string, seq reflect.Val
 		}()
 		seq.Call([]reflect.Value{yieldFn})
 	}()
+
+	// Flush any partial chunk before the terminal frame. Items already
+	// yielded by the handler must reach the client even when the stream ends
+	// abnormally (panic), so flush regardless of streamErr; a flush failure
+	// only becomes the stream's error when nothing worse happened first.
+	if chunker != nil {
+		if err := chunker.close(); err != nil && streamErr == nil {
+			streamErr = err
+		}
+	}
 
 	// Compute the final cause for the completion hooks. Cancellation
 	// wins over a late transport error because the cancel is the root

--- a/doc.go
+++ b/doc.go
@@ -66,6 +66,12 @@
 // request. See [OnStreamComplete] in the Middleware section for observing
 // the real end of a stream from logging / metrics middleware.
 //
+// For large streams, [ServerOptions.StreamChunking] batches consecutive
+// items into single stream_chunk frames (flushed on an item count, byte
+// size, or max-delay threshold — see [StreamChunking]) instead of sending
+// one frame per item. Batching is transparent to the generated client's
+// AsyncIterable but requires a client generated from the same aprot version.
+//
 // # Input Transformation
 //
 // Request struct fields can be normalized before handler dispatch using

--- a/e2e/server/main.go
+++ b/e2e/server/main.go
@@ -21,7 +21,13 @@ func main() {
 	// Add REST + validation handlers for e2e coverage of those surfaces.
 	e2eapi.Register(registry)
 
-	server := aprot.NewServer(registry)
+	// Chunking enabled with a small MaxItems so the existing stream tests
+	// exercise stream_chunk frames end-to-end: they assert only item order and
+	// values, so their staying green proves chunking is transparent to the
+	// generated AsyncIterable (#239).
+	server := aprot.NewServer(registry, aprot.ServerOptions{
+		StreamChunking: &aprot.StreamChunking{MaxItems: 3},
+	})
 
 	state.Broadcaster = server
 	state.UserPusher = server

--- a/e2e/tests/stream-chunking.test.ts
+++ b/e2e/tests/stream-chunking.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { WebSocket } from 'ws';
+import { wsUrl } from './helpers';
+import { ApiClient } from '../api/client';
+import { numbers } from '../api/streaming-handlers';
+
+// The e2e server enables ServerOptions.StreamChunking with MaxItems=3, so
+// streamed items cross the wire batched in stream_chunk frames (#239). The
+// generated-client transparency is covered by stream.test.ts staying green;
+// this file asserts the wire format itself over a raw WebSocket, and that the
+// AsyncIterable still yields every item in order.
+
+interface RawFrame {
+    type: string;
+    id?: string;
+    items?: { index: number; label: string }[];
+}
+
+describe('Stream chunking (#239)', () => {
+    test('items arrive batched in stream_chunk frames, never stream_item', async () => {
+        const ws = new WebSocket(wsUrl());
+        await new Promise<void>((resolve, reject) => {
+            ws.on('open', () => resolve());
+            ws.on('error', reject);
+        });
+
+        const frames: RawFrame[] = [];
+        const done = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('timed out waiting for stream_end')), 5000);
+            ws.on('message', (data) => {
+                const msg = JSON.parse(data.toString()) as RawFrame;
+                if (msg.id !== 'chunk-test') return;
+                frames.push(msg);
+                if (msg.type === 'stream_end') {
+                    clearTimeout(timer);
+                    resolve();
+                }
+            });
+            ws.on('error', reject);
+        });
+
+        ws.send(
+            JSON.stringify({
+                type: 'request',
+                id: 'chunk-test',
+                method: 'StreamingHandlers.Numbers',
+                params: [10, 0],
+            }),
+        );
+        await done;
+        ws.close();
+
+        expect(frames.filter((f) => f.type === 'stream_item')).toHaveLength(0);
+
+        const chunks = frames.filter((f) => f.type === 'stream_chunk');
+        // MaxItems=3 → at most 3 items per frame, and 10 items must arrive in
+        // strictly fewer frames than items (the point of chunking). The exact
+        // split can vary if the 20ms MaxDelay timer fires mid-stream, so
+        // assert bounds rather than an exact [3,3,3,1] layout.
+        expect(chunks.length).toBeGreaterThanOrEqual(2);
+        expect(chunks.length).toBeLessThan(10);
+        for (const c of chunks) {
+            expect(c.items!.length).toBeGreaterThanOrEqual(1);
+            expect(c.items!.length).toBeLessThanOrEqual(3);
+        }
+
+        const received = chunks.flatMap((c) => c.items!);
+        expect(received.map((it) => it.index)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(received[0].label).toBe('item-1');
+
+        expect(frames[frames.length - 1].type).toBe('stream_end');
+    });
+});
+
+describe('Stream chunking via generated client', () => {
+    let client: ApiClient;
+
+    beforeEach(async () => {
+        client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+    });
+
+    afterEach(() => {
+        client.disconnect();
+    });
+
+    test('a slow producer still delivers items promptly (MaxDelay flush)', async () => {
+        // 3 items at 100ms apart with MaxItems=3: without the MaxDelay timer
+        // the first item would only ship when the third fills the chunk
+        // (~200ms later). The 20ms MaxDelay flush must deliver it long before
+        // the producer finishes.
+        const firstItemAt: number[] = [];
+        const start = Date.now();
+        const items: number[] = [];
+        for await (const item of numbers(client, 3, 100)) {
+            firstItemAt.push(Date.now() - start);
+            items.push(item.index);
+        }
+        expect(items).toEqual([1, 2, 3]);
+        // Total stream time is ~200ms+; the first item must arrive well
+        // before the end. Generous bound to avoid CI flakiness.
+        expect(firstItemAt[0]).toBeLessThan(150);
+    });
+});

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -383,6 +383,10 @@ class SSETransport implements ClientTransport {
                 onMessage(e.data);
             });
 
+            this.eventSource.addEventListener('stream_chunk', (e: MessageEvent) => {
+                onMessage(e.data);
+            });
+
             this.eventSource.addEventListener('stream_end', (e: MessageEvent) => {
                 onMessage(e.data);
             });
@@ -1032,6 +1036,16 @@ export class ApiClient {
             case 'stream_item': {
                 const s = this.streams.get(msg.id);
                 if (s) s.push(msg.item);
+                break;
+            }
+            case 'stream_chunk': {
+                // Server-side chunking (ServerOptions.StreamChunking) batches
+                // consecutive items into one frame; unroll so the
+                // AsyncIterable still yields one item at a time.
+                const s = this.streams.get(msg.id);
+                if (s && Array.isArray(msg.items)) {
+                    for (const item of msg.items) s.push(item);
+                }
                 break;
             }
             case 'stream_end': {

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -376,6 +376,10 @@ class SSETransport implements ClientTransport {
                 onMessage(e.data);
             });
 
+            this.eventSource.addEventListener('stream_chunk', (e: MessageEvent) => {
+                onMessage(e.data);
+            });
+
             this.eventSource.addEventListener('stream_end', (e: MessageEvent) => {
                 onMessage(e.data);
             });
@@ -1025,6 +1029,16 @@ export class ApiClient {
             case 'stream_item': {
                 const s = this.streams.get(msg.id);
                 if (s) s.push(msg.item);
+                break;
+            }
+            case 'stream_chunk': {
+                // Server-side chunking (ServerOptions.StreamChunking) batches
+                // consecutive items into one frame; unroll so the
+                // AsyncIterable still yields one item at a time.
+                const s = this.streams.get(msg.id);
+                if (s && Array.isArray(msg.items)) {
+                    for (const item of msg.items) s.push(item);
+                }
                 break;
             }
             case 'stream_end': {

--- a/protocol.go
+++ b/protocol.go
@@ -17,6 +17,7 @@ const (
 	TypeSubscribe   MessageType = "subscribe"
 	TypeUnsubscribe MessageType = "unsubscribe"
 	TypeStreamItem  MessageType = "stream_item"
+	TypeStreamChunk MessageType = "stream_chunk"
 	TypeStreamEnd   MessageType = "stream_end"
 	// TypeAuth is a client->server frame carrying a token for first-message
 	// authentication (and mid-session token refresh). TypeAuthOK / TypeAuthError
@@ -91,6 +92,19 @@ type StreamItemMessage struct {
 	Type MessageType `json:"type"`
 	ID   string      `json:"id"`
 	Item any         `json:"item"`
+}
+
+// StreamChunkMessage carries a batch of consecutive elements of a
+// server-streamed iterator in a single frame. It is sent instead of per-item
+// [StreamItemMessage] frames when the server enables
+// [ServerOptions.StreamChunking]. Each element of Items has the same shape a
+// StreamItemMessage.Item would have (the element value, or a 2-element
+// [K, V] array for HandlerKindStream2 handlers); items are pre-marshaled so
+// a chunk is assembled without re-encoding them.
+type StreamChunkMessage struct {
+	Type  MessageType      `json:"type"`
+	ID    string           `json:"id"`
+	Items []jsontext.Value `json:"items"`
 }
 
 // StreamEndMessage terminates a server-streamed iterator for a request.

--- a/server.go
+++ b/server.go
@@ -95,6 +95,36 @@ type ServerOptions struct {
 	// connections linger indefinitely, which is a DoS vector on public endpoints;
 	// keep a bounded timeout there.
 	AuthTimeout time.Duration
+	// StreamChunking batches consecutive items yielded by streaming handlers
+	// into stream_chunk frames instead of sending one frame per item, cutting
+	// framing and syscall overhead for large streamed collections. Nil (the
+	// default) keeps the per-item stream_item frames. Enabling chunking
+	// requires a client generated from the same aprot version — older
+	// generated clients do not understand stream_chunk frames. See
+	// [StreamChunking].
+	StreamChunking *StreamChunking
+}
+
+// StreamChunking configures server-side batching of streamed items (issue
+// #239). A chunk is flushed as soon as any threshold is reached; a partial
+// chunk held by a stalled producer is flushed after MaxDelay so buffering
+// never adds unbounded latency. The batching is transparent to the generated
+// TypeScript client — the AsyncIterable still yields one item at a time.
+//
+// Fields set to zero (or negative) take their documented defaults, so
+// &StreamChunking{} enables chunking with sensible settings.
+type StreamChunking struct {
+	// MaxItems flushes a chunk once it holds this many items. Default: 128.
+	MaxItems int
+	// MaxBytes flushes a chunk once its marshaled items reach this many
+	// bytes. A single item larger than MaxBytes still ships (in its own
+	// chunk), so a chunk may exceed the limit by the size of one item.
+	// Default: 64 KiB.
+	MaxBytes int
+	// MaxDelay flushes a partial chunk this long after its first item was
+	// buffered, bounding the extra latency chunking can add when the
+	// producer is slower than the thresholds. Default: 20ms.
+	MaxDelay time.Duration
 }
 
 func defaultServerOptions() ServerOptions {
@@ -188,6 +218,21 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		}
 		if opt.AuthTimeout != 0 {
 			options.AuthTimeout = opt.AuthTimeout
+		}
+		if opt.StreamChunking != nil {
+			// Copy so later mutation of the caller's struct can't race the
+			// server, and fill defaults for unset thresholds.
+			cfg := *opt.StreamChunking
+			if cfg.MaxItems <= 0 {
+				cfg.MaxItems = 128
+			}
+			if cfg.MaxBytes <= 0 {
+				cfg.MaxBytes = 64 << 10
+			}
+			if cfg.MaxDelay <= 0 {
+				cfg.MaxDelay = 20 * time.Millisecond
+			}
+			options.StreamChunking = &cfg
 		}
 	}
 

--- a/stream_chunk.go
+++ b/stream_chunk.go
@@ -1,0 +1,107 @@
+package aprot
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// streamChunker batches marshaled stream items into StreamChunkMessage frames
+// per the server's [StreamChunking] thresholds. It is created per streaming
+// request by streamIterator when chunking is enabled.
+//
+// add is called from the iteration goroutine; the MaxDelay flush fires on a
+// timer goroutine, so the buffer is mutex-guarded. Frame ordering is
+// preserved because every flush enqueues on the transport while holding the
+// mutex.
+type streamChunker struct {
+	conn  *Conn
+	ctx   context.Context
+	reqID string
+	cfg   StreamChunking
+
+	mu    sync.Mutex
+	items []jsontext.Value
+	bytes int
+	timer *time.Timer
+	// err is the first marshal/send failure. It is sticky: once set, add
+	// returns it so the yield callback stops the handler's iteration.
+	err error
+}
+
+func newStreamChunker(ctx context.Context, conn *Conn, reqID string, cfg StreamChunking) *streamChunker {
+	return &streamChunker{conn: conn, ctx: ctx, reqID: reqID, cfg: cfg}
+}
+
+// add marshals item into the buffer and flushes when the item-count or byte
+// threshold is reached. The first item buffered after a flush arms the
+// MaxDelay timer so a stalled producer cannot hold delivered items back.
+func (sc *streamChunker) add(item any) error {
+	data, err := marshalJSON(item)
+	if err != nil {
+		sc.mu.Lock()
+		if sc.err == nil {
+			sc.err = err
+		}
+		sc.mu.Unlock()
+		return err
+	}
+
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if sc.err != nil {
+		return sc.err
+	}
+	sc.items = append(sc.items, data)
+	sc.bytes += len(data)
+	if len(sc.items) >= sc.cfg.MaxItems || sc.bytes >= sc.cfg.MaxBytes {
+		return sc.flushLocked()
+	}
+	if len(sc.items) == 1 {
+		sc.timer = time.AfterFunc(sc.cfg.MaxDelay, sc.delayFlush)
+	}
+	return nil
+}
+
+// delayFlush is the MaxDelay timer callback. A send failure here is recorded
+// in sc.err and surfaces on the next add (or close).
+func (sc *streamChunker) delayFlush() {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if sc.err == nil {
+		_ = sc.flushLocked()
+	}
+}
+
+// flushLocked sends the buffered items as one StreamChunkMessage. Caller
+// must hold sc.mu. A no-op on an empty buffer.
+func (sc *streamChunker) flushLocked() error {
+	if sc.timer != nil {
+		sc.timer.Stop()
+		sc.timer = nil
+	}
+	if len(sc.items) == 0 {
+		return sc.err
+	}
+	msg := StreamChunkMessage{Type: TypeStreamChunk, ID: sc.reqID, Items: sc.items}
+	sc.items = nil
+	sc.bytes = 0
+	if err := sc.conn.sendJSONCtx(sc.ctx, msg); err != nil {
+		if sc.err == nil {
+			sc.err = err
+		}
+		return err
+	}
+	return nil
+}
+
+// close flushes any partial chunk and returns the first error the chunker
+// encountered (marshal, send, or timer-flush failure). Called once after the
+// handler's iteration finishes, before the terminal stream_end frame.
+func (sc *streamChunker) close() error {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.flushLocked()
+}

--- a/stream_chunk_test.go
+++ b/stream_chunk_test.go
@@ -1,0 +1,342 @@
+package aprot
+
+import (
+	"context"
+	"iter"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// streamChunkTestServer builds a Server with chunking enabled + a Conn with a
+// recording transport, mirroring streamTestServer.
+func streamChunkTestServer(t *testing.T, cfg StreamChunking) (*Conn, *recordingTransport) {
+	t.Helper()
+	r := NewRegistry()
+	s := NewServer(r, ServerOptions{StreamChunking: &cfg})
+	rt := &recordingTransport{}
+	c := &Conn{
+		transport: rt,
+		server:    s,
+		requests:  make(map[string]context.CancelCauseFunc),
+		id:        1,
+	}
+	return c, rt
+}
+
+// chunkItems extracts the items array from a decoded stream_chunk message.
+func chunkItems(t *testing.T, msg map[string]any) []any {
+	t.Helper()
+	items, ok := msg["items"].([]any)
+	if !ok {
+		t.Fatalf("stream_chunk message has no items array: %v", msg)
+	}
+	return items
+}
+
+func TestStreamChunking_MaxItems(t *testing.T) {
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 2, MaxBytes: 1 << 20, MaxDelay: time.Minute})
+
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		for i := 1; i <= 5; i++ {
+			if !yield(i) {
+				return
+			}
+		}
+	})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+
+	msgs := drainMessages(t, rt)
+	// 5 items at MaxItems=2 → chunks of [1,2], [3,4], [5], then stream_end.
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages (3 chunks + end), got %d: %v", len(msgs), msgs)
+	}
+	wantChunks := [][]int{{1, 2}, {3, 4}, {5}}
+	for i, want := range wantChunks {
+		if msgs[i]["type"] != "stream_chunk" {
+			t.Errorf("msg[%d] type = %v, want stream_chunk", i, msgs[i]["type"])
+		}
+		if msgs[i]["id"] != "r1" {
+			t.Errorf("msg[%d] id = %v, want r1", i, msgs[i]["id"])
+		}
+		items := chunkItems(t, msgs[i])
+		if len(items) != len(want) {
+			t.Fatalf("chunk[%d] has %d items, want %d: %v", i, len(items), len(want), items)
+		}
+		for j, w := range want {
+			if v, ok := items[j].(float64); !ok || int(v) != w {
+				t.Errorf("chunk[%d] item[%d] = %v, want %d", i, j, items[j], w)
+			}
+		}
+	}
+	if msgs[3]["type"] != "stream_end" {
+		t.Errorf("last message type = %v, want stream_end", msgs[3]["type"])
+	}
+	if code, _ := msgs[3]["code"].(float64); code != 0 {
+		t.Errorf("clean end should have zero code, got %v", msgs[3]["code"])
+	}
+}
+
+func TestStreamChunking_MaxBytes(t *testing.T) {
+	// Each item is a 10-byte JSON string ("aaaaaaaa"). MaxBytes 15 → the
+	// second item pushes the buffer to 20 ≥ 15, flushing a 2-item chunk.
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 100, MaxBytes: 15, MaxDelay: time.Minute})
+
+	seq := iter.Seq[string](func(yield func(string) bool) {
+		for i := 0; i < 4; i++ {
+			if !yield("aaaaaaaa") {
+				return
+			}
+		}
+	})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf("")}
+
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+
+	msgs := drainMessages(t, rt)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages (2 chunks + end), got %d: %v", len(msgs), msgs)
+	}
+	for i := 0; i < 2; i++ {
+		if msgs[i]["type"] != "stream_chunk" {
+			t.Errorf("msg[%d] type = %v, want stream_chunk", i, msgs[i]["type"])
+		}
+		items := chunkItems(t, msgs[i])
+		if len(items) != 2 {
+			t.Errorf("chunk[%d] has %d items, want 2", i, len(items))
+		}
+	}
+	if msgs[2]["type"] != "stream_end" {
+		t.Errorf("last message type = %v, want stream_end", msgs[2]["type"])
+	}
+}
+
+func TestStreamChunking_MaxDelayFlushesPartialChunk(t *testing.T) {
+	// A producer that stalls after two items must not hold them hostage:
+	// the MaxDelay timer flushes the partial chunk while the stream is open.
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 100, MaxBytes: 1 << 20, MaxDelay: 20 * time.Millisecond})
+
+	release := make(chan struct{})
+	flushed := make(chan struct{})
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		yield(1)
+		yield(2)
+		// Signal readiness, then stall until the test has observed the
+		// timer-driven flush.
+		close(flushed)
+		<-release
+		yield(3)
+	})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+	}()
+
+	<-flushed
+	// Wait for the MaxDelay timer to fire and flush the partial chunk.
+	deadline := time.After(2 * time.Second)
+	for {
+		if msgs := drainMessages(t, rt); len(msgs) > 0 {
+			items := chunkItems(t, msgs[0])
+			if msgs[0]["type"] != "stream_chunk" || len(items) != 2 {
+				t.Fatalf("expected first frame to be a 2-item stream_chunk, got %v", msgs[0])
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for MaxDelay flush of the partial chunk")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	close(release)
+	<-done
+
+	msgs := drainMessages(t, rt)
+	last := msgs[len(msgs)-1]
+	if last["type"] != "stream_end" {
+		t.Fatalf("last message type = %v, want stream_end", last["type"])
+	}
+	// All three items must have arrived across the chunk frames, in order.
+	var got []int
+	for _, m := range msgs[:len(msgs)-1] {
+		if m["type"] != "stream_chunk" {
+			t.Fatalf("unexpected frame type %v: %v", m["type"], m)
+		}
+		for _, it := range chunkItems(t, m) {
+			got = append(got, int(it.(float64)))
+		}
+	}
+	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("items across chunks = %v, want [1 2 3]", got)
+	}
+}
+
+func TestStreamChunking_Seq2Pairs(t *testing.T) {
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 10, MaxBytes: 1 << 20, MaxDelay: time.Minute})
+
+	seq := iter.Seq2[string, int](func(yield func(string, int) bool) {
+		yield("a", 1)
+		yield("b", 2)
+	})
+	info := &HandlerInfo{
+		Kind:          HandlerKindStream2,
+		ResponseType:  reflect.TypeOf(int(0)),
+		StreamKeyType: reflect.TypeOf(""),
+	}
+
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+
+	msgs := drainMessages(t, rt)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (1 chunk + end), got %d: %v", len(msgs), msgs)
+	}
+	items := chunkItems(t, msgs[0])
+	if len(items) != 2 {
+		t.Fatalf("chunk has %d items, want 2", len(items))
+	}
+	want := []struct {
+		k string
+		v int
+	}{{"a", 1}, {"b", 2}}
+	for i, w := range want {
+		pair, ok := items[i].([]any)
+		if !ok || len(pair) != 2 {
+			t.Fatalf("item[%d] = %v, want a [k, v] pair", i, items[i])
+		}
+		if pair[0] != w.k {
+			t.Errorf("item[%d][0] = %v, want %q", i, pair[0], w.k)
+		}
+		if v, ok := pair[1].(float64); !ok || int(v) != w.v {
+			t.Errorf("item[%d][1] = %v, want %d", i, pair[1], w.v)
+		}
+	}
+}
+
+func TestStreamChunking_PanicFlushesBufferedItemsBeforeErrorEnd(t *testing.T) {
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 10, MaxBytes: 1 << 20, MaxDelay: time.Minute})
+
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		yield(1)
+		yield(2)
+		panic("boom")
+	})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+
+	msgs := drainMessages(t, rt)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (flushed chunk + error end), got %d: %v", len(msgs), msgs)
+	}
+	items := chunkItems(t, msgs[0])
+	if len(items) != 2 {
+		t.Errorf("flushed chunk has %d items, want 2 (yielded before the panic)", len(items))
+	}
+	end := msgs[1]
+	if end["type"] != "stream_end" {
+		t.Fatalf("last message type = %v, want stream_end", end["type"])
+	}
+	if code, _ := end["code"].(float64); int(code) != CodeInternalError {
+		t.Errorf("end code = %v, want %d", end["code"], CodeInternalError)
+	}
+}
+
+func TestStreamChunking_EmptySeq(t *testing.T) {
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 10, MaxBytes: 1 << 20, MaxDelay: time.Minute})
+
+	seq := iter.Seq[int](func(yield func(int) bool) {})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+
+	c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+
+	msgs := drainMessages(t, rt)
+	if len(msgs) != 1 || msgs[0]["type"] != "stream_end" {
+		t.Fatalf("expected a single stream_end (no empty chunk frame), got %v", msgs)
+	}
+}
+
+func TestStreamChunking_UnmarshalableItemErrorsStream(t *testing.T) {
+	c, rt := streamChunkTestServer(t, StreamChunking{MaxItems: 10, MaxBytes: 1 << 20, MaxDelay: time.Minute})
+
+	// Channels have no JSON encoding; marshaling must fail and terminate the
+	// stream with an error end, not silently drop the item.
+	seq := iter.Seq[chan int](func(yield func(chan int) bool) {
+		yield(make(chan int))
+	})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(make(chan int))}
+
+	err := c.streamIterator(context.Background(), "r1", reflect.ValueOf(seq), info, nil)
+	if err == nil {
+		t.Error("expected streamIterator to return the marshal error")
+	}
+
+	msgs := drainMessages(t, rt)
+	last := msgs[len(msgs)-1]
+	if last["type"] != "stream_end" {
+		t.Fatalf("last message type = %v, want stream_end", last["type"])
+	}
+	if code, _ := last["code"].(float64); code == 0 {
+		t.Error("stream_end after marshal failure should carry an error code")
+	}
+}
+
+func TestStreamChunking_HookCountsItemsNotChunks(t *testing.T) {
+	c, _ := streamChunkTestServer(t, StreamChunking{MaxItems: 2, MaxBytes: 1 << 20, MaxDelay: time.Minute})
+
+	seq := iter.Seq[int](func(yield func(int) bool) {
+		for i := 1; i <= 5; i++ {
+			if !yield(i) {
+				return
+			}
+		}
+	})
+	info := &HandlerInfo{Kind: HandlerKindStream, ResponseType: reflect.TypeOf(int(0))}
+
+	ctx, hooks := withStreamCompleteHooks(context.Background())
+	var gotItems int
+	var gotErr error
+	OnStreamComplete(ctx, func(err error, items int) {
+		gotErr = err
+		gotItems = items
+	})
+
+	c.streamIterator(ctx, "r1", reflect.ValueOf(seq), info, hooks)
+
+	if gotErr != nil {
+		t.Errorf("hook err = %v, want nil", gotErr)
+	}
+	if gotItems != 5 {
+		t.Errorf("hook items = %d, want 5 (individual items, not chunk frames)", gotItems)
+	}
+}
+
+func TestStreamChunking_OptionDefaults(t *testing.T) {
+	// Enabling chunking with an empty config applies the documented defaults.
+	s := NewServer(NewRegistry(), ServerOptions{StreamChunking: &StreamChunking{}})
+	cfg := s.options.StreamChunking
+	if cfg == nil {
+		t.Fatal("StreamChunking option was not retained")
+	}
+	if cfg.MaxItems != 128 {
+		t.Errorf("MaxItems default = %d, want 128", cfg.MaxItems)
+	}
+	if cfg.MaxBytes != 64<<10 {
+		t.Errorf("MaxBytes default = %d, want %d", cfg.MaxBytes, 64<<10)
+	}
+	if cfg.MaxDelay != 20*time.Millisecond {
+		t.Errorf("MaxDelay default = %v, want 20ms", cfg.MaxDelay)
+	}
+
+	// Not setting the option leaves chunking disabled.
+	s2 := NewServer(NewRegistry())
+	if s2.options.StreamChunking != nil {
+		t.Error("chunking should be disabled by default")
+	}
+}

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -382,6 +382,10 @@ class SSETransport implements ClientTransport {
                 onMessage(e.data);
             });
 
+            this.eventSource.addEventListener('stream_chunk', (e: MessageEvent) => {
+                onMessage(e.data);
+            });
+
             this.eventSource.addEventListener('stream_end', (e: MessageEvent) => {
                 onMessage(e.data);
             });
@@ -1031,6 +1035,16 @@ export class ApiClient {
             case 'stream_item': {
                 const s = this.streams.get(msg.id);
                 if (s) s.push(msg.item);
+                break;
+            }
+            case 'stream_chunk': {
+                // Server-side chunking (ServerOptions.StreamChunking) batches
+                // consecutive items into one frame; unroll so the
+                // AsyncIterable still yields one item at a time.
+                const s = this.streams.get(msg.id);
+                if (s && Array.isArray(msg.items)) {
+                    for (const item of msg.items) s.push(item);
+                }
                 break;
             }
             case 'stream_end': {


### PR DESCRIPTION
Implements the **chunked yields** half of #239. Credit-based flow control is intentionally left as a follow-up — chunking alone makes streaming viable for the "initial load of a large collection" case the issue describes.

## What this does

`ServerOptions.StreamChunking` (nil by default = today's per-item behavior) batches consecutive items yielded by a streaming handler into a new `stream_chunk` wire frame:

```go
server := aprot.NewServer(registry, aprot.ServerOptions{
    StreamChunking: &aprot.StreamChunking{}, // all defaults: 128 items / 64 KiB / 20ms
})
```

A chunk flushes when **any** threshold is hit:

- `MaxItems` (default 128) or `MaxBytes` of marshaled items (default 64 KiB) — checked synchronously in the yield path;
- `MaxDelay` (default 20ms) after the first buffered item, via a timer, so a stalled/slow producer never holds already-yielded items back. This bounds the latency cost of chunking to `MaxDelay` worst-case.

Items are marshaled once at yield time (`jsontext.Value`), so chunk assembly doesn't re-encode them, and per-item marshal errors keep exactly the per-item path's semantics (error `stream_end`). A panic mid-stream still flushes the items yielded before it; `OnStreamComplete` counts items, not frames.

The generated TS client unrolls `stream_chunk` in `handleMessage` (and the SSE transport subscribes to the new event type), so the `AsyncIterable` API is completely unchanged. **Compat note:** enabling chunking requires a client generated from this aprot version — older generated clients don't understand `stream_chunk`. That's why it's opt-in and documented as such.

## Testing

- **Unit** (`stream_chunk_test.go`, TDD red→green): MaxItems/MaxBytes flush boundaries, timer-driven MaxDelay flush of a partial chunk while the producer stalls, `iter.Seq2` pair batching, panic-flushes-before-error-end, empty stream (no empty chunk frame), unmarshalable item terminates the stream, `OnStreamComplete` item counting, option defaults + disabled-by-default.
- **e2e**: the e2e server now enables chunking with `MaxItems: 3`, so **every existing stream test (WS and SSE) runs against chunked frames** — all 90 tests pass unchanged, which is the transparency proof. New `stream-chunking.test.ts` additionally asserts the raw wire format over a plain WebSocket (only `stream_chunk` frames, ≤ 3 items each, all 10 items in order) and the MaxDelay latency bound through the generated client.
- `tsc --noEmit` clean in e2e and the React example; example clients regenerated from the updated template.
- Note: `go test -race` could not run locally (Windows ThreadSanitizer allocation failure, environment issue) — relying on CI for the race pass over the new timer/yield mutex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)