### PR TITLE
Add binary Blob response support

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -113,6 +113,14 @@ Streaming handlers cannot be exposed via REST (panics at registration). For SSE/
 
 **Chunked delivery (#239):** by default each yielded item is one wire frame. `aprot.ServerOptions{StreamChunking: &aprot.StreamChunking{MaxItems: 128, MaxBytes: 64 << 10, MaxDelay: 20 * time.Millisecond}}` batches consecutive items into `stream_chunk` frames — flushed when *any* threshold is hit; `MaxDelay` bounds added latency for slow producers. `&aprot.StreamChunking{}` = all defaults; nil = disabled (per-item frames). Transparent to the generated `AsyncIterable`, but requires a client generated from the same aprot version (older clients don't know `stream_chunk`). Server-wide, applies to all streaming handlers.
 
+### Binary Blob responses (#238)
+```go
+func (h *H) GetAvatar(ctx context.Context, userID string) (aprot.Blob, error) {
+    return aprot.Blob{ContentType: "image/png", Data: pngBytes}, nil
+}
+```
+Return `aprot.Blob` / `*aprot.Blob` as the **top-level result** and the generated method is typed `Promise<Blob>`, resolving a DOM `Blob` on every transport: WS sends a raw binary frame (no base64); SSE/stream fall back to a `{"$blob": {contentType, data}}` JSON envelope that the client converts back automatically. Subscription refreshes (`subscribeGetAvatar`, `useGetAvatar`) also deliver `Blob`s. Opt-in only: a plain `[]byte` result stays a base64 string, and a `Blob` nested in a struct, streamed, or used as a param travels as JSON `{ contentType?: string; data: string }`. Do not name your own generated type `Blob` — the DOM type is used verbatim.
+
 ## Input Transformation
 
 `transform:"…"` ops run after JSON decoding, before validation. Statically checked at `Register` time.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Type-safe handlers** — define handlers with any signature; parameters become TypeScript arguments
 - **Automatic TypeScript generation** — standalone functions, React hooks, typed errors, enum const objects
 - **Streaming handlers** — return `iter.Seq[T]` / `iter.Seq2[K, V]` from Go and the generated client exposes `AsyncIterable<T>`, so UIs can populate lists item-by-item as results arrive
+- **Binary Blob responses** — return `aprot.Blob` from a handler and the client receives a DOM `Blob`; delivered as a raw WebSocket binary frame (no base64 overhead), with an automatic JSON fallback on SSE and stream transports
 - **Subscription refresh** — server-driven auto-refresh: query handlers declare trigger keys, mutation handlers fire them to push updates to all subscribed clients
 - **Query cache** — multiple React components using the same hook share a single server subscription and receive data from a shared cache; configurable per-hook or globally via `setQueryCacheEnabled`
 - **Middleware** — server-level and per-handler middleware chains
@@ -611,6 +612,31 @@ The `err` passed to the hook distinguishes every termination path:
 Use `errors.Is(err, aprot.ErrClientCanceled)` etc. to distinguish. The hook also receives `items int` — the number of elements successfully yielded to the client (for `iter.Seq2`, each `(key, value)` pair counts as one).
 
 `OnStreamComplete` is a no-op on a unary handler's context — the hooks slot is only populated when the dispatcher sees a streaming return type. Middleware that calls it on every request (as in the example above) works uniformly across both.
+
+## Binary Blob Responses
+
+Return `aprot.Blob` (or `*aprot.Blob`) from a handler to deliver raw binary data — images, PDFs, file downloads — without base64 inflation:
+
+```go
+func (h *FileHandlers) GetAvatar(ctx context.Context, userID string) (aprot.Blob, error) {
+    data, err := h.store.Avatar(userID)
+    if err != nil {
+        return aprot.Blob{}, err
+    }
+    return aprot.Blob{ContentType: "image/png", Data: data}, nil
+}
+```
+
+The generated client method is typed `Promise<Blob>` and resolves a DOM `Blob`:
+
+```typescript
+const avatar = await getAvatar(client, userId);
+imgEl.src = URL.createObjectURL(avatar); // avatar.type === 'image/png'
+```
+
+Over WebSocket the payload travels as a binary frame (a 4-byte header length, a small JSON header, then the raw bytes). Transports without binary frames (SSE, byte-stream) fall back to a JSON envelope carrying base64 data, which the client converts back into a `Blob` automatically — the resolved type never depends on the transport. Subscription refreshes (`subscribeGetAvatar`, `useGetAvatar`) deliver `Blob`s the same way.
+
+Binary delivery is opt-in via the `Blob` type and applies to top-level results only. A plain `[]byte` result keeps its base64 string encoding, and a `Blob` nested inside another struct, streamed as an item, or passed as a parameter travels as ordinary JSON (`{contentType?, data}` with base64 `data`).
 
 ## Validation
 

--- a/blob.go
+++ b/blob.go
@@ -1,0 +1,12 @@
+package aprot
+
+// Blob is an RPC result that can be delivered as a WebSocket binary frame.
+//
+// When the active transport supports binary frames, a Blob result is sent on
+// the binary side channel and received by generated TypeScript clients as a
+// Blob. Transports without binary support fall back to the JSON representation,
+// with Data encoded by the JSON package (base64 for []byte).
+type Blob struct {
+	ContentType string `json:"contentType,omitempty"`
+	Data        []byte `json:"data"`
+}

--- a/blob.go
+++ b/blob.go
@@ -1,11 +1,42 @@
 package aprot
 
-// Blob is an RPC result that can be delivered as a WebSocket binary frame.
+import "reflect"
+
+// blobType lets the generator recognize Blob response types.
+var blobType = reflect.TypeOf(Blob{})
+
+// isBlobResponse reports whether a handler's response type is Blob or *Blob,
+// i.e. a result that opts into binary delivery (see asBlob for the runtime
+// counterpart).
+func isBlobResponse(t reflect.Type) bool {
+	if t == nil {
+		return false
+	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t == blobType
+}
+
+// blobTSWireShape is the TypeScript type of a Blob outside a top-level
+// result position (nested in a struct, streamed, or used as a parameter),
+// where it travels as plain JSON with base64 data. Only top-level results
+// are delivered as binary frames and typed as the DOM Blob.
+const blobTSWireShape = "{ contentType?: string; data: string }"
+
+// Blob is an RPC result that is delivered to the client as raw binary data.
 //
-// When the active transport supports binary frames, a Blob result is sent on
-// the binary side channel and received by generated TypeScript clients as a
-// Blob. Transports without binary support fall back to the JSON representation,
-// with Data encoded by the JSON package (base64 for []byte).
+// Return Blob (or *Blob) from a handler to opt into binary delivery. On
+// transports with a native binary channel (WebSocket) the payload is sent as
+// a binary frame; on other transports (SSE, stream) it falls back to a JSON
+// envelope carrying base64 data under a "$blob" marker. Generated TypeScript
+// clients convert both encodings into a DOM Blob, so the client-visible
+// result type does not depend on the transport.
+//
+// Binary delivery applies only to Blob as the top-level result of a unary
+// handler (including server-driven subscription refreshes). A Blob nested
+// inside another struct, streamed as an item, or passed as a parameter
+// travels as plain JSON ({contentType, data} with base64 data).
 type Blob struct {
 	ContentType string `json:"contentType,omitempty"`
 	Data        []byte `json:"data"`

--- a/blob_test.go
+++ b/blob_test.go
@@ -1,0 +1,42 @@
+package aprot
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/go-json-experiment/json"
+)
+
+func TestSendResponseBlobUsesBinaryFrameWhenSupported(t *testing.T) {
+	rt := &recordingTransport{}
+	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
+
+	c.sendResponse("req-1", Blob{ContentType: "text/plain", Data: []byte("hello")})
+
+	messages := rt.Messages()
+	if len(messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(messages))
+	}
+	frame := messages[0]
+	if len(frame) < 4 {
+		t.Fatalf("frame too short: %d bytes", len(frame))
+	}
+	headerLen := int(binary.BigEndian.Uint32(frame[:4]))
+	if len(frame) < 4+headerLen {
+		t.Fatalf("frame header length %d exceeds frame length %d", headerLen, len(frame))
+	}
+	var header binaryFrameHeader
+	if err := json.Unmarshal(frame[4:4+headerLen], &header); err != nil {
+		t.Fatalf("unmarshal header: %v", err)
+	}
+	if header.Version != binaryFrameVersion {
+		t.Fatalf("header version = %d, want %d", header.Version, binaryFrameVersion)
+	}
+	if header.Type != "response" || header.ID != "req-1" || header.ContentType != "text/plain" {
+		t.Fatalf("unexpected header: %+v", header)
+	}
+	if payload := string(frame[4+headerLen:]); payload != "hello" {
+		t.Fatalf("payload = %q, want %q", payload, "hello")
+	}
+}

--- a/blob_test.go
+++ b/blob_test.go
@@ -8,6 +8,95 @@ import (
 	"github.com/go-json-experiment/json"
 )
 
+func TestSendResponseByteSliceStaysJSON(t *testing.T) {
+	rt := &recordingTransport{}
+	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
+
+	c.sendResponse("req-1", []byte("hello"))
+
+	messages := rt.Messages()
+	if len(messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(messages))
+	}
+	var msg struct {
+		Type   string `json:"type"`
+		ID     string `json:"id"`
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(messages[0], &msg); err != nil {
+		t.Fatalf("expected JSON response, got %q: %v", messages[0], err)
+	}
+	if msg.Type != "response" || msg.ID != "req-1" {
+		t.Fatalf("unexpected envelope: %+v", msg)
+	}
+	if msg.Result != "aGVsbG8=" {
+		t.Fatalf("result = %q, want base64 %q", msg.Result, "aGVsbG8=")
+	}
+}
+
+func TestSendResponseNilBlobPointerIsJSONNull(t *testing.T) {
+	rt := &recordingTransport{}
+	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
+
+	c.sendResponse("req-1", (*Blob)(nil))
+
+	messages := rt.Messages()
+	if len(messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(messages))
+	}
+	var msg struct {
+		Result any `json:"result"`
+	}
+	if err := json.Unmarshal(messages[0], &msg); err != nil {
+		t.Fatalf("expected JSON response, got %q: %v", messages[0], err)
+	}
+	if msg.Result != nil {
+		t.Fatalf("result = %v, want null", msg.Result)
+	}
+}
+
+// noBinaryRecordingTransport records sends but reports no binary support,
+// mirroring the SSE and stream transports.
+type noBinaryRecordingTransport struct {
+	recordingTransport
+}
+
+func (t *noBinaryRecordingTransport) SupportsBinary() bool { return false }
+
+func TestSendResponseBlobFallsBackToJSONWithoutBinarySupport(t *testing.T) {
+	rt := &noBinaryRecordingTransport{}
+	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
+
+	c.sendResponse("req-1", Blob{ContentType: "text/plain", Data: []byte("hello")})
+
+	messages := rt.Messages()
+	if len(messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(messages))
+	}
+	var msg struct {
+		Type   string `json:"type"`
+		ID     string `json:"id"`
+		Result struct {
+			Blob *struct {
+				ContentType string `json:"contentType"`
+				Data        []byte `json:"data"`
+			} `json:"$blob"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(messages[0], &msg); err != nil {
+		t.Fatalf("expected JSON response, got %q: %v", messages[0], err)
+	}
+	if msg.Type != "response" || msg.ID != "req-1" {
+		t.Fatalf("unexpected envelope: %+v", msg)
+	}
+	if msg.Result.Blob == nil {
+		t.Fatalf("result missing $blob marker: %s", messages[0])
+	}
+	if msg.Result.Blob.ContentType != "text/plain" || string(msg.Result.Blob.Data) != "hello" {
+		t.Fatalf("unexpected $blob payload: %+v", msg.Result.Blob)
+	}
+}
+
 func TestSendResponseBlobUsesBinaryFrameWhenSupported(t *testing.T) {
 	rt := &recordingTransport{}
 	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}

--- a/connection.go
+++ b/connection.go
@@ -322,7 +322,8 @@ func (c *Conn) sendJSONCtx(ctx context.Context, v any) error {
 }
 
 func (c *Conn) sendResponse(id string, result any) {
-	if c.sendBinaryResponse(id, result) {
+	if blob, ok := asBlob(result); ok {
+		c.sendBlobResponse(id, blob)
 		return
 	}
 	msg := ResponseMessage{
@@ -340,20 +341,46 @@ func (c *Conn) sendResponse(id string, result any) {
 	_ = c.sendRaw(data)
 }
 
-func (c *Conn) sendBinaryResponse(id string, result any) bool {
-	var blob Blob
+// asBlob reports whether a handler result opts into binary delivery. Only the
+// explicit Blob type does; a plain []byte keeps its JSON base64 encoding so
+// existing handlers are unaffected. A nil *Blob is not a blob — it falls
+// through to the JSON path and reaches the client as a null result, matching
+// every other nil pointer result.
+func asBlob(result any) (Blob, bool) {
 	switch v := result.(type) {
 	case Blob:
-		blob = v
+		return v, true
 	case *Blob:
 		if v == nil {
-			return false
+			return Blob{}, false
 		}
-		blob = *v
-	case []byte:
-		blob = Blob{Data: v}
-	default:
-		return false
+		return *v, true
+	}
+	return Blob{}, false
+}
+
+// blobFallbackResult is the JSON representation of a Blob result on transports
+// without binary frames (SSE, stream). The $blob marker lets the client
+// convert it back into the same Blob value the binary path delivers, so the
+// client-visible result type does not depend on the transport.
+type blobFallbackResult struct {
+	Blob Blob `json:"$blob"`
+}
+
+func (c *Conn) sendBlobResponse(id string, blob Blob) {
+	if !c.transport.SupportsBinary() {
+		msg := ResponseMessage{
+			Type:   TypeResponse,
+			ID:     id,
+			Result: blobFallbackResult{Blob: blob},
+		}
+		data, err := marshalJSON(msg)
+		if err != nil {
+			c.sendError(id, CodeInternalError, "failed to encode response: "+err.Error())
+			return
+		}
+		_ = c.sendRaw(data)
+		return
 	}
 	frame, err := encodeBinaryFrame(binaryFrameHeader{
 		Type:        "response",
@@ -362,14 +389,11 @@ func (c *Conn) sendBinaryResponse(id string, result any) bool {
 	}, blob.Data)
 	if err != nil {
 		c.sendError(id, CodeInternalError, "failed to encode binary response: "+err.Error())
-		return true
+		return
 	}
-	if err := c.transport.SendBinary(frame); err != nil {
-		// Transports without binary support (SSE, stream) retain the previous JSON
-		// behavior, which encodes []byte as base64 and Blob as a JSON object.
-		return false
-	}
-	return true
+	// Send failures mean the connection is going away; match the JSON path,
+	// which discards sendRaw errors for the same reason.
+	_ = c.transport.SendBinary(frame)
 }
 
 // errorCode maps a handler error to the protocol code that sendError /

--- a/connection.go
+++ b/connection.go
@@ -322,6 +322,9 @@ func (c *Conn) sendJSONCtx(ctx context.Context, v any) error {
 }
 
 func (c *Conn) sendResponse(id string, result any) {
+	if c.sendBinaryResponse(id, result) {
+		return
+	}
 	msg := ResponseMessage{
 		Type:   TypeResponse,
 		ID:     id,
@@ -335,6 +338,38 @@ func (c *Conn) sendResponse(id string, result any) {
 		return
 	}
 	_ = c.sendRaw(data)
+}
+
+func (c *Conn) sendBinaryResponse(id string, result any) bool {
+	var blob Blob
+	switch v := result.(type) {
+	case Blob:
+		blob = v
+	case *Blob:
+		if v == nil {
+			return false
+		}
+		blob = *v
+	case []byte:
+		blob = Blob{Data: v}
+	default:
+		return false
+	}
+	frame, err := encodeBinaryFrame(binaryFrameHeader{
+		Type:        "response",
+		ID:          id,
+		ContentType: blob.ContentType,
+	}, blob.Data)
+	if err != nil {
+		c.sendError(id, CodeInternalError, "failed to encode binary response: "+err.Error())
+		return true
+	}
+	if err := c.transport.SendBinary(frame); err != nil {
+		// Transports without binary support (SSE, stream) retain the previous JSON
+		// behavior, which encodes []byte as base64 and Blob as a JSON object.
+		return false
+	}
+	return true
 }
 
 // errorCode maps a handler error to the protocol code that sendError /

--- a/doc.go
+++ b/doc.go
@@ -72,6 +72,29 @@
 // one frame per item. Batching is transparent to the generated client's
 // AsyncIterable but requires a client generated from the same aprot version.
 //
+// # Binary Blob Responses
+//
+// Returning [Blob] (or *Blob) from a unary handler opts the result into
+// binary delivery:
+//
+//	func (h *FileHandlers) GetAvatar(ctx context.Context, userID string) (aprot.Blob, error) {
+//	    return aprot.Blob{ContentType: "image/png", Data: pngBytes}, nil
+//	}
+//
+// The generated client method is typed Promise<Blob> and resolves a DOM Blob.
+// Over WebSocket the payload is sent as a binary frame (4-byte big-endian
+// header length, JSON header, raw payload — no base64 inflation). Transports
+// without binary frames (SSE, byte-stream) fall back to a JSON envelope whose
+// result is {"$blob": {contentType, data}} with base64 data; the generated
+// client converts it back into a DOM Blob, so the resolved type is identical
+// on every transport. Server-driven subscription refreshes deliver Blobs the
+// same way.
+//
+// Only the explicit Blob type opts in, and only as a top-level result: a
+// plain []byte result keeps its base64 string encoding, and a Blob nested in
+// another struct, streamed as an item, or used as a parameter travels as
+// ordinary JSON ({contentType?, data}).
+//
 // # Input Transformation
 //
 // Request struct fields can be normalized before handler dispatch using
@@ -748,6 +771,9 @@
 //     int, int64, int32, int16, float64, bool, time.Time); other
 //     instantiations fall back to the {"V":…,"Valid":…} object shape.
 //   - json.RawMessage → unknown
+//   - Blob as a top-level result → DOM Blob (binary delivery; see Binary
+//     Blob Responses); nested/streamed Blob → { contentType?: string;
+//     data: string }
 //   - struct → interface
 //   - Registered enum → const object + union type
 //

--- a/e2e/e2eapi/handlers.go
+++ b/e2e/e2eapi/handlers.go
@@ -8,6 +8,7 @@ package e2eapi
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"github.com/marrasen/aprot"
 )
@@ -78,6 +79,42 @@ func (h *FixedArrayHandlers) EchoArrays(ctx context.Context, req *FixedArrayPayl
 	return req, nil
 }
 
+// BlobHandlers exercises binary Blob responses (#238). A top-level Blob
+// result crosses the wire as a WebSocket binary frame, or as the $blob JSON
+// fallback on transports without binary frames (SSE); generated clients must
+// resolve a DOM Blob either way — including for subscription refreshes.
+type BlobHandlers struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+// NewBlobHandlers seeds a payload with non-UTF-8 bytes so the tests catch
+// any encoding corruption on either the binary or the base64 fallback path.
+func NewBlobHandlers() *BlobHandlers {
+	return &BlobHandlers{data: []byte{0x00, 0x01, 0xfe, 0xff, 'v', '1'}}
+}
+
+// GetBlob returns the current payload and subscribes callers to SetBlob
+// refreshes via the "blob" trigger key.
+func (h *BlobHandlers) GetBlob(ctx context.Context) (aprot.Blob, error) {
+	aprot.RegisterRefreshTrigger(ctx, "blob")
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return aprot.Blob{
+		ContentType: "application/x-e2e",
+		Data:        append([]byte(nil), h.data...),
+	}, nil
+}
+
+// SetBlob replaces the payload and refreshes every GetBlob subscriber.
+func (h *BlobHandlers) SetBlob(ctx context.Context, data string) error {
+	h.mu.Lock()
+	h.data = []byte(data)
+	h.mu.Unlock()
+	aprot.TriggerRefresh(ctx, "blob")
+	return nil
+}
+
 // Register wires the e2e-only REST and validation handlers onto an existing
 // registry and turns on request validation. Existing handlers without validate
 // tags are unaffected (validation is a no-op for them).
@@ -85,5 +122,6 @@ func Register(registry *aprot.Registry) {
 	registry.RegisterREST(&EchoHandlers{})
 	registry.Register(&SignupHandlers{})
 	registry.Register(&FixedArrayHandlers{})
+	registry.Register(NewBlobHandlers())
 	registry.SetValidator(aprot.NewPlaygroundValidator())
 }

--- a/e2e/tests/blob.test.ts
+++ b/e2e/tests/blob.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { wsUrl, sseUrl } from './helpers';
+import { ApiClient } from '../api/client';
+import { getBlob, setBlob, subscribeGetBlob } from '../api/blob-handlers';
+
+// The server seeds the payload with non-UTF-8 bytes (see e2eapi.NewBlobHandlers)
+// so both the binary frame and the base64 fallback paths must round-trip them.
+const SEED = new Uint8Array([0x00, 0x01, 0xfe, 0xff, 0x76, 0x31]); // ...'v1'
+
+async function bytesOf(blob: Blob): Promise<Uint8Array> {
+    return new Uint8Array(await blob.arrayBuffer());
+}
+
+describe('Blob responses over WebSocket (binary frames)', () => {
+    let client: ApiClient;
+
+    beforeEach(async () => {
+        client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+    });
+
+    afterEach(() => {
+        client.disconnect();
+    });
+
+    test('getBlob resolves a DOM Blob with contentType and exact bytes', async () => {
+        const blob = await getBlob(client);
+        expect(blob).toBeInstanceOf(Blob);
+        expect(blob.type).toBe('application/x-e2e');
+        expect(await bytesOf(blob)).toEqual(SEED);
+    });
+
+    test('subscription refresh delivers a Blob to the callback', async () => {
+        // Initial subscription result must be a Blob.
+        const initial = await new Promise<Blob>((resolve) => {
+            subscribeGetBlob(client, (data) => resolve(data));
+        });
+        expect(initial).toBeInstanceOf(Blob);
+
+        // Mutate — the server fires TriggerRefresh("blob") and the refreshed
+        // payload must arrive through the same subscription, still as a Blob.
+        const marker = `ws-refresh-${Date.now()}`;
+        const refreshed = await new Promise<Blob>((resolve) => {
+            subscribeGetBlob(client, (data) => {
+                void (async () => {
+                    const text = new TextDecoder().decode(await bytesOf(data));
+                    if (text === marker) resolve(data);
+                })();
+            });
+            void setBlob(client, marker);
+        });
+
+        expect(refreshed).toBeInstanceOf(Blob);
+        expect(refreshed.type).toBe('application/x-e2e');
+    });
+});
+
+describe('Blob responses over SSE ($blob JSON fallback)', () => {
+    let client: ApiClient;
+
+    beforeEach(async () => {
+        client = new ApiClient(sseUrl(), { transport: 'sse', reconnect: false });
+        await client.connect();
+    });
+
+    afterEach(() => {
+        client.disconnect();
+    });
+
+    test('getBlob resolves a DOM Blob with contentType and exact bytes', async () => {
+        const marker = `sse-bytes-${Date.now()}`;
+        await setBlob(client, marker);
+        const blob = await getBlob(client);
+        expect(blob).toBeInstanceOf(Blob);
+        expect(blob.type).toBe('application/x-e2e');
+        expect(new TextDecoder().decode(await bytesOf(blob))).toBe(marker);
+    });
+
+    test('subscription refresh delivers a Blob to the callback', async () => {
+        const initial = await new Promise<Blob>((resolve) => {
+            subscribeGetBlob(client, (data) => resolve(data));
+        });
+        expect(initial).toBeInstanceOf(Blob);
+
+        const marker = `sse-refresh-${Date.now()}`;
+        const refreshed = await new Promise<Blob>((resolve) => {
+            subscribeGetBlob(client, (data) => {
+                void (async () => {
+                    const text = new TextDecoder().decode(await bytesOf(data));
+                    if (text === marker) resolve(data);
+                })();
+            });
+            void setBlob(client, marker);
+        });
+
+        expect(refreshed).toBeInstanceOf(Blob);
+        expect(refreshed.type).toBe('application/x-e2e');
+    });
+});

--- a/errors.go
+++ b/errors.go
@@ -111,4 +111,6 @@ var (
 	ErrConnectionClosed = &CancelReason{"connection closed"}
 	// ErrServerShutdown indicates the server is shutting down.
 	ErrServerShutdown = &CancelReason{"server shutdown"}
+	// ErrBinaryUnsupported indicates the transport cannot send binary frames.
+	ErrBinaryUnsupported = fmt.Errorf("binary frames unsupported")
 )

--- a/errors.go
+++ b/errors.go
@@ -111,6 +111,4 @@ var (
 	ErrConnectionClosed = &CancelReason{"connection closed"}
 	// ErrServerShutdown indicates the server is shutting down.
 	ErrServerShutdown = &CancelReason{"server shutdown"}
-	// ErrBinaryUnsupported indicates the transport cannot send binary frames.
-	ErrBinaryUnsupported = fmt.Errorf("binary frames unsupported")
 )

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -77,6 +77,28 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+// Shared decoder for binary frame headers — small and reused per message.
+const binaryHeaderDecoder = new TextDecoder();
+
+// decodeBlobResult converts the server's JSON fallback for a Blob result —
+// an object whose only key is "$blob" carrying { contentType?, data(base64) } —
+// into a DOM Blob, so callers see the same type the binary path delivers.
+// Any other result value passes through untouched.
+function decodeBlobResult(result: unknown): unknown {
+    if (
+        result === null || typeof result !== 'object' || Array.isArray(result)
+        || !('$blob' in result) || Object.keys(result).length !== 1
+    ) {
+        return result;
+    }
+    const b = (result as { $blob: { contentType?: string; data?: string } }).$blob;
+    if (b === null || typeof b !== 'object') return result;
+    const bin = atob(b.data ?? '');
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return new Blob([bytes], b.contentType ? { type: b.contentType } : undefined);
+}
+
 // ConnectionErrorReason classifies why a connection failed or could not be
 // used. Browsers deliberately collapse most pre-WebSocket-upgrade failures
 // (DNS, TCP refused, TLS handshake, HTTP 4xx during upgrade) into close
@@ -189,7 +211,7 @@ export interface TransportCloseInfo {
  *   must be reusable after disconnect()/onClose.
  */
 export interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -265,7 +287,7 @@ export function getSSEUrl(path: string = '/sse'): string {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve, reject) => {
             // Detach and close previous socket so its deferred onclose
             // cannot interfere with the new connection (mobile wake race).
@@ -278,6 +300,7 @@ class WebSocketTransport implements ClientTransport {
             }
             let opened = false;
             this.ws = new WebSocket(url);
+            this.ws.binaryType = 'arraybuffer';
             this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
@@ -327,7 +350,7 @@ class SSETransport implements ClientTransport {
     private baseUrl: string = '';
     private onMessage: ((data: string) => void) | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
         this.onMessage = onMessage;
 
@@ -942,7 +965,11 @@ export class ApiClient {
         }
     }
 
-    private handleMessage(data: string): void {
+    private handleMessage(data: string | Blob | ArrayBuffer): void {
+        if (typeof data !== 'string') {
+            this.handleBinaryMessage(data);
+            return;
+        }
         const msg = JSON.parse(data);
         switch (msg.type) {
             case 'config':
@@ -961,19 +988,7 @@ export class ApiClient {
                 break;
             }
             case 'response': {
-                const p = this.pending.get(msg.id);
-                if (p) {
-                    this.pending.delete(msg.id);
-                    p.onSettle?.();
-                    p.resolve(msg.result);
-                    this.notifyLoadingChange();
-                } else {
-                    // Server-driven subscription refresh
-                    const sub = this.subscriptions.get(msg.id);
-                    if (sub) {
-                        sub.callback(msg.result);
-                    }
-                }
+                this.settleResponse(msg.id, decodeBlobResult(msg.result));
                 break;
             }
             case 'error': {
@@ -1062,6 +1077,64 @@ export class ApiClient {
                 break;
             }
         }
+    }
+
+    /**
+     * Delivers a result for `id`: settles the pending request if there is
+     * one, otherwise dispatches to the matching server-driven subscription.
+     * Both the JSON `response` envelope and binary frames end here, so the
+     * two paths cannot drift apart.
+     */
+    private settleResponse(id: string, result: unknown): void {
+        const p = this.pending.get(id);
+        if (p) {
+            this.pending.delete(id);
+            p.onSettle?.();
+            p.resolve(result);
+            this.notifyLoadingChange();
+        } else {
+            // Server-driven subscription refresh
+            const sub = this.subscriptions.get(id);
+            if (sub) {
+                sub.callback(result);
+            }
+        }
+    }
+
+    private rejectResponse(id: string, error: Error): void {
+        const p = this.pending.get(id);
+        if (p) {
+            this.pending.delete(id);
+            p.onSettle?.();
+            p.reject(error);
+            this.notifyLoadingChange();
+        } else {
+            const sub = this.subscriptions.get(id);
+            if (sub) {
+                sub.onError?.(error);
+            }
+        }
+    }
+
+    private async handleBinaryMessage(data: Blob | ArrayBuffer): Promise<void> {
+        const buffer = data instanceof ArrayBuffer ? data : await data.arrayBuffer();
+        const view = new DataView(buffer);
+        const headerLen = view.getUint32(0, false);
+        const headerBytes = new Uint8Array(buffer, 4, headerLen);
+        const header = JSON.parse(binaryHeaderDecoder.decode(headerBytes));
+        if (header.version !== 1 || header.type !== 'response') {
+            // Unknown frame: reject rather than drop, so the awaiting caller
+            // fails fast instead of hanging until the connection closes.
+            this.rejectResponse(header.id, new ApiError(
+                ErrorCode.InternalError,
+                `unsupported binary frame (version ${header.version}, type ${header.type})`,
+            ));
+            return;
+        }
+        // Zero-copy view into the received buffer; Blob copies on read.
+        const payload = new Uint8Array(buffer, 4 + headerLen);
+        const blob = new Blob([payload], header.contentType ? { type: header.contentType } : undefined);
+        this.settleResponse(header.id, blob);
     }
 
     private applyConfig(config: {

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -70,6 +70,28 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+// Shared decoder for binary frame headers — small and reused per message.
+const binaryHeaderDecoder = new TextDecoder();
+
+// decodeBlobResult converts the server's JSON fallback for a Blob result —
+// an object whose only key is "$blob" carrying { contentType?, data(base64) } —
+// into a DOM Blob, so callers see the same type the binary path delivers.
+// Any other result value passes through untouched.
+function decodeBlobResult(result: unknown): unknown {
+    if (
+        result === null || typeof result !== 'object' || Array.isArray(result)
+        || !('$blob' in result) || Object.keys(result).length !== 1
+    ) {
+        return result;
+    }
+    const b = (result as { $blob: { contentType?: string; data?: string } }).$blob;
+    if (b === null || typeof b !== 'object') return result;
+    const bin = atob(b.data ?? '');
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return new Blob([bytes], b.contentType ? { type: b.contentType } : undefined);
+}
+
 // ConnectionErrorReason classifies why a connection failed or could not be
 // used. Browsers deliberately collapse most pre-WebSocket-upgrade failures
 // (DNS, TCP refused, TLS handshake, HTTP 4xx during upgrade) into close
@@ -182,7 +204,7 @@ export interface TransportCloseInfo {
  *   must be reusable after disconnect()/onClose.
  */
 export interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -258,7 +280,7 @@ export function getSSEUrl(path: string = '/sse'): string {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve, reject) => {
             // Detach and close previous socket so its deferred onclose
             // cannot interfere with the new connection (mobile wake race).
@@ -271,6 +293,7 @@ class WebSocketTransport implements ClientTransport {
             }
             let opened = false;
             this.ws = new WebSocket(url);
+            this.ws.binaryType = 'arraybuffer';
             this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
@@ -320,7 +343,7 @@ class SSETransport implements ClientTransport {
     private baseUrl: string = '';
     private onMessage: ((data: string) => void) | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
         this.onMessage = onMessage;
 
@@ -935,7 +958,11 @@ export class ApiClient {
         }
     }
 
-    private handleMessage(data: string): void {
+    private handleMessage(data: string | Blob | ArrayBuffer): void {
+        if (typeof data !== 'string') {
+            this.handleBinaryMessage(data);
+            return;
+        }
         const msg = JSON.parse(data);
         switch (msg.type) {
             case 'config':
@@ -954,19 +981,7 @@ export class ApiClient {
                 break;
             }
             case 'response': {
-                const p = this.pending.get(msg.id);
-                if (p) {
-                    this.pending.delete(msg.id);
-                    p.onSettle?.();
-                    p.resolve(msg.result);
-                    this.notifyLoadingChange();
-                } else {
-                    // Server-driven subscription refresh
-                    const sub = this.subscriptions.get(msg.id);
-                    if (sub) {
-                        sub.callback(msg.result);
-                    }
-                }
+                this.settleResponse(msg.id, decodeBlobResult(msg.result));
                 break;
             }
             case 'error': {
@@ -1055,6 +1070,64 @@ export class ApiClient {
                 break;
             }
         }
+    }
+
+    /**
+     * Delivers a result for `id`: settles the pending request if there is
+     * one, otherwise dispatches to the matching server-driven subscription.
+     * Both the JSON `response` envelope and binary frames end here, so the
+     * two paths cannot drift apart.
+     */
+    private settleResponse(id: string, result: unknown): void {
+        const p = this.pending.get(id);
+        if (p) {
+            this.pending.delete(id);
+            p.onSettle?.();
+            p.resolve(result);
+            this.notifyLoadingChange();
+        } else {
+            // Server-driven subscription refresh
+            const sub = this.subscriptions.get(id);
+            if (sub) {
+                sub.callback(result);
+            }
+        }
+    }
+
+    private rejectResponse(id: string, error: Error): void {
+        const p = this.pending.get(id);
+        if (p) {
+            this.pending.delete(id);
+            p.onSettle?.();
+            p.reject(error);
+            this.notifyLoadingChange();
+        } else {
+            const sub = this.subscriptions.get(id);
+            if (sub) {
+                sub.onError?.(error);
+            }
+        }
+    }
+
+    private async handleBinaryMessage(data: Blob | ArrayBuffer): Promise<void> {
+        const buffer = data instanceof ArrayBuffer ? data : await data.arrayBuffer();
+        const view = new DataView(buffer);
+        const headerLen = view.getUint32(0, false);
+        const headerBytes = new Uint8Array(buffer, 4, headerLen);
+        const header = JSON.parse(binaryHeaderDecoder.decode(headerBytes));
+        if (header.version !== 1 || header.type !== 'response') {
+            // Unknown frame: reject rather than drop, so the awaiting caller
+            // fails fast instead of hanging until the connection closes.
+            this.rejectResponse(header.id, new ApiError(
+                ErrorCode.InternalError,
+                `unsupported binary frame (version ${header.version}, type ${header.type})`,
+            ));
+            return;
+        }
+        // Zero-copy view into the received buffer; Blob copies on read.
+        const payload = new Uint8Array(buffer, 4 + headerLen);
+        const blob = new Blob([payload], header.contentType ? { type: header.contentType } : undefined);
+        this.settleResponse(header.id, blob);
     }
 
     private applyConfig(config: {

--- a/generate.go
+++ b/generate.go
@@ -951,6 +951,10 @@ func (g *Generator) buildMethodData(info *HandlerInfo, wireMethod, shortName str
 		respType = "void"
 	case isStream, isStream2:
 		respType = g.goTypeToTS(info.ResponseType)
+	case isBlobResponse(info.ResponseType):
+		// Top-level Blob results are delivered as binary frames (or the $blob
+		// JSON fallback) and always reach the caller as a DOM Blob.
+		respType = "Blob"
 	default:
 		respType = g.goTypeToTS(info.ResponseType)
 	}
@@ -1446,6 +1450,12 @@ func (g *Generator) collectType(t reflect.Type) {
 	if t == nil || t == voidResponseType {
 		return
 	}
+	// Blob is never emitted as an interface: top-level results are typed as
+	// the DOM Blob (which an interface of the same name would shadow), and
+	// nested occurrences use the inline wire shape from goTypeToTS.
+	if t == blobType {
+		return
+	}
 	if _, ok := g.types[t]; ok {
 		return
 	}
@@ -1791,6 +1801,12 @@ func (g *Generator) goTypeToTS(t reflect.Type) string {
 	// number[] (the named-byte-slice default) is wrong. Type it as `unknown`.
 	if t.PkgPath() == "encoding/json" && t.Name() == "RawMessage" {
 		return "unknown"
+	}
+
+	// Blob outside a top-level result position travels as plain JSON.
+	// buildMethodData overrides top-level unary results to the DOM Blob.
+	if t == blobType {
+		return blobTSWireShape
 	}
 
 	switch t.Kind() {

--- a/generate_test.go
+++ b/generate_test.go
@@ -782,6 +782,62 @@ func TestVoidHandlerCallError(t *testing.T) {
 	}
 }
 
+type BlobHandlers struct{}
+
+func (h *BlobHandlers) GetAvatar(ctx context.Context) (Blob, error) {
+	return Blob{ContentType: "image/png", Data: []byte{1}}, nil
+}
+
+func (h *BlobHandlers) GetReport(ctx context.Context) (*Blob, error) {
+	return &Blob{ContentType: "application/pdf"}, nil
+}
+
+// BlobFieldStruct nests a Blob inside a regular result; nested blobs stay in
+// their JSON wire shape because only top-level Blob results use binary frames.
+type BlobFieldStruct struct {
+	Attachment Blob   `json:"attachment"`
+	Name       string `json:"name"`
+}
+
+func (h *BlobHandlers) GetDocument(ctx context.Context) (BlobFieldStruct, error) {
+	return BlobFieldStruct{}, nil
+}
+
+func TestGenerateBlobResponse(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&BlobHandlers{})
+
+	gen := NewGenerator(registry)
+
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	output := buf.String()
+
+	// Top-level Blob results resolve to a DOM Blob at runtime, so the method
+	// must be typed Promise<Blob> — for both value and pointer returns.
+	if !strings.Contains(output, "getAvatar(client: ApiClient, options?: RequestOptions): Promise<Blob>") {
+		t.Error("GetAvatar should be typed Promise<Blob>")
+	}
+	if !strings.Contains(output, "getReport(client: ApiClient, options?: RequestOptions): Promise<Blob>") {
+		t.Error("GetReport (*Blob) should be typed Promise<Blob>")
+	}
+
+	// The DOM Blob type must not be shadowed by a generated interface.
+	if strings.Contains(output, "export interface Blob {") {
+		t.Error("Should not generate an interface named Blob (shadows the DOM Blob type)")
+	}
+
+	// A Blob nested in another struct is delivered as JSON, so its field keeps
+	// the honest wire shape instead of claiming to be a DOM Blob.
+	if !strings.Contains(output, "attachment: { contentType?: string; data: string }") {
+		t.Error("Nested Blob field should map to its JSON wire shape")
+	}
+
+	t.Logf("Generated TypeScript (blob):\n%s", output)
+}
+
 func TestGenerateVoidResponse(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&VoidHandlers{})

--- a/observer_test.go
+++ b/observer_test.go
@@ -331,14 +331,14 @@ func TestObserver_SendBufferFull(t *testing.T) {
 	t.Cleanup(func() { _ = server.Stop(context.Background()) })
 
 	tr := &wsTransport{
-		send: make(chan []byte, 256),
+		send: make(chan outboundFrame, 256),
 		done: make(chan struct{}),
 	}
 	tr.conn = &Conn{server: server, transport: tr, id: 1}
 
 	// Fill the buffer so the next enqueue must report backpressure.
 	for i := 0; i < 256; i++ {
-		tr.send <- nil
+		tr.send <- outboundFrame{}
 	}
 
 	sent := make(chan error, 1)

--- a/protocol.go
+++ b/protocol.go
@@ -2,6 +2,8 @@ package aprot
 
 import "github.com/go-json-experiment/json/jsontext"
 
+const binaryFrameVersion byte = 1
+
 // MessageType represents the type of protocol message.
 type MessageType string
 
@@ -57,6 +59,13 @@ type ResponseMessage struct {
 	Type   MessageType `json:"type"`
 	ID     string      `json:"id"`
 	Result any         `json:"result"`
+}
+
+type binaryFrameHeader struct {
+	Version     byte   `json:"version"`
+	Type        string `json:"type"`
+	ID          string `json:"id"`
+	ContentType string `json:"contentType,omitempty"`
 }
 
 // ErrorMessage represents an error response from server to client.

--- a/stream_test.go
+++ b/stream_test.go
@@ -307,8 +307,12 @@ func (f *failAfterN) Send(data []byte) error {
 	return nil
 }
 func (f *failAfterN) SendCtx(ctx context.Context, data []byte) error { return f.Send(data) }
-func (f *failAfterN) Close() error                                   { return nil }
-func (f *failAfterN) CloseGracefully() error                         { return nil }
+func (f *failAfterN) SendBinary(data []byte) error                   { return f.Send(data) }
+func (f *failAfterN) SendBinaryCtx(ctx context.Context, data []byte) error {
+	return f.SendBinary(data)
+}
+func (f *failAfterN) Close() error           { return nil }
+func (f *failAfterN) CloseGracefully() error { return nil }
 
 func TestStreamIterator_TransportCloseDuringSend(t *testing.T) {
 	r := NewRegistry()

--- a/stream_test.go
+++ b/stream_test.go
@@ -307,6 +307,7 @@ func (f *failAfterN) Send(data []byte) error {
 	return nil
 }
 func (f *failAfterN) SendCtx(ctx context.Context, data []byte) error { return f.Send(data) }
+func (f *failAfterN) SupportsBinary() bool                           { return true }
 func (f *failAfterN) SendBinary(data []byte) error                   { return f.Send(data) }
 func (f *failAfterN) SendBinaryCtx(ctx context.Context, data []byte) error {
 	return f.SendBinary(data)

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -296,14 +296,13 @@ func (m *mockTransport) SendCtx(ctx context.Context, data []byte) error {
 	}
 	return m.Send(data)
 }
+func (m *mockTransport) SupportsBinary() bool { return true }
 func (m *mockTransport) SendBinary(data []byte) error {
 	return m.Send(data)
 }
 func (m *mockTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
-	if ctx != nil {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return m.SendBinary(data)
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -296,5 +296,16 @@ func (m *mockTransport) SendCtx(ctx context.Context, data []byte) error {
 	}
 	return m.Send(data)
 }
+func (m *mockTransport) SendBinary(data []byte) error {
+	return m.Send(data)
+}
+func (m *mockTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	return m.SendBinary(data)
+}
 func (m *mockTransport) Close() error           { return nil }
 func (m *mockTransport) CloseGracefully() error { return nil }

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -188,7 +188,7 @@ export interface TransportCloseInfo {
  *   must be reusable after disconnect()/onClose.
  */
 export interface ClientTransport {
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void>;
     send(message: object): void;
     disconnect(): void;
     isConnected(): boolean;
@@ -264,7 +264,7 @@ export function getSSEUrl(path: string = '/sse'): string {
 class WebSocketTransport implements ClientTransport {
     private ws: WebSocket | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         return new Promise((resolve, reject) => {
             // Detach and close previous socket so its deferred onclose
             // cannot interfere with the new connection (mobile wake race).
@@ -277,6 +277,7 @@ class WebSocketTransport implements ClientTransport {
             }
             let opened = false;
             this.ws = new WebSocket(url);
+            this.ws.binaryType = 'arraybuffer';
             this.ws.onopen = () => { opened = true; resolve(); };
             this.ws.onerror = () => {}; // Error is followed by close
             this.ws.onmessage = (e) => onMessage(e.data);
@@ -326,7 +327,7 @@ class SSETransport implements ClientTransport {
     private baseUrl: string = '';
     private onMessage: ((data: string) => void) | null = null;
 
-    connect(url: string, onMessage: (data: string) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
+    connect(url: string, onMessage: (data: string | Blob | ArrayBuffer) => void, onClose: (info?: TransportCloseInfo) => void): Promise<void> {
         this.baseUrl = url;
         this.onMessage = onMessage;
 
@@ -941,7 +942,11 @@ export class ApiClient {
         }
     }
 
-    private handleMessage(data: string): void {
+    private handleMessage(data: string | Blob | ArrayBuffer): void {
+        if (typeof data !== 'string') {
+            this.handleBinaryMessage(data);
+            return;
+        }
         const msg = JSON.parse(data);
         switch (msg.type) {
             case 'config':
@@ -1060,6 +1065,24 @@ export class ApiClient {
                 }
                 break;
             }
+        }
+    }
+
+    private async handleBinaryMessage(data: Blob | ArrayBuffer): Promise<void> {
+        const buffer = data instanceof ArrayBuffer ? data : await data.arrayBuffer();
+        const view = new DataView(buffer);
+        const headerLen = view.getUint32(0, false);
+        const headerBytes = new Uint8Array(buffer, 4, headerLen);
+        const header = JSON.parse(new TextDecoder().decode(headerBytes));
+        if (header.version !== 1 || header.type !== 'response') return;
+        const payload = buffer.slice(4 + headerLen);
+        const blob = new Blob([payload], header.contentType ? { type: header.contentType } : undefined);
+        const p = this.pending.get(header.id);
+        if (p) {
+            this.pending.delete(header.id);
+            p.onSettle?.();
+            p.resolve(blob);
+            this.notifyLoadingChange();
         }
     }
 

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -76,6 +76,28 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+// Shared decoder for binary frame headers — small and reused per message.
+const binaryHeaderDecoder = new TextDecoder();
+
+// decodeBlobResult converts the server's JSON fallback for a Blob result —
+// an object whose only key is "$blob" carrying { contentType?, data(base64) } —
+// into a DOM Blob, so callers see the same type the binary path delivers.
+// Any other result value passes through untouched.
+function decodeBlobResult(result: unknown): unknown {
+    if (
+        result === null || typeof result !== 'object' || Array.isArray(result)
+        || !('$blob' in result) || Object.keys(result).length !== 1
+    ) {
+        return result;
+    }
+    const b = (result as { $blob: { contentType?: string; data?: string } }).$blob;
+    if (b === null || typeof b !== 'object') return result;
+    const bin = atob(b.data ?? '');
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return new Blob([bytes], b.contentType ? { type: b.contentType } : undefined);
+}
+
 // ConnectionErrorReason classifies why a connection failed or could not be
 // used. Browsers deliberately collapse most pre-WebSocket-upgrade failures
 // (DNS, TCP refused, TLS handshake, HTTP 4xx during upgrade) into close
@@ -965,19 +987,7 @@ export class ApiClient {
                 break;
             }
             case 'response': {
-                const p = this.pending.get(msg.id);
-                if (p) {
-                    this.pending.delete(msg.id);
-                    p.onSettle?.();
-                    p.resolve(msg.result);
-                    this.notifyLoadingChange();
-                } else {
-                    // Server-driven subscription refresh
-                    const sub = this.subscriptions.get(msg.id);
-                    if (sub) {
-                        sub.callback(msg.result);
-                    }
-                }
+                this.settleResponse(msg.id, decodeBlobResult(msg.result));
                 break;
             }
             case 'error': {
@@ -1068,22 +1078,62 @@ export class ApiClient {
         }
     }
 
+    /**
+     * Delivers a result for `id`: settles the pending request if there is
+     * one, otherwise dispatches to the matching server-driven subscription.
+     * Both the JSON `response` envelope and binary frames end here, so the
+     * two paths cannot drift apart.
+     */
+    private settleResponse(id: string, result: unknown): void {
+        const p = this.pending.get(id);
+        if (p) {
+            this.pending.delete(id);
+            p.onSettle?.();
+            p.resolve(result);
+            this.notifyLoadingChange();
+        } else {
+            // Server-driven subscription refresh
+            const sub = this.subscriptions.get(id);
+            if (sub) {
+                sub.callback(result);
+            }
+        }
+    }
+
+    private rejectResponse(id: string, error: Error): void {
+        const p = this.pending.get(id);
+        if (p) {
+            this.pending.delete(id);
+            p.onSettle?.();
+            p.reject(error);
+            this.notifyLoadingChange();
+        } else {
+            const sub = this.subscriptions.get(id);
+            if (sub) {
+                sub.onError?.(error);
+            }
+        }
+    }
+
     private async handleBinaryMessage(data: Blob | ArrayBuffer): Promise<void> {
         const buffer = data instanceof ArrayBuffer ? data : await data.arrayBuffer();
         const view = new DataView(buffer);
         const headerLen = view.getUint32(0, false);
         const headerBytes = new Uint8Array(buffer, 4, headerLen);
-        const header = JSON.parse(new TextDecoder().decode(headerBytes));
-        if (header.version !== 1 || header.type !== 'response') return;
-        const payload = buffer.slice(4 + headerLen);
-        const blob = new Blob([payload], header.contentType ? { type: header.contentType } : undefined);
-        const p = this.pending.get(header.id);
-        if (p) {
-            this.pending.delete(header.id);
-            p.onSettle?.();
-            p.resolve(blob);
-            this.notifyLoadingChange();
+        const header = JSON.parse(binaryHeaderDecoder.decode(headerBytes));
+        if (header.version !== 1 || header.type !== 'response') {
+            // Unknown frame: reject rather than drop, so the awaiting caller
+            // fails fast instead of hanging until the connection closes.
+            this.rejectResponse(header.id, new ApiError(
+                ErrorCode.InternalError,
+                `unsupported binary frame (version ${header.version}, type ${header.type})`,
+            ));
+            return;
         }
+        // Zero-copy view into the received buffer; Blob copies on read.
+        const payload = new Uint8Array(buffer, 4 + headerLen);
+        const blob = new Blob([payload], header.contentType ? { type: header.contentType } : undefined);
+        this.settleResponse(header.id, blob);
     }
 
     private applyConfig(config: {

--- a/testing.go
+++ b/testing.go
@@ -36,15 +36,15 @@ func (t *recordingTransport) SendCtx(ctx context.Context, data []byte) error {
 	return t.Send(data)
 }
 
+func (t *recordingTransport) SupportsBinary() bool { return true }
+
 func (t *recordingTransport) SendBinary(data []byte) error {
 	return t.Send(data)
 }
 
 func (t *recordingTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
-	if ctx != nil {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return t.SendBinary(data)
 }

--- a/testing.go
+++ b/testing.go
@@ -36,6 +36,19 @@ func (t *recordingTransport) SendCtx(ctx context.Context, data []byte) error {
 	return t.Send(data)
 }
 
+func (t *recordingTransport) SendBinary(data []byte) error {
+	return t.Send(data)
+}
+
+func (t *recordingTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	return t.SendBinary(data)
+}
+
 func (t *recordingTransport) Close() error           { return nil }
 func (t *recordingTransport) CloseGracefully() error { return nil }
 

--- a/transport.go
+++ b/transport.go
@@ -13,6 +13,11 @@ type transport interface {
 	// for stream items where a canceled request should promptly stop yielding
 	// even if the outbound queue is full.
 	SendCtx(ctx context.Context, data []byte) error
+	// SendBinary sends one binary protocol frame when the transport supports it.
+	// Transports without a native binary channel may return ErrBinaryUnsupported.
+	SendBinary(data []byte) error
+	// SendBinaryCtx is like SendBinary but returns early if ctx is canceled.
+	SendBinaryCtx(ctx context.Context, data []byte) error
 	// Close closes the transport.
 	Close() error
 	// CloseGracefully sends a close frame (if supported) before closing.

--- a/transport.go
+++ b/transport.go
@@ -1,6 +1,9 @@
 package aprot
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // transport is the internal interface for connection I/O.
 // Both WebSocket and SSE transports implement this.
@@ -13,8 +16,12 @@ type transport interface {
 	// for stream items where a canceled request should promptly stop yielding
 	// even if the outbound queue is full.
 	SendCtx(ctx context.Context, data []byte) error
-	// SendBinary sends one binary protocol frame when the transport supports it.
-	// Transports without a native binary channel may return ErrBinaryUnsupported.
+	// SupportsBinary reports whether the transport has a native binary frame
+	// channel. Callers must check it before using SendBinary/SendBinaryCtx;
+	// binary-frame encoding is skipped entirely on transports without it.
+	SupportsBinary() bool
+	// SendBinary sends one binary protocol frame. Only valid when
+	// SupportsBinary reports true.
 	SendBinary(data []byte) error
 	// SendBinaryCtx is like SendBinary but returns early if ctx is canceled.
 	SendBinaryCtx(ctx context.Context, data []byte) error
@@ -23,3 +30,16 @@ type transport interface {
 	// CloseGracefully sends a close frame (if supported) before closing.
 	CloseGracefully() error
 }
+
+// errBinaryUnsupported is returned by SendBinary/SendBinaryCtx on transports
+// without a native binary channel. Callers avoid it by checking
+// SupportsBinary first.
+var errBinaryUnsupported = errors.New("transport does not support binary frames")
+
+// noBinary provides the binary-frame methods for transports without a native
+// binary channel. Embed it to satisfy the transport interface.
+type noBinary struct{}
+
+func (noBinary) SupportsBinary() bool                        { return false }
+func (noBinary) SendBinary([]byte) error                     { return errBinaryUnsupported }
+func (noBinary) SendBinaryCtx(context.Context, []byte) error { return errBinaryUnsupported }

--- a/transport_sse.go
+++ b/transport_sse.go
@@ -35,6 +35,17 @@ func (t *sseTransport) SendCtx(ctx context.Context, data []byte) error {
 	return t.Send(data)
 }
 
+func (t *sseTransport) SendBinary(data []byte) error {
+	return ErrBinaryUnsupported
+}
+
+func (t *sseTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return ErrBinaryUnsupported
+}
+
 func (t *sseTransport) Send(data []byte) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/transport_sse.go
+++ b/transport_sse.go
@@ -11,6 +11,7 @@ import (
 
 // sseTransport wraps an http.ResponseWriter for SSE output.
 type sseTransport struct {
+	noBinary
 	w       http.ResponseWriter
 	flusher http.Flusher
 	mu      sync.Mutex
@@ -33,17 +34,6 @@ func (t *sseTransport) SendCtx(ctx context.Context, data []byte) error {
 		}
 	}
 	return t.Send(data)
-}
-
-func (t *sseTransport) SendBinary(data []byte) error {
-	return ErrBinaryUnsupported
-}
-
-func (t *sseTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return ErrBinaryUnsupported
 }
 
 func (t *sseTransport) Send(data []byte) error {

--- a/transport_stream.go
+++ b/transport_stream.go
@@ -91,6 +91,17 @@ func (t *streamTransport) SendCtx(ctx context.Context, data []byte) error {
 	}
 }
 
+func (t *streamTransport) SendBinary(data []byte) error {
+	return ErrBinaryUnsupported
+}
+
+func (t *streamTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return ErrBinaryUnsupported
+}
+
 // reportBufferFull signals send-buffer backpressure to the observer. The
 // frame is not dropped; the caller falls back to a blocking send.
 func (t *streamTransport) reportBufferFull() {

--- a/transport_stream.go
+++ b/transport_stream.go
@@ -17,6 +17,7 @@ import (
 // net.Conn — to the aprot protocol using newline-delimited JSON framing:
 // exactly one protocol message per line, in both directions.
 type streamTransport struct {
+	noBinary
 	rw   io.ReadWriteCloser
 	send chan []byte
 	done chan struct{} // closed once to signal shutdown; makes Send a no-op
@@ -89,17 +90,6 @@ func (t *streamTransport) SendCtx(ctx context.Context, data []byte) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-}
-
-func (t *streamTransport) SendBinary(data []byte) error {
-	return ErrBinaryUnsupported
-}
-
-func (t *streamTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return ErrBinaryUnsupported
 }
 
 // reportBufferFull signals send-buffer backpressure to the observer. The

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -2,6 +2,7 @@ package aprot
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"net"
 	"os"
@@ -13,13 +14,18 @@ import (
 // wsTransport wraps a WebSocket connection as a transport.
 type wsTransport struct {
 	ws   *websocket.Conn
-	send chan []byte
+	send chan outboundFrame
 	done chan struct{} // closed once to signal shutdown; makes Send a no-op
 	opts ServerOptions // read limit, write timeout, and keepalive settings
 	// conn is a back-reference used only to report send-buffer pressure and
 	// write timeouts to the server's observer. Set after construction, before
 	// the pumps start; nil in transports created without a connection.
 	conn *Conn
+}
+
+type outboundFrame struct {
+	messageType int
+	data        []byte
 }
 
 // observer returns the server's observer via the connection back-reference, or
@@ -34,13 +40,29 @@ func (t *wsTransport) observer() Observer {
 func newWSTransport(ws *websocket.Conn, opts ServerOptions) *wsTransport {
 	return &wsTransport{
 		ws:   ws,
-		send: make(chan []byte, 256),
+		send: make(chan outboundFrame, 256),
 		done: make(chan struct{}),
 		opts: opts,
 	}
 }
 
 func (t *wsTransport) Send(data []byte) error {
+	return t.sendFrame(context.Background(), outboundFrame{messageType: websocket.TextMessage, data: data})
+}
+
+func (t *wsTransport) SendCtx(ctx context.Context, data []byte) error {
+	return t.sendFrame(ctx, outboundFrame{messageType: websocket.TextMessage, data: data})
+}
+
+func (t *wsTransport) SendBinary(data []byte) error {
+	return t.sendFrame(context.Background(), outboundFrame{messageType: websocket.BinaryMessage, data: data})
+}
+
+func (t *wsTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
+	return t.sendFrame(ctx, outboundFrame{messageType: websocket.BinaryMessage, data: data})
+}
+
+func (t *wsTransport) sendFrame(ctx context.Context, frame outboundFrame) error {
 	// Blocking send — waits for room in the 256-slot buffer. Unblocks
 	// immediately if the transport is closed. Previously this method dropped
 	// on a full buffer, which silently lost responses/progress for slow
@@ -50,24 +72,7 @@ func (t *wsTransport) Send(data []byte) error {
 	select {
 	case <-t.done:
 		return ErrConnectionClosed
-	case t.send <- data:
-		return nil
-	default:
-		t.reportBufferFull()
-	}
-	select {
-	case <-t.done:
-		return ErrConnectionClosed
-	case t.send <- data:
-		return nil
-	}
-}
-
-func (t *wsTransport) SendCtx(ctx context.Context, data []byte) error {
-	select {
-	case <-t.done:
-		return ErrConnectionClosed
-	case t.send <- data:
+	case t.send <- frame:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -77,7 +82,7 @@ func (t *wsTransport) SendCtx(ctx context.Context, data []byte) error {
 	select {
 	case <-t.done:
 		return ErrConnectionClosed
-	case t.send <- data:
+	case t.send <- frame:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -163,12 +168,25 @@ func (t *wsTransport) writePump() {
 			if err := t.writeMessage(websocket.PingMessage, nil); err != nil {
 				return
 			}
-		case data := <-t.send:
-			if err := t.writeMessage(websocket.TextMessage, data); err != nil {
+		case frame := <-t.send:
+			if err := t.writeMessage(frame.messageType, frame.data); err != nil {
 				return
 			}
 		}
 	}
+}
+
+func encodeBinaryFrame(header binaryFrameHeader, payload []byte) ([]byte, error) {
+	header.Version = binaryFrameVersion
+	headerData, err := marshalJSON(header)
+	if err != nil {
+		return nil, err
+	}
+	frame := make([]byte, 4+len(headerData)+len(payload))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(headerData)))
+	copy(frame[4:], headerData)
+	copy(frame[4+len(headerData):], payload)
+	return frame, nil
 }
 
 // writeMessage writes one frame, bounded by WriteTimeout so a peer that

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"math"
 	"net"
 	"os"
 	"time"
@@ -53,6 +55,8 @@ func (t *wsTransport) Send(data []byte) error {
 func (t *wsTransport) SendCtx(ctx context.Context, data []byte) error {
 	return t.sendFrame(ctx, outboundFrame{messageType: websocket.TextMessage, data: data})
 }
+
+func (t *wsTransport) SupportsBinary() bool { return true }
 
 func (t *wsTransport) SendBinary(data []byte) error {
 	return t.sendFrame(context.Background(), outboundFrame{messageType: websocket.BinaryMessage, data: data})
@@ -182,8 +186,12 @@ func encodeBinaryFrame(header binaryFrameHeader, payload []byte) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
+	headerLen := uint64(len(headerData))
+	if headerLen > math.MaxUint32 {
+		return nil, fmt.Errorf("binary frame header too large: %d bytes", len(headerData))
+	}
 	frame := make([]byte, 4+len(headerData)+len(payload))
-	binary.BigEndian.PutUint32(frame[:4], uint32(len(headerData)))
+	binary.BigEndian.PutUint32(frame[:4], uint32(headerLen))
 	copy(frame[4:], headerData)
 	copy(frame[4+len(headerData):], payload)
 	return frame, nil


### PR DESCRIPTION
Closes #238.

## Summary
- New `aprot.Blob` result type opts a handler into binary delivery: over WebSocket the payload is sent as a raw binary frame (4-byte header length + JSON header + payload, no base64 inflation); generated TypeScript clients resolve a DOM `Blob`.
- Binary delivery is **opt-in via `Blob`/`*Blob` only** — plain `[]byte` results keep their existing JSON base64 encoding and `Promise<string>` typings.
- Transports are asked up front via a new `SupportsBinary()` capability method (WS: yes; SSE/stream: no). Non-binary transports send a `{"$blob": {contentType, data}}` JSON envelope that the client converts back into a DOM `Blob`, so the resolved type is identical on every transport.
- Generator maps a top-level `Blob` result to the DOM `Blob` type (`Promise<Blob>`, `(data: Blob) => void` subscription callbacks) and never emits a shadowing `Blob` interface; nested/streamed/parameter Blobs keep the JSON wire shape `{ contentType?: string; data: string }`.
- Client template: JSON and binary responses settle through one shared path, so binary **subscription refreshes** reach their callbacks; unknown binary frame versions **reject** the pending request instead of hanging it.
- Fixes the gosec G115 CI failure (guarded uint32 header-length conversion in `encodeBinaryFrame`).

## Wire format
Binary frame: `[4-byte big-endian header length][JSON header {version, type, id, contentType?}][raw payload]`. JSON fallback: `{"type":"response","id":…,"result":{"$blob":{"contentType":…,"data":"<base64>"}}}`.

## Verification
- `go test ./...` (root + tasks)
- `gosec ./...` — clean
- e2e: 17 files / 94 tests pass, including new `blob.test.ts` covering WS binary frames, the SSE `$blob` fallback, and subscription refreshes on both transports
- Regenerated vanilla + react example clients; `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)