### PR TITLE
Add subscription patches: push O(patch) updates instead of full results

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -259,6 +259,34 @@ func (h *H) CreateUser(ctx context.Context, req *CreateReq) (*User, error) {
 - `Server.TriggerRefresh(keys...)` for background goroutines / cron / webhooks — flushes immediately, no request context required.
 - `RegisterRefreshTrigger` is a no-op outside subscribe; package-level `TriggerRefresh` is a no-op outside a request context.
 
+### Subscription patches (#237)
+
+`TriggerRefresh` re-sends the **full result** on every fire — O(list) per keystroke on big collections. `PatchSubscription` pushes O(patch) instead:
+
+```go
+func (h *H) SetRating(ctx context.Context, id string, rating int) error {
+    h.store.SetRating(id, rating)
+    return aprot.PatchSubscription(ctx, RatingPatch{ID: id, Rating: rating}, "photos") // patch first, then key parts
+}
+```
+
+Client opts in by providing a reducer — that's also what declares patch support to the server (without one, the server falls back to a full refresh automatically):
+
+```typescript
+// React (cached): patch is applied to the shared cache snapshot — every component sees it.
+const { data } = useListPhotos({ applyPatch: mergeByKey('id') });
+// Wrapped results:
+useListPhotos({ applyPatch: (data, patch) => ({ ...data, photos: mergeByKey('id')(data.photos, patch) }) });
+// Vanilla: 5th arg of generated subscribe functions.
+subscribeListPhotos(client, cb, onErr, { onPatch: (patch) => { /* fold into local state */ } });
+```
+
+- `mergeByKey('id')` = shallow-merge patches (`{id, ...fields}`, single or array) into a keyed array; unmatched keys ignored.
+- Reducers must be pure (return a new value). Patches are delivered immediately, not batched; a patch may arrive before the mutation's own response settles.
+- Patches are for in-place updates only — fire `TriggerRefresh` for structural changes (add/remove items).
+- `Server.PatchSubscription(patch, keys...)` for out-of-request callers; returns error only if the patch fails to marshal.
+- `useQuerySuspense` and clients without a reducer stay on the full-refresh path; `Observer.PatchFanout(key, patched, refreshed)` reports the split.
+
 ## REST + OpenAPI
 
 ```go

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Streaming handlers** — return `iter.Seq[T]` / `iter.Seq2[K, V]` from Go and the generated client exposes `AsyncIterable<T>`, so UIs can populate lists item-by-item as results arrive
 - **Binary Blob responses** — return `aprot.Blob` from a handler and the client receives a DOM `Blob`; delivered as a raw WebSocket binary frame (no base64 overhead), with an automatic JSON fallback on SSE and stream transports
 - **Subscription refresh** — server-driven auto-refresh: query handlers declare trigger keys, mutation handlers fire them to push updates to all subscribed clients
+- **Subscription patches** — mutations push O(patch) partial updates to subscribed queries instead of re-sending the full result; clients apply them to the shared query cache via an `applyPatch` reducer, with automatic full-refresh fallback for clients that don't opt in
 - **Query cache** — multiple React components using the same hook share a single server subscription and receive data from a shared cache; configurable per-hook or globally via `setQueryCacheEnabled`
 - **Middleware** — server-level and per-handler middleware chains
 - **Push events** — broadcast to all clients or target specific users
@@ -637,6 +638,34 @@ imgEl.src = URL.createObjectURL(avatar); // avatar.type === 'image/png'
 Over WebSocket the payload travels as a binary frame (a 4-byte header length, a small JSON header, then the raw bytes). Transports without binary frames (SSE, byte-stream) fall back to a JSON envelope carrying base64 data, which the client converts back into a `Blob` automatically — the resolved type never depends on the transport. Subscription refreshes (`subscribeGetAvatar`, `useGetAvatar`) deliver `Blob`s the same way.
 
 Binary delivery is opt-in via the `Blob` type and applies to top-level results only. A plain `[]byte` result keeps its base64 string encoding, and a `Blob` nested inside another struct, streamed as an item, or passed as a parameter travels as ordinary JSON (`{contentType?, data}` with base64 `data`).
+
+## Subscription Patches
+
+`TriggerRefresh` re-runs the subscribed query and re-sends the **entire result** — on a several-thousand-row list, every small mutation costs a full re-serialization and a megabyte-scale frame. `PatchSubscription` pushes just the change instead:
+
+```go
+// Query handler — declares the trigger key as usual.
+func (h *PhotoHandlers) ListPhotos(ctx context.Context, folderID string) ([]Photo, error) {
+    aprot.RegisterRefreshTrigger(ctx, "photos", folderID)
+    return h.store.ListPhotos(folderID)
+}
+
+// Mutation — pushes an O(patch) update instead of re-sending the list.
+func (h *PhotoHandlers) SetRating(ctx context.Context, folderID, id string, rating int) error {
+    h.store.SetRating(id, rating)
+    return aprot.PatchSubscription(ctx, PhotoPatch{ID: id, Rating: rating}, "photos", folderID)
+}
+```
+
+React hooks opt in with an `applyPatch` reducer, applied to the shared query-cache snapshot so every component using the hook re-renders with the patched data — no refetch, no full-result frame:
+
+```typescript
+const { data } = useListPhotos(folderId, { applyPatch: mergeByKey('id') });
+```
+
+`mergeByKey('id')` covers the common case — a keyed array shallow-merged with `{id, ...partialFields}` patches (single or arrays). Wrapped results take a one-liner: `applyPatch: (data, patch) => ({ ...data, photos: mergeByKey('id')(data.photos, patch) })`. Vanilla clients receive patches through the generated subscribe functions: `subscribeListPhotos(client, folderId, cb, onErr, { onPatch })`.
+
+Providing a reducer is what declares patch support to the server. Subscribers without one — older generated clients, `useQuerySuspense`, or hooks that simply don't pass `applyPatch` — automatically fall back to the classic full refresh, so mixed fleets stay consistent, and `Observer.PatchFanout` reports how many subscribers took each path. Patches are delivered immediately (not batched with the surrounding request) and are meant for in-place updates to existing entries; keep firing `TriggerRefresh` for structural changes such as added or removed items.
 
 ## Validation
 

--- a/connection.go
+++ b/connection.go
@@ -975,13 +975,14 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 			c.server.subscriptions.updateKeys(c.id, msg.ID, keys)
 			// Re-subscribe with the same ID may carry new params; refresh them
 			// so server-driven re-execution doesn't replay the stale ones.
-			c.server.subscriptions.updateParams(c.id, msg.ID, msg.Params)
+			c.server.subscriptions.updateParams(c.id, msg.ID, msg.Params, msg.Patch)
 		} else if ok, limited := c.server.subscriptions.register(&subscription{
-			conn:   c,
-			id:     msg.ID,
-			method: msg.Method,
-			keys:   keys,
-			params: msg.Params,
+			conn:       c,
+			id:         msg.ID,
+			method:     msg.Method,
+			keys:       keys,
+			params:     msg.Params,
+			wantsPatch: msg.Patch,
 		}); !ok {
 			if limited {
 				// The connection is at its subscription cap; tell the client so

--- a/doc.go
+++ b/doc.go
@@ -471,6 +471,33 @@
 // [TriggerRefresh] is a no-op outside a request context. Subscriptions are
 // cleaned up automatically on client disconnect.
 //
+// # Subscription Patches
+//
+// TriggerRefresh re-runs the query and re-sends the entire result, which
+// amplifies small mutations into large frames on big subscribed collections.
+// [PatchSubscription] pushes a small typed patch instead:
+//
+//	func (h *H) SetRating(ctx context.Context, id string, rating int) error {
+//	    h.store.SetRating(id, rating)
+//	    return aprot.PatchSubscription(ctx, RatingPatch{ID: id, Rating: rating}, "photos")
+//	}
+//
+// Subscribers that registered a patch reducer receive the payload as a
+// subscription_patch frame and apply it client-side; everyone else falls back
+// to a full refresh automatically, so mixed client fleets stay consistent. In
+// generated React clients the reducer is the applyPatch hook option, applied
+// to the shared query-cache snapshot so every component sees it:
+//
+//	const { data } = useListPhotos({ applyPatch: mergeByKey('id') });
+//
+// mergeByKey builds the common reducer for keyed-array results; wrapped
+// results take a hand-written reducer. Vanilla clients pass onPatch to the
+// generated subscribe functions and fold patches themselves. Patches are
+// meant for in-place updates to existing entries — keep using TriggerRefresh
+// for structural changes (items added or removed). [Server.PatchSubscription]
+// is the out-of-request variant, and [Observer.PatchFanout] reports how many
+// subscribers took each path.
+//
 // # Error Handling
 //
 // Return [ProtocolError] values from handlers to send structured errors to
@@ -785,5 +812,6 @@
 //
 // Messages are JSON objects with a "type" field. Client-to-server: request,
 // cancel, subscribe, unsubscribe. Server-to-client: response, error, progress,
-// push, config, connected (SSE only).
+// push, config, subscription_patch, connected (SSE only). Streaming adds
+// stream_item / stream_chunk / stream_end.
 package aprot

--- a/e2e/e2eapi/handlers.go
+++ b/e2e/e2eapi/handlers.go
@@ -115,6 +115,69 @@ func (h *BlobHandlers) SetBlob(ctx context.Context, data string) error {
 	return nil
 }
 
+// PatchHandlers exercises subscription patches (#237): a mutation pushes a
+// small typed patch to subscribers that declared patch support instead of
+// re-running the subscribed query, and falls back to a full refresh for
+// subscribers that did not. The execution counter lets tests assert which
+// path was taken.
+type PatchHandlers struct {
+	mu         sync.Mutex
+	ratings    map[string]int
+	executions int
+}
+
+// PatchItem is one entry of the subscribed list.
+type PatchItem struct {
+	ID     string `json:"id"`
+	Rating int    `json:"rating"`
+}
+
+// PatchItemList wraps the list so tests also cover reducers on non-array
+// result shapes.
+type PatchItemList struct {
+	Items []PatchItem `json:"items"`
+}
+
+// RatingPatch is the payload SetRating pushes to subscribers.
+type RatingPatch struct {
+	ID     string `json:"id"`
+	Rating int    `json:"rating"`
+}
+
+func NewPatchHandlers() *PatchHandlers {
+	return &PatchHandlers{ratings: map[string]int{"p1": 0, "p2": 0, "p3": 0}}
+}
+
+// ListPatchItems is the subscribed query; every execution increments the
+// counter so tests can distinguish a patch (no re-execution) from a full
+// refresh (one re-execution).
+func (h *PatchHandlers) ListPatchItems(ctx context.Context) (*PatchItemList, error) {
+	aprot.RegisterRefreshTrigger(ctx, "patch-items")
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.executions++
+	items := make([]PatchItem, 0, len(h.ratings))
+	for _, id := range []string{"p1", "p2", "p3"} {
+		items = append(items, PatchItem{ID: id, Rating: h.ratings[id]})
+	}
+	return &PatchItemList{Items: items}, nil
+}
+
+// SetRating mutates one entry and pushes it as a patch.
+func (h *PatchHandlers) SetRating(ctx context.Context, id string, rating int) error {
+	h.mu.Lock()
+	h.ratings[id] = rating
+	h.mu.Unlock()
+	return aprot.PatchSubscription(ctx, RatingPatch{ID: id, Rating: rating}, "patch-items")
+}
+
+// GetListExecutions reports how many times ListPatchItems has run.
+func (h *PatchHandlers) GetListExecutions(ctx context.Context) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.executions, nil
+}
+
 // Register wires the e2e-only REST and validation handlers onto an existing
 // registry and turns on request validation. Existing handlers without validate
 // tags are unaffected (validation is a no-op for them).
@@ -123,5 +186,6 @@ func Register(registry *aprot.Registry) {
 	registry.Register(&SignupHandlers{})
 	registry.Register(&FixedArrayHandlers{})
 	registry.Register(NewBlobHandlers())
+	registry.Register(NewPatchHandlers())
 	registry.SetValidator(aprot.NewPlaygroundValidator())
 }

--- a/e2e/tests/react-patch.test.tsx
+++ b/e2e/tests/react-patch.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { wsUrl } from './helpers';
+import { ApiClient, ApiClientProvider, mergeByKey } from '../react-api/client';
+import { useListPatchItems, setRating, getListExecutions } from '../react-api/patch-handlers';
+import type { PatchItemList } from '../react-api/patch-handlers';
+
+// Subscription patches through the React query cache (#237): two components
+// share one cached subscription with an applyPatch reducer; a mutation's
+// patch must update both — applied to the shared snapshot — without the
+// subscribed query re-executing on the server.
+
+const applyPatch = (data: PatchItemList, patch: unknown): PatchItemList => ({
+    ...data,
+    items: mergeByKey<PatchItemList['items'][number]>('id')(data.items, patch),
+});
+
+function RatingProbe({ label }: { label: string }) {
+    const { data } = useListPatchItems({ applyPatch });
+    const p3 = data?.items.find((i) => i.id === 'p3');
+    if (!p3) return <div>{label}: loading</div>;
+    return <div>{label}: p3={p3.rating}</div>;
+}
+
+describe('React hooks apply subscription patches to the shared cache', () => {
+    let client: ApiClient;
+
+    beforeAll(async () => {
+        client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+    });
+
+    afterAll(() => {
+        cleanup();
+        client.disconnect();
+    });
+
+    test('a patch updates every component on the shared cache without a refetch', async () => {
+        render(
+            <ApiClientProvider value={client}>
+                <RatingProbe label="a" />
+                <RatingProbe label="b" />
+            </ApiClientProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('a: p3=0')).toBeTruthy();
+            expect(screen.getByText('b: p3=0')).toBeTruthy();
+        }, { timeout: 10000 });
+
+        const executionsBefore = await getListExecutions(client);
+
+        await setRating(client, 'p3', 42);
+
+        await waitFor(() => {
+            expect(screen.getByText('a: p3=42')).toBeTruthy();
+            expect(screen.getByText('b: p3=42')).toBeTruthy();
+        }, { timeout: 10000 });
+
+        // Both components updated from the patched shared snapshot; the
+        // subscribed query never re-executed on the server.
+        const executionsAfter = await getListExecutions(client);
+        expect(executionsAfter).toBe(executionsBefore);
+    });
+});

--- a/e2e/tests/subscription-patch.test.ts
+++ b/e2e/tests/subscription-patch.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { wsUrl } from './helpers';
+import { ApiClient, mergeByKey } from '../api/client';
+import { subscribeListPatchItems, setRating, getListExecutions } from '../api/patch-handlers';
+import type { PatchItemList, PatchItem } from '../api/patch-handlers';
+
+// Subscription patches (#237): a mutation pushes O(patch) to subscribers that
+// declared patch support, instead of re-running the query and re-sending the
+// full result. The server-side execution counter proves which path ran.
+
+describe('Subscription patches (WebSocket)', () => {
+    let client: ApiClient;
+
+    beforeEach(async () => {
+        client = new ApiClient(wsUrl(), { reconnect: false });
+        await client.connect();
+    });
+
+    afterEach(() => {
+        client.disconnect();
+    });
+
+    test('patch reaches an opted-in subscriber without re-running the query', async () => {
+        const patches: unknown[] = [];
+        let initial: PatchItemList | null = null;
+
+        const unsubscribe = subscribeListPatchItems(
+            client,
+            (data) => { initial ??= data; },
+            undefined,
+            { onPatch: (patch) => patches.push(patch) },
+        );
+
+        // Wait for the initial subscription result.
+        await expect.poll(() => initial !== null).toBe(true);
+        const executionsBefore = await getListExecutions(client);
+
+        const marker = Math.floor(Math.random() * 1_000_000);
+        await setRating(client, 'p1', marker);
+
+        await expect.poll(() => patches.length).toBeGreaterThan(0);
+        expect(patches[0]).toEqual({ id: 'p1', rating: marker });
+
+        // The patch replaced the refresh: the query must not have re-executed.
+        const executionsAfter = await getListExecutions(client);
+        expect(executionsAfter).toBe(executionsBefore);
+
+        unsubscribe();
+    });
+
+    test('subscriber without patch support falls back to a full refresh', async () => {
+        const results: PatchItemList[] = [];
+        const unsubscribe = subscribeListPatchItems(client, (data) => { results.push(data); });
+
+        await expect.poll(() => results.length).toBeGreaterThan(0);
+        const executionsBefore = await getListExecutions(client);
+
+        const marker = Math.floor(Math.random() * 1_000_000);
+        await setRating(client, 'p2', marker);
+
+        // The full result arrives through the normal refresh path.
+        await expect.poll(() =>
+            results.some((r) => r.items.some((i) => i.id === 'p2' && i.rating === marker)),
+        ).toBe(true);
+
+        // ...which means the query re-executed exactly once for this subscriber.
+        const executionsAfter = await getListExecutions(client);
+        expect(executionsAfter).toBe(executionsBefore + 1);
+
+        unsubscribe();
+    });
+
+    test('mergeByKey folds patches into a keyed array', () => {
+        const merge = mergeByKey<PatchItem>('id');
+        const data: PatchItem[] = [
+            { id: 'p1', rating: 0 },
+            { id: 'p2', rating: 1 },
+        ];
+
+        const merged = merge(data, { id: 'p2', rating: 9 });
+        expect(merged).toEqual([
+            { id: 'p1', rating: 0 },
+            { id: 'p2', rating: 9 },
+        ]);
+        // Pure: the input array is untouched.
+        expect(data[1].rating).toBe(1);
+
+        // Arrays of patches and unknown keys are handled.
+        const merged2 = merge(data, [{ id: 'p1', rating: 7 }, { id: 'missing', rating: 3 }]);
+        expect(merged2).toEqual([
+            { id: 'p1', rating: 7 },
+            { id: 'p2', rating: 1 },
+        ]);
+    });
+});

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -77,6 +77,49 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+/**
+ * Options for {@link ApiClient.subscribe} and generated `subscribeX` helpers.
+ */
+export interface SubscribeOptions {
+    /**
+     * Called when the server pushes a `subscription_patch` frame for this
+     * subscription (see the server-side `aprot.PatchSubscription`). Providing
+     * it declares patch support to the server; without it, the server falls
+     * back to a full refresh (re-running the query and re-sending the result).
+     * The patch payload is whatever the mutation handler pushed — apply it to
+     * your local copy of the data.
+     */
+    onPatch?: (patch: unknown) => void;
+}
+
+/**
+ * Builds an `applyPatch` reducer for the common case: the subscribed result
+ * is an array of objects with a unique key field, and patches are partial
+ * objects (or arrays of them) carrying that key. Entries matching a patch's
+ * key are shallow-merged; patches with no matching entry are ignored — use a
+ * full refresh (server-side `TriggerRefresh`) for structural changes like
+ * added or removed items.
+ *
+ *   const { data } = useListPhotos({ applyPatch: mergeByKey('id') });
+ *
+ * For wrapped results (e.g. `{ photos: Photo[] }`) or richer semantics,
+ * write the reducer by hand: `(data, patch) => ({ ...data, photos: ... })`.
+ */
+export function mergeByKey<T extends object>(key: keyof T & string): (data: T[], patch: unknown) => T[] {
+    return (data: T[], patch: unknown): T[] => {
+        const patches = (Array.isArray(patch) ? patch : [patch]) as Array<Partial<T> & Record<string, unknown>>;
+        const byKey = new Map<unknown, Partial<T>>();
+        for (const p of patches) {
+            if (p && typeof p === 'object' && key in p) byKey.set(p[key], p);
+        }
+        if (byKey.size === 0) return data;
+        return data.map((item) => {
+            const p = byKey.get((item as Record<string, unknown>)[key]);
+            return p ? { ...item, ...p } : item;
+        });
+    };
+}
+
 // Shared decoder for binary frame headers — small and reused per message.
 const binaryHeaderDecoder = new TextDecoder();
 
@@ -541,6 +584,7 @@ export class ApiClient {
         params: unknown[];
         callback: (data: unknown) => void;
         onError?: (error: Error) => void;
+        onPatch?: (patch: unknown) => void;
     }>();
     private streams = new Map<string, {
         push: (item: unknown) => void;
@@ -991,6 +1035,20 @@ export class ApiClient {
                 this.settleResponse(msg.id, decodeBlobResult(msg.result));
                 break;
             }
+            case 'subscription_patch': {
+                const sub = this.subscriptions.get(msg.id);
+                if (!sub) break;
+                if (sub.onPatch) {
+                    sub.onPatch(msg.patch);
+                } else if (this.transport.isConnected()) {
+                    // Defensive: the server only sends patches to subscriptions
+                    // that declared support, so this should not happen — but if
+                    // it does, re-subscribe to fetch the full result rather
+                    // than silently going stale.
+                    this.transport.send({ type: 'subscribe', id: msg.id, method: sub.method, params: sub.params });
+                }
+                break;
+            }
             case 'error': {
                 const p = this.pending.get(msg.id);
                 if (p) {
@@ -1262,7 +1320,7 @@ export class ApiClient {
                 resolve: (result) => { sub.callback(result); },
                 reject: (err) => { sub.onError?.(err as Error); },
             });
-            this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params });
+            this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params, ...(sub.onPatch ? { patch: true } : {}) });
         }
         this.notifyLoadingChange();
     }
@@ -1278,10 +1336,11 @@ export class ApiClient {
         };
     }
 
-    subscribe<T>(method: string, params: unknown[], callback: (data: T) => void, onError?: (error: Error) => void): () => void {
+    subscribe<T>(method: string, params: unknown[], callback: (data: T) => void, onError?: (error: Error) => void, options?: SubscribeOptions): () => void {
         const id = String(++this.requestId);
         const cb = callback as (data: unknown) => void;
-        this.subscriptions.set(id, { method, params, callback: cb, onError });
+        const onPatch = options?.onPatch;
+        this.subscriptions.set(id, { method, params, callback: cb, onError, onPatch });
 
         // Register in pending for the initial response
         this.pending.set(id, {
@@ -1290,7 +1349,7 @@ export class ApiClient {
         });
 
         if (this.transport.isConnected()) {
-            this.transport.send({ type: 'subscribe', id, method, params });
+            this.transport.send({ type: 'subscribe', id, method, params, ...(onPatch ? { patch: true } : {}) });
         }
 
         return () => {
@@ -1635,7 +1694,23 @@ export function useIsLoading(): boolean {
 /**
  * Options for {@link useQuery} hooks.
  */
-export interface UseQueryOptions {
+export interface UseQueryOptions<TData = unknown> {
+    /**
+     * Reducer applying server-pushed `subscription_patch` payloads to the
+     * current `data` without a refetch (see the server-side
+     * `aprot.PatchSubscription`). Providing it declares patch support for the
+     * subscription; without it, the server falls back to re-running the query
+     * and re-sending the full result. Must be pure: return a new value,
+     * never mutate `data` in place. For keyed-array results, `mergeByKey`
+     * builds the common shallow-merge reducer:
+     *
+     *   useListPhotos({ applyPatch: mergeByKey('id') })
+     *
+     * In cached mode the patch is applied to the shared cache snapshot, so
+     * every component using the same hook sees it. Only applies in
+     * subscription mode.
+     */
+    applyPatch?: (data: TData, patch: unknown) => TData;
     /**
      * When `false`, the query will not execute. Useful for conditional fetching
      * (e.g., wait until an ID is available). Defaults to `true`.
@@ -1853,6 +1928,15 @@ interface SubscriptionCacheEntry {
     listeners: Set<() => void>;
     refCount: number;
     unsubscribe: (() => void) | null;
+    /** Reducer applying subscription_patch payloads to the cached data. */
+    applyPatch?: (data: unknown, patch: unknown) => unknown;
+    /**
+     * Patches that arrived before the initial subscribe response. The server
+     * may push a patch between registering the subscription and sending the
+     * first result, and that result can predate the patch's mutation — so
+     * these are replayed on top of the first data instead of being dropped.
+     */
+    pendingPatches: unknown[];
 }
 
 const subscriptionCaches = new WeakMap<ApiClient, Map<string, SubscriptionCacheEntry>>();
@@ -1871,6 +1955,7 @@ function subscribeCached<T>(
     key: string,
     method: string,
     params: unknown[],
+    applyPatch?: (data: T, patch: unknown) => T,
 ): {
     subscribe: (listener: () => void) => () => void;
     getSnapshot: () => SubscriptionSnapshot<T>;
@@ -1889,8 +1974,12 @@ function subscribeCached<T>(
                 listeners: new Set(),
                 refCount: 0,
                 unsubscribe: null,
+                pendingPatches: [],
             };
             cache.set(key, entry);
+        }
+        if (applyPatch) {
+            entry.applyPatch = applyPatch as (data: unknown, patch: unknown) => unknown;
         }
         entry.listeners.add(listener);
         entry.refCount++;
@@ -1901,13 +1990,30 @@ function subscribeCached<T>(
                 method,
                 params,
                 (result) => {
-                    e.snapshot = { data: result, error: null, isLoading: false };
+                    let data: unknown = result;
+                    // Replay patches that raced ahead of this (re)load — the
+                    // result may have been computed before their mutations.
+                    if (e.applyPatch && data !== null) {
+                        for (const p of e.pendingPatches) data = e.applyPatch(data, p);
+                    }
+                    e.pendingPatches = [];
+                    e.snapshot = { data, error: null, isLoading: false };
                     notify(e);
                 },
                 (err) => {
                     e.snapshot = { ...e.snapshot, error: err, isLoading: false };
                     notify(e);
                 },
+                applyPatch ? {
+                    onPatch: (patch) => {
+                        if (e.snapshot.data === null || !e.applyPatch) {
+                            e.pendingPatches.push(patch);
+                            return;
+                        }
+                        e.snapshot = { ...e.snapshot, data: e.applyPatch(e.snapshot.data, patch) };
+                        notify(e);
+                    },
+                } : undefined,
             );
         }
 
@@ -2008,11 +2114,11 @@ function updateCachedSnapshot<T>(
  * (unmount, param change, or React Strict Mode re-run), which cancels the
  * Go handler's `context.Context`.
  */
-export function useQuery<TRes>(fn: (client: ApiClient, signal: AbortSignal) => Promise<TRes>, options?: UseQueryOptions): UseQueryResult<TRes>;
-export function useQuery<TArgs extends unknown[], TRes>(fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>, options: UseQueryOptions & { params: TArgs }): UseQueryResult<TRes>;
+export function useQuery<TRes>(fn: (client: ApiClient, signal: AbortSignal) => Promise<TRes>, options?: UseQueryOptions<TRes>): UseQueryResult<TRes>;
+export function useQuery<TArgs extends unknown[], TRes>(fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>, options: UseQueryOptions<TRes> & { params: TArgs }): UseQueryResult<TRes>;
 export function useQuery<TArgs extends unknown[], TRes>(
     fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>,
-    options?: UseQueryOptions & { params?: TArgs },
+    options?: UseQueryOptions<TRes> & { params?: TArgs },
 ): UseQueryResult<TRes> {
     const client = useApiClient();
     const [data, setData] = useState<TRes | null>(null);
@@ -2039,10 +2145,12 @@ export function useQuery<TArgs extends unknown[], TRes>(
 
     const cacheStore = useMemo(() => {
         if (!shouldCache) return null;
-        return subscribeCached<TRes>(client, cacheKey, subscribeMethod!, subscribeOpts!.params);
+        return subscribeCached<TRes>(client, cacheKey, subscribeMethod!, subscribeOpts!.params, options?.applyPatch);
     // subscribeMethod / subscribeOpts.params are already encoded into cacheKey,
     // so listing them again would force the memo to re-run on identity changes
-    // even when the resolved key is unchanged.
+    // even when the resolved key is unchanged. applyPatch is intentionally
+    // omitted too: inline reducers change identity every render, and the cache
+    // entry keeps the latest reducer via subscribeCached's subscribe() path.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, cacheKey, shouldCache]);
 
@@ -2101,6 +2209,7 @@ export function useQuery<TArgs extends unknown[], TRes>(
         if (!subscribeMethod || options?.enabled === false) return;
         if (options?.cache !== false && queryCacheEnabled) return; // cached path handles this
         setIsLoading(true);
+        const applyPatch = options?.applyPatch;
         const unsubscribe = client.subscribe<TRes>(
             subscribeMethod,
             subscribeOpts!.params,
@@ -2113,6 +2222,13 @@ export function useQuery<TArgs extends unknown[], TRes>(
                 setError(err);
                 setIsLoading(false);
             },
+            applyPatch ? {
+                // Patches arriving before the first result are dropped here;
+                // the cached path (the default) queues and replays them.
+                onPatch: (patch) => {
+                    setData((d) => (d === null ? d : applyPatch(d, patch)));
+                },
+            } : undefined,
         );
         return unsubscribe;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/example/react/client/src/api/handlers.ts
+++ b/example/react/client/src/api/handlers.ts
@@ -103,8 +103,8 @@ export function createUser(client: ApiClient, name: string, email: string, optio
 // (unaffected by minification, unlike Function.name).
 createUser.method = 'Handlers.CreateUser' as const;
 
-export function subscribeCreateUser(client: ApiClient, name: string, email: string, callback: (data: CreateUserResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<CreateUserResponse>('Handlers.CreateUser', [name, email], callback, onError);
+export function subscribeCreateUser(client: ApiClient, name: string, email: string, callback: (data: CreateUserResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<CreateUserResponse>('Handlers.CreateUser', [name, email], callback, onError, options);
 }
 
 
@@ -116,8 +116,8 @@ export function getDashboard(client: ApiClient, options?: RequestOptions): Promi
 // (unaffected by minification, unlike Function.name).
 getDashboard.method = 'Handlers.GetDashboard' as const;
 
-export function subscribeGetDashboard(client: ApiClient, callback: (data: GetDashboardResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<GetDashboardResponse>('Handlers.GetDashboard', [], callback, onError);
+export function subscribeGetDashboard(client: ApiClient, callback: (data: GetDashboardResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<GetDashboardResponse>('Handlers.GetDashboard', [], callback, onError, options);
 }
 
 
@@ -129,8 +129,8 @@ export function getTask(client: ApiClient, id: string, options?: RequestOptions)
 // (unaffected by minification, unlike Function.name).
 getTask.method = 'Handlers.GetTask' as const;
 
-export function subscribeGetTask(client: ApiClient, id: string, callback: (data: GetTaskResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<GetTaskResponse>('Handlers.GetTask', [id], callback, onError);
+export function subscribeGetTask(client: ApiClient, id: string, callback: (data: GetTaskResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<GetTaskResponse>('Handlers.GetTask', [id], callback, onError, options);
 }
 
 
@@ -142,8 +142,8 @@ export function getUser(client: ApiClient, id: string, options?: RequestOptions)
 // (unaffected by minification, unlike Function.name).
 getUser.method = 'Handlers.GetUser' as const;
 
-export function subscribeGetUser(client: ApiClient, id: string, callback: (data: GetUserResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<GetUserResponse>('Handlers.GetUser', [id], callback, onError);
+export function subscribeGetUser(client: ApiClient, id: string, callback: (data: GetUserResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<GetUserResponse>('Handlers.GetUser', [id], callback, onError, options);
 }
 
 
@@ -155,8 +155,8 @@ export function listUsers(client: ApiClient, options?: RequestOptions): Promise<
 // (unaffected by minification, unlike Function.name).
 listUsers.method = 'Handlers.ListUsers' as const;
 
-export function subscribeListUsers(client: ApiClient, callback: (data: ListUsersResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<ListUsersResponse>('Handlers.ListUsers', [], callback, onError);
+export function subscribeListUsers(client: ApiClient, callback: (data: ListUsersResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<ListUsersResponse>('Handlers.ListUsers', [], callback, onError, options);
 }
 
 
@@ -168,8 +168,8 @@ export function processBatch(client: ApiClient, items: string[], delay: number, 
 // (unaffected by minification, unlike Function.name).
 processBatch.method = 'Handlers.ProcessBatch' as const;
 
-export function subscribeProcessBatch(client: ApiClient, items: string[], delay: number, callback: (data: ProcessBatchResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<ProcessBatchResponse>('Handlers.ProcessBatch', [items, delay], callback, onError);
+export function subscribeProcessBatch(client: ApiClient, items: string[], delay: number, callback: (data: ProcessBatchResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<ProcessBatchResponse>('Handlers.ProcessBatch', [items, delay], callback, onError, options);
 }
 
 
@@ -181,8 +181,8 @@ export function sendNotification(client: ApiClient, message: string, level: stri
 // (unaffected by minification, unlike Function.name).
 sendNotification.method = 'Handlers.SendNotification' as const;
 
-export function subscribeSendNotification(client: ApiClient, message: string, level: string, callback: (data: SystemNotificationEvent) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<SystemNotificationEvent>('Handlers.SendNotification', [message, level], callback, onError);
+export function subscribeSendNotification(client: ApiClient, message: string, level: string, callback: (data: SystemNotificationEvent) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<SystemNotificationEvent>('Handlers.SendNotification', [message, level], callback, onError, options);
 }
 
 
@@ -194,8 +194,8 @@ export function startSharedWork(client: ApiClient, title: string, steps: string[
 // (unaffected by minification, unlike Function.name).
 startSharedWork.method = 'Handlers.StartSharedWork' as const;
 
-export function subscribeStartSharedWork(client: ApiClient, title: string, steps: string[], delay: number, callback: (data: StartSharedWorkResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<StartSharedWorkResponse>('Handlers.StartSharedWork', [title, steps, delay], callback, onError);
+export function subscribeStartSharedWork(client: ApiClient, title: string, steps: string[], delay: number, callback: (data: StartSharedWorkResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<StartSharedWorkResponse>('Handlers.StartSharedWork', [title, steps, delay], callback, onError, options);
 }
 
 export function onUserCreatedEvent(client: ApiClient, handler: PushHandler<UserCreatedEvent>): () => void {
@@ -219,7 +219,7 @@ export function onSystemNotificationEvent(client: ApiClient, handler: PushHandle
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useCreateUser(name: string, email: string, options?: UseQueryOptions): UseQueryResult<CreateUserResponse> {
+export function useCreateUser(name: string, email: string, options?: UseQueryOptions<CreateUserResponse>): UseQueryResult<CreateUserResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, name: string, email: string) => createUser(client, name, email, { signal }),
         [],
@@ -233,7 +233,7 @@ export function useCreateUser(name: string, email: string, options?: UseQueryOpt
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useGetDashboard(options?: UseQueryOptions): UseQueryResult<GetDashboardResponse> {
+export function useGetDashboard(options?: UseQueryOptions<GetDashboardResponse>): UseQueryResult<GetDashboardResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal) => getDashboard(client, { signal }),
         [],
@@ -248,7 +248,7 @@ export function useGetDashboard(options?: UseQueryOptions): UseQueryResult<GetDa
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useGetTask(id: string, options?: UseQueryOptions): UseQueryResult<GetTaskResponse> {
+export function useGetTask(id: string, options?: UseQueryOptions<GetTaskResponse>): UseQueryResult<GetTaskResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, id: string) => getTask(client, id, { signal }),
         [],
@@ -263,7 +263,7 @@ export function useGetTask(id: string, options?: UseQueryOptions): UseQueryResul
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useGetUser(id: string, options?: UseQueryOptions): UseQueryResult<GetUserResponse> {
+export function useGetUser(id: string, options?: UseQueryOptions<GetUserResponse>): UseQueryResult<GetUserResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, id: string) => getUser(client, id, { signal }),
         [],
@@ -277,7 +277,7 @@ export function useGetUser(id: string, options?: UseQueryOptions): UseQueryResul
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useListUsers(options?: UseQueryOptions): UseQueryResult<ListUsersResponse> {
+export function useListUsers(options?: UseQueryOptions<ListUsersResponse>): UseQueryResult<ListUsersResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal) => listUsers(client, { signal }),
         [],
@@ -292,7 +292,7 @@ export function useListUsers(options?: UseQueryOptions): UseQueryResult<ListUser
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useProcessBatch(items: string[], delay: number, options?: UseQueryOptions): UseQueryResult<ProcessBatchResponse> {
+export function useProcessBatch(items: string[], delay: number, options?: UseQueryOptions<ProcessBatchResponse>): UseQueryResult<ProcessBatchResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, items: string[], delay: number) => processBatch(client, items, delay, { signal }),
         [],
@@ -307,7 +307,7 @@ export function useProcessBatch(items: string[], delay: number, options?: UseQue
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useSendNotification(message: string, level: string, options?: UseQueryOptions): UseQueryResult<SystemNotificationEvent> {
+export function useSendNotification(message: string, level: string, options?: UseQueryOptions<SystemNotificationEvent>): UseQueryResult<SystemNotificationEvent> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, message: string, level: string) => sendNotification(client, message, level, { signal }),
         [],
@@ -322,7 +322,7 @@ export function useSendNotification(message: string, level: string, options?: Us
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useStartSharedWork(title: string, steps: string[], delay: number, options?: UseQueryOptions): UseQueryResult<StartSharedWorkResponse> {
+export function useStartSharedWork(title: string, steps: string[], delay: number, options?: UseQueryOptions<StartSharedWorkResponse>): UseQueryResult<StartSharedWorkResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, title: string, steps: string[], delay: number) => startSharedWork(client, title, steps, delay, { signal }),
         [],

--- a/example/react/client/src/api/tasks-handler.ts
+++ b/example/react/client/src/api/tasks-handler.ts
@@ -80,8 +80,8 @@ export function cancelTask(client: ApiClient, taskId: string, options?: RequestO
 // (unaffected by minification, unlike Function.name).
 cancelTask.method = 'tasksHandler.CancelTask' as const;
 
-export function subscribeCancelTask(client: ApiClient, taskId: string, callback: (data: void) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<void>('tasksHandler.CancelTask', [taskId], callback, onError);
+export function subscribeCancelTask(client: ApiClient, taskId: string, callback: (data: void) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<void>('tasksHandler.CancelTask', [taskId], callback, onError, options);
 }
 
 export function onTaskStateEvent(client: ApiClient, handler: PushHandler<TaskStateEvent>): () => void {
@@ -113,7 +113,7 @@ export function onRequestTaskProgressEvent(client: ApiClient, handler: PushHandl
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useCancelTask(taskId: string, options?: UseQueryOptions): UseQueryResult<void> {
+export function useCancelTask(taskId: string, options?: UseQueryOptions<void>): UseQueryResult<void> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, taskId: string) => cancelTask(client, taskId, { signal }),
         [],

--- a/example/react/client/src/api/todos.ts
+++ b/example/react/client/src/api/todos.ts
@@ -43,8 +43,8 @@ export function createTodo(client: ApiClient, req: CreateTodoRequest, options?: 
 // (unaffected by minification, unlike Function.name).
 createTodo.method = 'Todos.CreateTodo' as const;
 
-export function subscribeCreateTodo(client: ApiClient, req: CreateTodoRequest, callback: (data: Todo) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<Todo>('Todos.CreateTodo', [req], callback, onError);
+export function subscribeCreateTodo(client: ApiClient, req: CreateTodoRequest, callback: (data: Todo) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<Todo>('Todos.CreateTodo', [req], callback, onError, options);
 }
 
 
@@ -56,8 +56,8 @@ export function deleteTodo(client: ApiClient, id: string, options?: RequestOptio
 // (unaffected by minification, unlike Function.name).
 deleteTodo.method = 'Todos.DeleteTodo' as const;
 
-export function subscribeDeleteTodo(client: ApiClient, id: string, callback: (data: void) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<void>('Todos.DeleteTodo', [id], callback, onError);
+export function subscribeDeleteTodo(client: ApiClient, id: string, callback: (data: void) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<void>('Todos.DeleteTodo', [id], callback, onError, options);
 }
 
 
@@ -69,8 +69,8 @@ export function getTodo(client: ApiClient, id: string, options?: RequestOptions)
 // (unaffected by minification, unlike Function.name).
 getTodo.method = 'Todos.GetTodo' as const;
 
-export function subscribeGetTodo(client: ApiClient, id: string, callback: (data: Todo) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<Todo>('Todos.GetTodo', [id], callback, onError);
+export function subscribeGetTodo(client: ApiClient, id: string, callback: (data: Todo) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<Todo>('Todos.GetTodo', [id], callback, onError, options);
 }
 
 
@@ -82,8 +82,8 @@ export function listTodos(client: ApiClient, options?: RequestOptions): Promise<
 // (unaffected by minification, unlike Function.name).
 listTodos.method = 'Todos.ListTodos' as const;
 
-export function subscribeListTodos(client: ApiClient, callback: (data: ListTodosResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<ListTodosResponse>('Todos.ListTodos', [], callback, onError);
+export function subscribeListTodos(client: ApiClient, callback: (data: ListTodosResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<ListTodosResponse>('Todos.ListTodos', [], callback, onError, options);
 }
 
 
@@ -95,8 +95,8 @@ export function updateTodo(client: ApiClient, id: string, req: UpdateTodoRequest
 // (unaffected by minification, unlike Function.name).
 updateTodo.method = 'Todos.UpdateTodo' as const;
 
-export function subscribeUpdateTodo(client: ApiClient, id: string, req: UpdateTodoRequest, callback: (data: Todo) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<Todo>('Todos.UpdateTodo', [id, req], callback, onError);
+export function subscribeUpdateTodo(client: ApiClient, id: string, req: UpdateTodoRequest, callback: (data: Todo) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<Todo>('Todos.UpdateTodo', [id, req], callback, onError, options);
 }
 
 // React Hooks for Todos
@@ -108,7 +108,7 @@ export function subscribeUpdateTodo(client: ApiClient, id: string, req: UpdateTo
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useCreateTodo(req: CreateTodoRequest, options?: UseQueryOptions): UseQueryResult<Todo> {
+export function useCreateTodo(req: CreateTodoRequest, options?: UseQueryOptions<Todo>): UseQueryResult<Todo> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, req: CreateTodoRequest) => createTodo(client, req, { signal }),
         [],
@@ -123,7 +123,7 @@ export function useCreateTodo(req: CreateTodoRequest, options?: UseQueryOptions)
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useDeleteTodo(id: string, options?: UseQueryOptions): UseQueryResult<void> {
+export function useDeleteTodo(id: string, options?: UseQueryOptions<void>): UseQueryResult<void> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, id: string) => deleteTodo(client, id, { signal }),
         [],
@@ -138,7 +138,7 @@ export function useDeleteTodo(id: string, options?: UseQueryOptions): UseQueryRe
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useGetTodo(id: string, options?: UseQueryOptions): UseQueryResult<Todo> {
+export function useGetTodo(id: string, options?: UseQueryOptions<Todo>): UseQueryResult<Todo> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, id: string) => getTodo(client, id, { signal }),
         [],
@@ -152,7 +152,7 @@ export function useGetTodo(id: string, options?: UseQueryOptions): UseQueryResul
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useListTodos(options?: UseQueryOptions): UseQueryResult<ListTodosResponse> {
+export function useListTodos(options?: UseQueryOptions<ListTodosResponse>): UseQueryResult<ListTodosResponse> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal) => listTodos(client, { signal }),
         [],
@@ -167,7 +167,7 @@ export function useListTodos(options?: UseQueryOptions): UseQueryResult<ListTodo
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function useUpdateTodo(id: string, req: UpdateTodoRequest, options?: UseQueryOptions): UseQueryResult<Todo> {
+export function useUpdateTodo(id: string, req: UpdateTodoRequest, options?: UseQueryOptions<Todo>): UseQueryResult<Todo> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, id: string, req: UpdateTodoRequest) => updateTodo(client, id, req, { signal }),
         [],

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -70,6 +70,49 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+/**
+ * Options for {@link ApiClient.subscribe} and generated `subscribeX` helpers.
+ */
+export interface SubscribeOptions {
+    /**
+     * Called when the server pushes a `subscription_patch` frame for this
+     * subscription (see the server-side `aprot.PatchSubscription`). Providing
+     * it declares patch support to the server; without it, the server falls
+     * back to a full refresh (re-running the query and re-sending the result).
+     * The patch payload is whatever the mutation handler pushed — apply it to
+     * your local copy of the data.
+     */
+    onPatch?: (patch: unknown) => void;
+}
+
+/**
+ * Builds an `applyPatch` reducer for the common case: the subscribed result
+ * is an array of objects with a unique key field, and patches are partial
+ * objects (or arrays of them) carrying that key. Entries matching a patch's
+ * key are shallow-merged; patches with no matching entry are ignored — use a
+ * full refresh (server-side `TriggerRefresh`) for structural changes like
+ * added or removed items.
+ *
+ *   const { data } = useListPhotos({ applyPatch: mergeByKey('id') });
+ *
+ * For wrapped results (e.g. `{ photos: Photo[] }`) or richer semantics,
+ * write the reducer by hand: `(data, patch) => ({ ...data, photos: ... })`.
+ */
+export function mergeByKey<T extends object>(key: keyof T & string): (data: T[], patch: unknown) => T[] {
+    return (data: T[], patch: unknown): T[] => {
+        const patches = (Array.isArray(patch) ? patch : [patch]) as Array<Partial<T> & Record<string, unknown>>;
+        const byKey = new Map<unknown, Partial<T>>();
+        for (const p of patches) {
+            if (p && typeof p === 'object' && key in p) byKey.set(p[key], p);
+        }
+        if (byKey.size === 0) return data;
+        return data.map((item) => {
+            const p = byKey.get((item as Record<string, unknown>)[key]);
+            return p ? { ...item, ...p } : item;
+        });
+    };
+}
+
 // Shared decoder for binary frame headers — small and reused per message.
 const binaryHeaderDecoder = new TextDecoder();
 
@@ -534,6 +577,7 @@ export class ApiClient {
         params: unknown[];
         callback: (data: unknown) => void;
         onError?: (error: Error) => void;
+        onPatch?: (patch: unknown) => void;
     }>();
     private streams = new Map<string, {
         push: (item: unknown) => void;
@@ -984,6 +1028,20 @@ export class ApiClient {
                 this.settleResponse(msg.id, decodeBlobResult(msg.result));
                 break;
             }
+            case 'subscription_patch': {
+                const sub = this.subscriptions.get(msg.id);
+                if (!sub) break;
+                if (sub.onPatch) {
+                    sub.onPatch(msg.patch);
+                } else if (this.transport.isConnected()) {
+                    // Defensive: the server only sends patches to subscriptions
+                    // that declared support, so this should not happen — but if
+                    // it does, re-subscribe to fetch the full result rather
+                    // than silently going stale.
+                    this.transport.send({ type: 'subscribe', id: msg.id, method: sub.method, params: sub.params });
+                }
+                break;
+            }
             case 'error': {
                 const p = this.pending.get(msg.id);
                 if (p) {
@@ -1255,7 +1313,7 @@ export class ApiClient {
                 resolve: (result) => { sub.callback(result); },
                 reject: (err) => { sub.onError?.(err as Error); },
             });
-            this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params });
+            this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params, ...(sub.onPatch ? { patch: true } : {}) });
         }
         this.notifyLoadingChange();
     }
@@ -1271,10 +1329,11 @@ export class ApiClient {
         };
     }
 
-    subscribe<T>(method: string, params: unknown[], callback: (data: T) => void, onError?: (error: Error) => void): () => void {
+    subscribe<T>(method: string, params: unknown[], callback: (data: T) => void, onError?: (error: Error) => void, options?: SubscribeOptions): () => void {
         const id = String(++this.requestId);
         const cb = callback as (data: unknown) => void;
-        this.subscriptions.set(id, { method, params, callback: cb, onError });
+        const onPatch = options?.onPatch;
+        this.subscriptions.set(id, { method, params, callback: cb, onError, onPatch });
 
         // Register in pending for the initial response
         this.pending.set(id, {
@@ -1283,7 +1342,7 @@ export class ApiClient {
         });
 
         if (this.transport.isConnected()) {
-            this.transport.send({ type: 'subscribe', id, method, params });
+            this.transport.send({ type: 'subscribe', id, method, params, ...(onPatch ? { patch: true } : {}) });
         }
 
         return () => {

--- a/example/vanilla/client/static/api/protected-handlers.ts
+++ b/example/vanilla/client/static/api/protected-handlers.ts
@@ -24,8 +24,8 @@ export function getProfile(client: ApiClient, options?: RequestOptions): Promise
     return client.request<GetProfileResponse>('ProtectedHandlers.GetProfile', [], options);
 }
 
-export function subscribeGetProfile(client: ApiClient, callback: (data: GetProfileResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<GetProfileResponse>('ProtectedHandlers.GetProfile', [], callback, onError);
+export function subscribeGetProfile(client: ApiClient, callback: (data: GetProfileResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<GetProfileResponse>('ProtectedHandlers.GetProfile', [], callback, onError, options);
 }
 
 
@@ -33,8 +33,8 @@ export function sendMessage(client: ApiClient, toUserID: string, message: string
     return client.request<SendMessageResponse>('ProtectedHandlers.SendMessage', [toUserID, message], options);
 }
 
-export function subscribeSendMessage(client: ApiClient, toUserID: string, message: string, callback: (data: SendMessageResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<SendMessageResponse>('ProtectedHandlers.SendMessage', [toUserID, message], callback, onError);
+export function subscribeSendMessage(client: ApiClient, toUserID: string, message: string, callback: (data: SendMessageResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<SendMessageResponse>('ProtectedHandlers.SendMessage', [toUserID, message], callback, onError, options);
 }
 
 export function onDirectMessageEvent(client: ApiClient, handler: PushHandler<DirectMessageEvent>): () => void {

--- a/example/vanilla/client/static/api/public-handlers.ts
+++ b/example/vanilla/client/static/api/public-handlers.ts
@@ -77,8 +77,8 @@ export function createUser(client: ApiClient, name: string, email: string, optio
     return client.request<CreateUserResponse>('PublicHandlers.CreateUser', [name, email], options);
 }
 
-export function subscribeCreateUser(client: ApiClient, name: string, email: string, callback: (data: CreateUserResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<CreateUserResponse>('PublicHandlers.CreateUser', [name, email], callback, onError);
+export function subscribeCreateUser(client: ApiClient, name: string, email: string, callback: (data: CreateUserResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<CreateUserResponse>('PublicHandlers.CreateUser', [name, email], callback, onError, options);
 }
 
 
@@ -86,8 +86,8 @@ export function getTask(client: ApiClient, id: string, options?: RequestOptions)
     return client.request<GetTaskResponse>('PublicHandlers.GetTask', [id], options);
 }
 
-export function subscribeGetTask(client: ApiClient, id: string, callback: (data: GetTaskResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<GetTaskResponse>('PublicHandlers.GetTask', [id], callback, onError);
+export function subscribeGetTask(client: ApiClient, id: string, callback: (data: GetTaskResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<GetTaskResponse>('PublicHandlers.GetTask', [id], callback, onError, options);
 }
 
 
@@ -95,8 +95,8 @@ export function getUser(client: ApiClient, id: string, options?: RequestOptions)
     return client.request<GetUserResponse>('PublicHandlers.GetUser', [id], options);
 }
 
-export function subscribeGetUser(client: ApiClient, id: string, callback: (data: GetUserResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<GetUserResponse>('PublicHandlers.GetUser', [id], callback, onError);
+export function subscribeGetUser(client: ApiClient, id: string, callback: (data: GetUserResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<GetUserResponse>('PublicHandlers.GetUser', [id], callback, onError, options);
 }
 
 
@@ -104,8 +104,8 @@ export function listUsers(client: ApiClient, options?: RequestOptions): Promise<
     return client.request<ListUsersResponse>('PublicHandlers.ListUsers', [], options);
 }
 
-export function subscribeListUsers(client: ApiClient, callback: (data: ListUsersResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<ListUsersResponse>('PublicHandlers.ListUsers', [], callback, onError);
+export function subscribeListUsers(client: ApiClient, callback: (data: ListUsersResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<ListUsersResponse>('PublicHandlers.ListUsers', [], callback, onError, options);
 }
 
 
@@ -113,8 +113,8 @@ export function login(client: ApiClient, username: string, password: string, opt
     return client.request<LoginResponse>('PublicHandlers.Login', [username, password], options);
 }
 
-export function subscribeLogin(client: ApiClient, username: string, password: string, callback: (data: LoginResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<LoginResponse>('PublicHandlers.Login', [username, password], callback, onError);
+export function subscribeLogin(client: ApiClient, username: string, password: string, callback: (data: LoginResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<LoginResponse>('PublicHandlers.Login', [username, password], callback, onError, options);
 }
 
 
@@ -122,8 +122,8 @@ export function processBatch(client: ApiClient, items: string[], delay: number, 
     return client.request<ProcessBatchResponse>('PublicHandlers.ProcessBatch', [items, delay], options);
 }
 
-export function subscribeProcessBatch(client: ApiClient, items: string[], delay: number, callback: (data: ProcessBatchResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<ProcessBatchResponse>('PublicHandlers.ProcessBatch', [items, delay], callback, onError);
+export function subscribeProcessBatch(client: ApiClient, items: string[], delay: number, callback: (data: ProcessBatchResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<ProcessBatchResponse>('PublicHandlers.ProcessBatch', [items, delay], callback, onError, options);
 }
 
 
@@ -131,8 +131,8 @@ export function processWithSubTasks(client: ApiClient, steps: string[], delay: n
     return client.request<ProcessWithSubTasksResponse>('PublicHandlers.ProcessWithSubTasks', [steps, delay], options);
 }
 
-export function subscribeProcessWithSubTasks(client: ApiClient, steps: string[], delay: number, callback: (data: ProcessWithSubTasksResponse) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<ProcessWithSubTasksResponse>('PublicHandlers.ProcessWithSubTasks', [steps, delay], callback, onError);
+export function subscribeProcessWithSubTasks(client: ApiClient, steps: string[], delay: number, callback: (data: ProcessWithSubTasksResponse) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<ProcessWithSubTasksResponse>('PublicHandlers.ProcessWithSubTasks', [steps, delay], callback, onError, options);
 }
 
 
@@ -140,8 +140,8 @@ export function sendNotification(client: ApiClient, message: string, level: stri
     return client.request<SystemNotificationEvent>('PublicHandlers.SendNotification', [message, level], options);
 }
 
-export function subscribeSendNotification(client: ApiClient, message: string, level: string, callback: (data: SystemNotificationEvent) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<SystemNotificationEvent>('PublicHandlers.SendNotification', [message, level], callback, onError);
+export function subscribeSendNotification(client: ApiClient, message: string, level: string, callback: (data: SystemNotificationEvent) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<SystemNotificationEvent>('PublicHandlers.SendNotification', [message, level], callback, onError, options);
 }
 
 
@@ -149,8 +149,8 @@ export function startSharedWork(client: ApiClient, title: string, steps: string[
     return client.request<void>('PublicHandlers.StartSharedWork', [title, steps, delay], options);
 }
 
-export function subscribeStartSharedWork(client: ApiClient, title: string, steps: string[], delay: number, callback: (data: void) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<void>('PublicHandlers.StartSharedWork', [title, steps, delay], callback, onError);
+export function subscribeStartSharedWork(client: ApiClient, title: string, steps: string[], delay: number, callback: (data: void) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<void>('PublicHandlers.StartSharedWork', [title, steps, delay], callback, onError, options);
 }
 
 export function onUserCreatedEvent(client: ApiClient, handler: PushHandler<UserCreatedEvent>): () => void {

--- a/example/vanilla/client/static/api/tasks-handler.ts
+++ b/example/vanilla/client/static/api/tasks-handler.ts
@@ -70,8 +70,8 @@ export function cancelTask(client: ApiClient, taskId: string, options?: RequestO
     return client.request<void>('tasksHandler.CancelTask', [taskId], options);
 }
 
-export function subscribeCancelTask(client: ApiClient, taskId: string, callback: (data: void) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<void>('tasksHandler.CancelTask', [taskId], callback, onError);
+export function subscribeCancelTask(client: ApiClient, taskId: string, callback: (data: void) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<void>('tasksHandler.CancelTask', [taskId], callback, onError, options);
 }
 
 export function onTaskStateEvent(client: ApiClient, handler: PushHandler<TaskStateEvent>): () => void {

--- a/generate_test.go
+++ b/generate_test.go
@@ -1307,8 +1307,12 @@ func TestGenerateNoRequestReact(t *testing.T) {
 		t.Error("Missing useCleanup hook")
 	}
 
-	// Query hook should not require params
-	if strings.Contains(output, "UseQueryOptions<ListItemsResponse>") {
+	// Query hook options are parametrized with the RESPONSE type (so
+	// applyPatch reducers are typed), never with a request type.
+	if !strings.Contains(output, "useListItems(options?: UseQueryOptions<ListItemsResponse>)") {
+		t.Error("Query hook should type its options as UseQueryOptions<ResponseType>")
+	}
+	if strings.Contains(output, "UseQueryOptions<ListItemsRequest>") {
 		t.Error("No-request query hook should not use UseQueryOptions with request type")
 	}
 

--- a/observer.go
+++ b/observer.go
@@ -46,6 +46,13 @@ type Observer interface {
 	// large fan-out for a single trigger is an amplification signal.
 	RefreshFanout(key string, matched int)
 
+	// PatchFanout fires once per [Server.PatchSubscription] call, reporting how
+	// many matching subscriptions received the patch frame and how many fell
+	// back to a full refresh (clients without patch support). A persistently
+	// non-zero refreshed count means some clients were generated before patch
+	// support and still pay full-result amplification.
+	PatchFanout(key string, patched, refreshed int)
+
 	// SendBufferFull fires when a connection's outbound WebSocket buffer is full
 	// at enqueue time — an early backpressure / slow-consumer signal and the
 	// precursor to a stalled-client write timeout. The frame is not dropped: the
@@ -96,5 +103,6 @@ func (NoopObserver) RequestCompleted(RequestEvent)                  {}
 func (NoopObserver) SubscriptionRegistered(*Conn, string, string)   {}
 func (NoopObserver) SubscriptionUnregistered(*Conn, string, string) {}
 func (NoopObserver) RefreshFanout(string, int)                      {}
+func (NoopObserver) PatchFanout(string, int, int)                   {}
 func (NoopObserver) SendBufferFull(*Conn)                           {}
 func (NoopObserver) WriteTimedOut(*Conn)                            {}

--- a/protocol.go
+++ b/protocol.go
@@ -18,9 +18,13 @@ const (
 	TypeConnected   MessageType = "connected"
 	TypeSubscribe   MessageType = "subscribe"
 	TypeUnsubscribe MessageType = "unsubscribe"
-	TypeStreamItem  MessageType = "stream_item"
-	TypeStreamChunk MessageType = "stream_chunk"
-	TypeStreamEnd   MessageType = "stream_end"
+	// TypeSubscriptionPatch is a server->client frame carrying a partial
+	// update for an active subscription, pushed by [PatchSubscription]
+	// instead of re-running the query and re-sending the full result.
+	TypeSubscriptionPatch MessageType = "subscription_patch"
+	TypeStreamItem        MessageType = "stream_item"
+	TypeStreamChunk       MessageType = "stream_chunk"
+	TypeStreamEnd         MessageType = "stream_end"
 	// TypeAuth is a client->server frame carrying a token for first-message
 	// authentication (and mid-session token refresh). TypeAuthOK / TypeAuthError
 	// are the server's responses.
@@ -45,6 +49,20 @@ type IncomingMessage struct {
 	// Token carries the auth token on a TypeAuth frame (first-message auth and
 	// mid-session refresh). Empty for all other message types.
 	Token string `json:"token,omitempty"`
+	// Patch, on a TypeSubscribe frame, declares that the client can apply
+	// subscription_patch frames for this subscription. Servers fall back to a
+	// full refresh for subscriptions without it (see [PatchSubscription]).
+	Patch bool `json:"patch,omitempty"`
+}
+
+// SubscriptionPatchMessage carries a partial update for an active
+// subscription, sent by [PatchSubscription] to subscribers that declared
+// patch support at subscribe time. The patch payload is opaque to aprot;
+// the client applies it with the reducer registered for the subscription.
+type SubscriptionPatchMessage struct {
+	Type  MessageType    `json:"type"`
+	ID    string         `json:"id"`
+	Patch jsontext.Value `json:"patch"`
 }
 
 // AuthResultMessage is the server's response to a TypeAuth frame: TypeAuthOK on

--- a/subscription.go
+++ b/subscription.go
@@ -21,6 +21,10 @@ type subscription struct {
 	method string              // handler method name
 	keys   map[string]struct{} // trigger keys this subscription depends on
 	params jsontext.Value      // raw JSON params for server-driven re-execution
+	// wantsPatch records that the client declared patch support for this
+	// subscription; PatchSubscription sends subscription_patch frames to
+	// these and falls back to a full refresh for the rest.
+	wantsPatch bool
 }
 
 // subscriptionManager tracks all active subscriptions across connections.
@@ -203,16 +207,18 @@ func (sm *subscriptionManager) updateKeys(connID uint64, subID string, newKeys m
 	}
 }
 
-// updateParams replaces the stored raw params for a subscription. Called when
-// a client re-subscribes with the same ID but different params, so that
-// server-driven re-execution uses the latest params rather than stale ones.
-func (sm *subscriptionManager) updateParams(connID uint64, subID string, params jsontext.Value) {
+// updateParams replaces the stored raw params and patch support for a
+// subscription. Called when a client re-subscribes with the same ID but
+// different params, so that server-driven re-execution uses the latest params
+// rather than stale ones (and the latest patch-support declaration).
+func (sm *subscriptionManager) updateParams(connID uint64, subID string, params jsontext.Value, wantsPatch bool) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	if connSubs, ok := sm.byConn[connID]; ok {
 		if sub, ok := connSubs[subID]; ok {
 			sub.params = params
+			sub.wantsPatch = wantsPatch
 		}
 	}
 }
@@ -382,6 +388,91 @@ func TriggerRefreshNow(ctx context.Context, keys ...string) {
 	if server != nil {
 		server.processRefreshQueue(rq)
 	}
+}
+
+// PatchSubscription pushes a partial update to every subscription matching
+// the given trigger keys, without re-running the subscribed query. Call it
+// from mutation handlers whose effect on a large subscribed result is small —
+// e.g. one edited row in a several-thousand-row list — so the wire cost is
+// O(patch) instead of O(full result):
+//
+//	func (h *Handlers) SetRating(ctx context.Context, id string, rating int) error {
+//	    h.store.SetRating(id, rating)
+//	    return aprot.PatchSubscription(ctx, PhotoPatch{ID: id, Rating: rating}, "photos")
+//	}
+//
+// The patch payload is marshaled once and delivered as a subscription_patch
+// frame to every subscriber that declared patch support (generated clients do
+// so when the subscription registers an applyPatch/onPatch reducer).
+// Subscribers without patch support fall back to a full refresh — their query
+// re-executes exactly as [TriggerRefresh] would — so mixed client fleets stay
+// consistent. Keys form one composite key, matching [RegisterRefreshTrigger].
+//
+// Patches are delivered immediately, not batched with the surrounding
+// request; a subscriber may observe the patch before the mutation's own
+// response settles. Use patches for in-place updates to existing entries and
+// keep [TriggerRefresh] for structural changes (items added or removed).
+//
+// Returns an error only when the patch cannot be marshaled; delivery is
+// fire-and-forget like every other server->client frame. Outside a request
+// context (including during subscription re-execution) this is a no-op —
+// use [Server.PatchSubscription] from background goroutines.
+func PatchSubscription(ctx context.Context, patch any, keys ...string) error {
+	rq, ok := ctx.Value(refreshQueueKey).(*refreshQueue)
+	if !ok || rq == nil {
+		return nil
+	}
+	rq.mu.Lock()
+	server := rq.server
+	rq.mu.Unlock()
+	if server == nil {
+		return nil
+	}
+	return server.PatchSubscription(patch, keys...)
+}
+
+// PatchSubscription is like the package-level [PatchSubscription] but callable
+// from background goroutines, cron jobs, webhook fan-in, or any other
+// out-of-request code path.
+func (s *Server) PatchSubscription(patch any, keys ...string) error {
+	rawPatch, err := marshalJSON(patch)
+	if err != nil {
+		return err
+	}
+	key := compositeKey(keys...)
+	subs := s.subscriptions.getSubscriptionsForKey(key)
+
+	patched, refreshed := 0, 0
+	for _, sub := range subs {
+		if !sub.wantsPatch {
+			refreshed++
+			s.requestsWg.Add(1)
+			go sub.conn.refreshSubscription(sub)
+			continue
+		}
+		patched++
+		data, err := marshalJSON(SubscriptionPatchMessage{
+			Type:  TypeSubscriptionPatch,
+			ID:    sub.id,
+			Patch: rawPatch,
+		})
+		if err != nil {
+			// The patch itself marshaled above, so only the envelope can fail
+			// here — which it cannot for valid IDs; skip defensively.
+			continue
+		}
+		// Deliver per subscriber in its own goroutine so one slow client's
+		// backpressure cannot stall the fan-out (mirrors refresh dispatch).
+		s.requestsWg.Add(1)
+		go func(c *Conn, data []byte) {
+			defer s.requestsWg.Done()
+			_ = c.sendRaw(data)
+		}(sub.conn, data)
+	}
+	if s.observer != nil {
+		s.observer.PatchFanout(key, patched, refreshed)
+	}
+	return nil
 }
 
 // TriggerRefresh fires a refresh for all subscriptions matching the given keys,

--- a/subscription_patch_test.go
+++ b/subscription_patch_test.go
@@ -1,0 +1,171 @@
+package aprot
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+// patchTestHandlers provides a subscribable query for fallback-refresh tests.
+type patchTestHandlers struct{}
+
+type patchTestList struct {
+	Items []string `json:"items"`
+}
+
+func (patchTestHandlers) GetList(ctx context.Context) (*patchTestList, error) {
+	RegisterRefreshTrigger(ctx, "items")
+	return &patchTestList{Items: []string{"a", "b"}}, nil
+}
+
+// newPatchTestConn builds a server-backed conn on a recording transport.
+func newPatchTestConn(t *testing.T) (*Server, *Conn, *recordingTransport) {
+	t.Helper()
+	r := NewRegistry()
+	r.Register(&patchTestHandlers{})
+	s := NewServer(r)
+	rt := &recordingTransport{}
+	c := &Conn{
+		transport: rt,
+		server:    s,
+		requests:  make(map[string]context.CancelCauseFunc),
+		id:        1,
+	}
+	return s, c, rt
+}
+
+// subscribeForPatch runs a real subscribe flow, asserts the initial response,
+// and returns the number of frames recorded so far (so callers can slice off
+// only the frames produced after the subscribe).
+func subscribeForPatch(t *testing.T, c *Conn, rt *recordingTransport, id string, wantsPatch bool) int {
+	t.Helper()
+	before := len(drainMessages(t, rt))
+	c.server.requestsWg.Add(1)
+	c.handleSubscribe(IncomingMessage{
+		Type:   TypeSubscribe,
+		ID:     id,
+		Method: "patchTestHandlers.GetList",
+		Patch:  wantsPatch,
+	})
+	msgs := drainMessages(t, rt)
+	if len(msgs) != before+1 || msgs[len(msgs)-1]["type"] != "response" {
+		t.Fatalf("subscribe: expected 1 new response, got %v", msgs[before:])
+	}
+	return len(msgs)
+}
+
+// messagesAfter returns the decoded frames recorded after the first n.
+func messagesAfter(t *testing.T, rt *recordingTransport, n int) []map[string]any {
+	t.Helper()
+	return drainMessages(t, rt)[n:]
+}
+
+func TestPatchSubscription_SendsPatchFrameToOptedInSubscriber(t *testing.T) {
+	s, c, rt := newPatchTestConn(t)
+	n := subscribeForPatch(t, c, rt, "sub-1", true)
+
+	if err := s.PatchSubscription(map[string]any{"id": "a", "rating": 3}, "items"); err != nil {
+		t.Fatalf("PatchSubscription: %v", err)
+	}
+	s.requestsWg.Wait()
+
+	msgs := messagesAfter(t, rt, n)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 patch frame, got %d: %v", len(msgs), msgs)
+	}
+	if msgs[0]["type"] != "subscription_patch" {
+		t.Fatalf("type = %v, want subscription_patch", msgs[0]["type"])
+	}
+	if msgs[0]["id"] != "sub-1" {
+		t.Fatalf("id = %v, want sub-1", msgs[0]["id"])
+	}
+	patch, ok := msgs[0]["patch"].(map[string]any)
+	if !ok {
+		t.Fatalf("patch missing or wrong shape: %v", msgs[0]["patch"])
+	}
+	if patch["id"] != "a" || patch["rating"] != float64(3) {
+		t.Fatalf("unexpected patch payload: %v", patch)
+	}
+}
+
+func TestPatchSubscription_FallsBackToRefreshWithoutPatchSupport(t *testing.T) {
+	s, c, rt := newPatchTestConn(t)
+	n := subscribeForPatch(t, c, rt, "sub-1", false)
+
+	if err := s.PatchSubscription(map[string]any{"id": "a"}, "items"); err != nil {
+		t.Fatalf("PatchSubscription: %v", err)
+	}
+	s.requestsWg.Wait()
+
+	msgs := messagesAfter(t, rt, n)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 refresh response, got %d: %v", len(msgs), msgs)
+	}
+	if msgs[0]["type"] != "response" {
+		t.Fatalf("type = %v, want response (full refresh fallback)", msgs[0]["type"])
+	}
+	if msgs[0]["id"] != "sub-1" {
+		t.Fatalf("id = %v, want sub-1", msgs[0]["id"])
+	}
+}
+
+func TestPatchSubscription_ResubscribeUpdatesPatchSupport(t *testing.T) {
+	s, c, rt := newPatchTestConn(t)
+	subscribeForPatch(t, c, rt, "sub-1", false)
+	// Re-subscribe with the same ID, now declaring patch support.
+	n := subscribeForPatch(t, c, rt, "sub-1", true)
+
+	if err := s.PatchSubscription(map[string]any{"id": "a"}, "items"); err != nil {
+		t.Fatalf("PatchSubscription: %v", err)
+	}
+	s.requestsWg.Wait()
+
+	msgs := messagesAfter(t, rt, n)
+	if len(msgs) != 1 || msgs[0]["type"] != "subscription_patch" {
+		t.Fatalf("expected subscription_patch after re-subscribe upgrade, got %v", msgs)
+	}
+}
+
+func TestPatchSubscription_MarshalErrorReturned(t *testing.T) {
+	s, c, rt := newPatchTestConn(t)
+	n := subscribeForPatch(t, c, rt, "sub-1", true)
+
+	if err := s.PatchSubscription(math.NaN(), "items"); err == nil {
+		t.Fatal("expected marshal error for NaN patch, got nil")
+	}
+	s.requestsWg.Wait()
+	if msgs := messagesAfter(t, rt, n); len(msgs) != 0 {
+		t.Fatalf("expected no frames after marshal failure, got %v", msgs)
+	}
+}
+
+func TestPatchSubscription_NoSubscribers(t *testing.T) {
+	s, _, _ := newPatchTestConn(t)
+	if err := s.PatchSubscription(map[string]any{"id": "a"}, "items"); err != nil {
+		t.Fatalf("PatchSubscription with no subscribers: %v", err)
+	}
+}
+
+func TestPatchSubscriptionCtx_DeliversViaRequestContext(t *testing.T) {
+	s, c, rt := newPatchTestConn(t)
+	n := subscribeForPatch(t, c, rt, "sub-1", true)
+
+	ctx := withRefreshQueue(context.Background(), &refreshQueue{server: s})
+	if err := PatchSubscription(ctx, map[string]any{"id": "a"}, "items"); err != nil {
+		t.Fatalf("PatchSubscription(ctx): %v", err)
+	}
+	s.requestsWg.Wait()
+
+	msgs := messagesAfter(t, rt, n)
+	if len(msgs) != 1 || msgs[0]["type"] != "subscription_patch" {
+		t.Fatalf("expected subscription_patch, got %v", msgs)
+	}
+}
+
+func TestPatchSubscriptionCtx_NoOpOutsideRequest(t *testing.T) {
+	// No refresh queue in context (e.g. subscription re-execution, or a
+	// background goroutine): must be a silent no-op, mirroring TriggerRefresh.
+	if err := PatchSubscription(context.Background(), map[string]any{"id": "a"}, "items"); err != nil {
+		t.Fatalf("expected nil error outside request context, got %v", err)
+	}
+}

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -76,6 +76,49 @@ export function getValidationErrors(err: unknown): FieldError[] | null {
     return err.data as FieldError[];
 }
 
+/**
+ * Options for {@link ApiClient.subscribe} and generated `subscribeX` helpers.
+ */
+export interface SubscribeOptions {
+    /**
+     * Called when the server pushes a `subscription_patch` frame for this
+     * subscription (see the server-side `aprot.PatchSubscription`). Providing
+     * it declares patch support to the server; without it, the server falls
+     * back to a full refresh (re-running the query and re-sending the result).
+     * The patch payload is whatever the mutation handler pushed — apply it to
+     * your local copy of the data.
+     */
+    onPatch?: (patch: unknown) => void;
+}
+
+/**
+ * Builds an `applyPatch` reducer for the common case: the subscribed result
+ * is an array of objects with a unique key field, and patches are partial
+ * objects (or arrays of them) carrying that key. Entries matching a patch's
+ * key are shallow-merged; patches with no matching entry are ignored — use a
+ * full refresh (server-side `TriggerRefresh`) for structural changes like
+ * added or removed items.
+ *
+ *   const { data } = useListPhotos({ applyPatch: mergeByKey('id') });
+ *
+ * For wrapped results (e.g. `{ photos: Photo[] }`) or richer semantics,
+ * write the reducer by hand: `(data, patch) => ({ ...data, photos: ... })`.
+ */
+export function mergeByKey<T extends object>(key: keyof T & string): (data: T[], patch: unknown) => T[] {
+    return (data: T[], patch: unknown): T[] => {
+        const patches = (Array.isArray(patch) ? patch : [patch]) as Array<Partial<T> & Record<string, unknown>>;
+        const byKey = new Map<unknown, Partial<T>>();
+        for (const p of patches) {
+            if (p && typeof p === 'object' && key in p) byKey.set(p[key], p);
+        }
+        if (byKey.size === 0) return data;
+        return data.map((item) => {
+            const p = byKey.get((item as Record<string, unknown>)[key]);
+            return p ? { ...item, ...p } : item;
+        });
+    };
+}
+
 // Shared decoder for binary frame headers — small and reused per message.
 const binaryHeaderDecoder = new TextDecoder();
 
@@ -540,6 +583,7 @@ export class ApiClient {
         params: unknown[];
         callback: (data: unknown) => void;
         onError?: (error: Error) => void;
+        onPatch?: (patch: unknown) => void;
     }>();
     private streams = new Map<string, {
         push: (item: unknown) => void;
@@ -990,6 +1034,20 @@ export class ApiClient {
                 this.settleResponse(msg.id, decodeBlobResult(msg.result));
                 break;
             }
+            case 'subscription_patch': {
+                const sub = this.subscriptions.get(msg.id);
+                if (!sub) break;
+                if (sub.onPatch) {
+                    sub.onPatch(msg.patch);
+                } else if (this.transport.isConnected()) {
+                    // Defensive: the server only sends patches to subscriptions
+                    // that declared support, so this should not happen — but if
+                    // it does, re-subscribe to fetch the full result rather
+                    // than silently going stale.
+                    this.transport.send({ type: 'subscribe', id: msg.id, method: sub.method, params: sub.params });
+                }
+                break;
+            }
             case 'error': {
                 const p = this.pending.get(msg.id);
                 if (p) {
@@ -1261,7 +1319,7 @@ export class ApiClient {
                 resolve: (result) => { sub.callback(result); },
                 reject: (err) => { sub.onError?.(err as Error); },
             });
-            this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params });
+            this.transport.send({ type: 'subscribe', id, method: sub.method, params: sub.params, ...(sub.onPatch ? { patch: true } : {}) });
         }
         this.notifyLoadingChange();
     }
@@ -1277,10 +1335,11 @@ export class ApiClient {
         };
     }
 
-    subscribe<T>(method: string, params: unknown[], callback: (data: T) => void, onError?: (error: Error) => void): () => void {
+    subscribe<T>(method: string, params: unknown[], callback: (data: T) => void, onError?: (error: Error) => void, options?: SubscribeOptions): () => void {
         const id = String(++this.requestId);
         const cb = callback as (data: unknown) => void;
-        this.subscriptions.set(id, { method, params, callback: cb, onError });
+        const onPatch = options?.onPatch;
+        this.subscriptions.set(id, { method, params, callback: cb, onError, onPatch });
 
         // Register in pending for the initial response
         this.pending.set(id, {
@@ -1289,7 +1348,7 @@ export class ApiClient {
         });
 
         if (this.transport.isConnected()) {
-            this.transport.send({ type: 'subscribe', id, method, params });
+            this.transport.send({ type: 'subscribe', id, method, params, ...(onPatch ? { patch: true } : {}) });
         }
 
         return () => {
@@ -1657,7 +1716,23 @@ export function useIsLoading(): boolean {
 /**
  * Options for {@link useQuery} hooks.
  */
-export interface UseQueryOptions {
+export interface UseQueryOptions<TData = unknown> {
+    /**
+     * Reducer applying server-pushed `subscription_patch` payloads to the
+     * current `data` without a refetch (see the server-side
+     * `aprot.PatchSubscription`). Providing it declares patch support for the
+     * subscription; without it, the server falls back to re-running the query
+     * and re-sending the full result. Must be pure: return a new value,
+     * never mutate `data` in place. For keyed-array results, `mergeByKey`
+     * builds the common shallow-merge reducer:
+     *
+     *   useListPhotos({ applyPatch: mergeByKey('id') })
+     *
+     * In cached mode the patch is applied to the shared cache snapshot, so
+     * every component using the same hook sees it. Only applies in
+     * subscription mode.
+     */
+    applyPatch?: (data: TData, patch: unknown) => TData;
     /**
      * When `false`, the query will not execute. Useful for conditional fetching
      * (e.g., wait until an ID is available). Defaults to `true`.
@@ -1875,6 +1950,15 @@ interface SubscriptionCacheEntry {
     listeners: Set<() => void>;
     refCount: number;
     unsubscribe: (() => void) | null;
+    /** Reducer applying subscription_patch payloads to the cached data. */
+    applyPatch?: (data: unknown, patch: unknown) => unknown;
+    /**
+     * Patches that arrived before the initial subscribe response. The server
+     * may push a patch between registering the subscription and sending the
+     * first result, and that result can predate the patch's mutation — so
+     * these are replayed on top of the first data instead of being dropped.
+     */
+    pendingPatches: unknown[];
 }
 
 const subscriptionCaches = new WeakMap<ApiClient, Map<string, SubscriptionCacheEntry>>();
@@ -1893,6 +1977,7 @@ function subscribeCached<T>(
     key: string,
     method: string,
     params: unknown[],
+    applyPatch?: (data: T, patch: unknown) => T,
 ): {
     subscribe: (listener: () => void) => () => void;
     getSnapshot: () => SubscriptionSnapshot<T>;
@@ -1911,8 +1996,12 @@ function subscribeCached<T>(
                 listeners: new Set(),
                 refCount: 0,
                 unsubscribe: null,
+                pendingPatches: [],
             };
             cache.set(key, entry);
+        }
+        if (applyPatch) {
+            entry.applyPatch = applyPatch as (data: unknown, patch: unknown) => unknown;
         }
         entry.listeners.add(listener);
         entry.refCount++;
@@ -1923,13 +2012,30 @@ function subscribeCached<T>(
                 method,
                 params,
                 (result) => {
-                    e.snapshot = { data: result, error: null, isLoading: false };
+                    let data: unknown = result;
+                    // Replay patches that raced ahead of this (re)load — the
+                    // result may have been computed before their mutations.
+                    if (e.applyPatch && data !== null) {
+                        for (const p of e.pendingPatches) data = e.applyPatch(data, p);
+                    }
+                    e.pendingPatches = [];
+                    e.snapshot = { data, error: null, isLoading: false };
                     notify(e);
                 },
                 (err) => {
                     e.snapshot = { ...e.snapshot, error: err, isLoading: false };
                     notify(e);
                 },
+                applyPatch ? {
+                    onPatch: (patch) => {
+                        if (e.snapshot.data === null || !e.applyPatch) {
+                            e.pendingPatches.push(patch);
+                            return;
+                        }
+                        e.snapshot = { ...e.snapshot, data: e.applyPatch(e.snapshot.data, patch) };
+                        notify(e);
+                    },
+                } : undefined,
             );
         }
 
@@ -2030,11 +2136,11 @@ function updateCachedSnapshot<T>(
  * (unmount, param change, or React Strict Mode re-run), which cancels the
  * Go handler's `context.Context`.
  */
-export function useQuery<TRes>(fn: (client: ApiClient, signal: AbortSignal) => Promise<TRes>, options?: UseQueryOptions): UseQueryResult<TRes>;
-export function useQuery<TArgs extends unknown[], TRes>(fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>, options: UseQueryOptions & { params: TArgs }): UseQueryResult<TRes>;
+export function useQuery<TRes>(fn: (client: ApiClient, signal: AbortSignal) => Promise<TRes>, options?: UseQueryOptions<TRes>): UseQueryResult<TRes>;
+export function useQuery<TArgs extends unknown[], TRes>(fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>, options: UseQueryOptions<TRes> & { params: TArgs }): UseQueryResult<TRes>;
 export function useQuery<TArgs extends unknown[], TRes>(
     fn: (client: ApiClient, signal: AbortSignal, ...args: TArgs) => Promise<TRes>,
-    options?: UseQueryOptions & { params?: TArgs },
+    options?: UseQueryOptions<TRes> & { params?: TArgs },
 ): UseQueryResult<TRes> {
     const client = useApiClient();
     const [data, setData] = useState<TRes | null>(null);
@@ -2061,10 +2167,12 @@ export function useQuery<TArgs extends unknown[], TRes>(
 
     const cacheStore = useMemo(() => {
         if (!shouldCache) return null;
-        return subscribeCached<TRes>(client, cacheKey, subscribeMethod!, subscribeOpts!.params);
+        return subscribeCached<TRes>(client, cacheKey, subscribeMethod!, subscribeOpts!.params, options?.applyPatch);
     // subscribeMethod / subscribeOpts.params are already encoded into cacheKey,
     // so listing them again would force the memo to re-run on identity changes
-    // even when the resolved key is unchanged.
+    // even when the resolved key is unchanged. applyPatch is intentionally
+    // omitted too: inline reducers change identity every render, and the cache
+    // entry keeps the latest reducer via subscribeCached's subscribe() path.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [client, cacheKey, shouldCache]);
 
@@ -2123,6 +2231,7 @@ export function useQuery<TArgs extends unknown[], TRes>(
         if (!subscribeMethod || options?.enabled === false) return;
         if (options?.cache !== false && queryCacheEnabled) return; // cached path handles this
         setIsLoading(true);
+        const applyPatch = options?.applyPatch;
         const unsubscribe = client.subscribe<TRes>(
             subscribeMethod,
             subscribeOpts!.params,
@@ -2135,6 +2244,13 @@ export function useQuery<TArgs extends unknown[], TRes>(
                 setError(err);
                 setIsLoading(false);
             },
+            applyPatch ? {
+                // Patches arriving before the first result are dropped here;
+                // the cached path (the default) queues and replays them.
+                onPatch: (patch) => {
+                    setData((d) => (d === null ? d : applyPatch(d, patch)));
+                },
+            } : undefined,
         );
         return unsubscribe;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/templates/client-handler-react.ts.tmpl
+++ b/templates/client-handler-react.ts.tmpl
@@ -68,8 +68,8 @@ export function {{.MethodName}}(client: ApiClient{{if hasParams .Params}}, {{par
 // (unaffected by minification, unlike Function.name).
 {{.MethodName}}.method = '{{.WireMethod}}' as const;
 
-export function {{.SubscribeName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, callback: (data: {{.ResponseType}}) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], callback, onError);
+export function {{.SubscribeName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, callback: (data: {{.ResponseType}}) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], callback, onError, options);
 }
 
 {{end -}}
@@ -123,7 +123,7 @@ export function {{.HookName}}({{if hasParams .Params}}{{paramDecl .Params}}, {{e
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function {{.HookName}}(options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
+export function {{.HookName}}(options?: UseQueryOptions<{{.ResponseType}}>): UseQueryResult<{{.ResponseType}}> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal) => {{.MethodName}}(client, { signal }),
         [],
@@ -138,7 +138,7 @@ export function {{.HookName}}(options?: UseQueryOptions): UseQueryResult<{{.Resp
  * See {@link UseQueryResult} for return value details — including the
  * query-scoped `mutate(action)` helper for refetch-after-mutation flows.
  */
-export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
+export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions<{{.ResponseType}}>): UseQueryResult<{{.ResponseType}}> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, {{paramDecl .Params}}) => {{.MethodName}}(client, {{paramNames .Params}}, { signal }),
         [],

--- a/templates/client-handler.ts.tmpl
+++ b/templates/client-handler.ts.tmpl
@@ -48,8 +48,8 @@ export function {{.MethodName}}(client: ApiClient{{if hasParams .Params}}, {{par
     return client.request<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], options);
 }
 
-export function {{.SubscribeName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, callback: (data: {{.ResponseType}}) => void, onError?: (error: Error) => void): () => void {
-    return client.subscribe<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], callback, onError);
+export function {{.SubscribeName}}(client: ApiClient{{if hasParams .Params}}, {{paramDecl .Params}}{{end}}, callback: (data: {{.ResponseType}}) => void, onError?: (error: Error) => void, options?: { onPatch?: (patch: unknown) => void }): () => void {
+    return client.subscribe<{{.ResponseType}}>('{{.WireMethod}}', [{{paramArray .Params}}], callback, onError, options);
 }
 
 {{end -}}

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -678,7 +678,7 @@ export function {{.HookName}}({{if hasParams .Params}}{{paramDecl .Params}}, {{e
 {{- end}}
 }
 {{- else if not (hasParams .Params)}}
-export function {{.HookName}}(options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
+export function {{.HookName}}(options?: UseQueryOptions<{{.ResponseType}}>): UseQueryResult<{{.ResponseType}}> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal) => {{.MethodName}}(client, { signal }),
         [],
@@ -686,7 +686,7 @@ export function {{.HookName}}(options?: UseQueryOptions): UseQueryResult<{{.Resp
     return useQuery(wrappedFn, options);
 }
 {{- else}}
-export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions): UseQueryResult<{{.ResponseType}}> {
+export function {{.HookName}}({{paramDecl .Params}}, options?: UseQueryOptions<{{.ResponseType}}>): UseQueryResult<{{.ResponseType}}> {
     const wrappedFn = useCallback(
         (client: ApiClient, signal: AbortSignal, {{paramDecl .Params}}) => {{.MethodName}}(client, {{paramNames .Params}}, { signal }),
         [],


### PR DESCRIPTION
Closes #237.

## Summary

Implements **option 1** from the issue (first-class patch pushes) with the acceptance sketch's fallback semantics.

- **`aprot.PatchSubscription(ctx, patch, keys...)`** — mutation handlers push a small typed payload to every subscription under the composite trigger key, instead of re-running the query and re-sending the full result. `Server.PatchSubscription(patch, keys...)` covers background goroutines/cron/webhooks. Errors only on patch marshal failure; no-op outside a request context (mirrors `TriggerRefresh`, prevents refresh cascades).
- **Automatic full-refresh fallback** — clients declare patch support per subscription (`patch: true` on the subscribe frame, sent when a reducer is registered). Subscribers without it — older generated clients, `useQuerySuspense`, hooks that don't pass `applyPatch` — get the classic re-execute-and-resend, so mixed fleets stay consistent.
- **React**: `useQuery` and generated hooks accept `applyPatch(data, patch)`, applied to the **shared query-cache snapshot** — every component on the same hook re-renders with patched data, no refetch. Patches racing ahead of the initial subscribe response are queued and replayed on top of the first result. `UseQueryOptions` is now generic over the response type (`UseQueryOptions<TRes>`).
- **Vanilla**: generated subscribe functions take `{ onPatch }` as a 5th argument.
- **`mergeByKey('id')`** — exported helper building the common reducer: pure shallow-merge of `{id, ...fields}` patches (single or array) into a keyed array; unmatched keys ignored (structural changes stay on `TriggerRefresh`).
- **`Observer.PatchFanout(key, patched, refreshed)`** — reports the split per patch call (non-breaking via the `NoopObserver` embed pattern).

## Wire format

Client→server: `subscribe` frames gain optional `"patch": true`. Server→client: new `{"type":"subscription_patch","id":<sub id>,"patch":<opaque payload>}`.

## Acceptance criteria from #237

- ✅ Rating 1 photo in a subscribed list transfers O(one patch), not O(list) — e2e-verified via a server-side execution counter (query does not re-run).
- ✅ Multiple components sharing the hook see the patch applied to shared cache — e2e react test with two components.
- ✅ Falls back to full refresh for clients/queries that opt out — e2e-verified (exactly one re-execution).

## Verification

- Go: TDD unit tests (fan-out, fallback, re-subscribe flag update, marshal error, no-op paths); `go test ./...` green
- e2e: 19 files / 98 tests pass incl. new `subscription-patch.test.ts` + `react-patch.test.tsx`
- Regenerated example + e2e clients; `npx tsc --noEmit` clean; `gosec ./...` clean; gofmt clean
- Docs updated: README.md, doc.go (new "Subscription Patches" section + wire protocol), APROT_AI.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)