### PR TITLE
tasks: pluggable cancel authorization + reconnect-safe ownership (+ isNotFound codegen fix)

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -492,6 +492,55 @@ type errorCodeData struct {
 	MethodName string // e.g., "isEndOfFile"
 }
 
+// builtinErrorHelpers are the ApiError type-guard method names the client
+// template emits unconditionally. A custom error whose generated helper name
+// (see NamingPlugin.ErrorMethodName) equals one of these would produce a
+// duplicate method — a TypeScript error — so such a registration is rejected at
+// generation time (validateErrorCodes) and skipped in the emitted data
+// (buildCustomErrorCodes).
+var builtinErrorHelpers = map[string]bool{
+	"isUnauthorized":       true,
+	"isForbidden":          true,
+	"isNotFound":           true,
+	"isInvalidParams":      true,
+	"isValidationFailed":   true,
+	"isCanceled":           true,
+	"isConnectionRejected": true,
+	"isTooManyRequests":    true,
+	"isAuthFailed":         true,
+}
+
+// validateErrorCodes records a generation error for each custom error whose
+// generated helper name collides with a built-in ApiError helper. Called once
+// per generation so the collision is reported a single time.
+func (g *Generator) validateErrorCodes() {
+	for _, ec := range g.registry.ErrorCodes() {
+		method := g.naming().ErrorMethodName(ec.Name)
+		if builtinErrorHelpers[method] {
+			g.recordGenError(fmt.Errorf(
+				"custom error %q generates helper %q, which collides with a built-in ApiError method; register the error under a different name (e.g. %q)",
+				ec.Name, method, ec.Name+"Error"))
+		}
+	}
+}
+
+// buildCustomErrorCodes converts the registry's custom error codes to template
+// data, skipping any whose generated helper name collides with a built-in
+// ApiError method. The collision itself is reported once by validateErrorCodes;
+// skipping here keeps the emitted client valid even if a caller ignores the
+// generation error.
+func (g *Generator) buildCustomErrorCodes() []errorCodeData {
+	var out []errorCodeData
+	for _, ec := range g.registry.ErrorCodes() {
+		method := g.naming().ErrorMethodName(ec.Name)
+		if builtinErrorHelpers[method] {
+			continue
+		}
+		out = append(out, errorCodeData{Name: ec.Name, Code: ec.Code, MethodName: method})
+	}
+	return out
+}
+
 // Generate writes TypeScript client code for all handler groups.
 // Returns a map of filename to content, or writes to OutputDir if set.
 // Generates:
@@ -500,6 +549,7 @@ type errorCodeData struct {
 func (g *Generator) Generate() (map[string]string, error) {
 	results := make(map[string]string)
 	g.genErrors = nil
+	g.validateErrorCodes()
 
 	// Phase 1: Pre-scan all groups to find types shared across 2+ groups.
 	// Shared types go into per-package .ts files; group-specific types stay in handler files.
@@ -679,13 +729,7 @@ func (g *Generator) Generate() (map[string]string, error) {
 		StructName: "Base",
 		FileName:   "client.ts",
 	}
-	for _, ec := range g.registry.ErrorCodes() {
-		baseData.CustomErrorCodes = append(baseData.CustomErrorCodes, errorCodeData{
-			Name:       ec.Name,
-			Code:       ec.Code,
-			MethodName: g.naming().ErrorMethodName(ec.Name),
-		})
-	}
+	baseData.CustomErrorCodes = g.buildCustomErrorCodes()
 
 	// Build base type name set for handler import resolution (RequestOptions, PushHandler, etc.)
 	baseTypeNames := make(map[string]bool)
@@ -895,13 +939,7 @@ func (g *Generator) GenerateTo(w io.Writer) error {
 	}
 
 	// Build custom error codes
-	for _, ec := range g.registry.ErrorCodes() {
-		data.CustomErrorCodes = append(data.CustomErrorCodes, errorCodeData{
-			Name:       ec.Name,
-			Code:       ec.Code,
-			MethodName: g.naming().ErrorMethodName(ec.Name),
-		})
-	}
+	data.CustomErrorCodes = g.buildCustomErrorCodes()
 
 	// Build enums
 	data.Enums = g.buildEnums()
@@ -1023,13 +1061,7 @@ func (g *Generator) buildTemplateData(group *HandlerGroup, meta *sourceMeta) tem
 	}
 
 	// Build custom error codes
-	for _, ec := range g.registry.ErrorCodes() {
-		data.CustomErrorCodes = append(data.CustomErrorCodes, errorCodeData{
-			Name:       ec.Name,
-			Code:       ec.Code,
-			MethodName: g.naming().ErrorMethodName(ec.Name),
-		})
-	}
+	data.CustomErrorCodes = g.buildCustomErrorCodes()
 
 	// Build enums (sorted by name for deterministic output)
 	enumTypes := make([]reflect.Type, 0, len(g.collectedEnums))

--- a/generate_test.go
+++ b/generate_test.go
@@ -259,6 +259,50 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
+// A custom error registered under a name whose generated helper collides with
+// a built-in ApiError method (here "NotFound" -> isNotFound) must fail
+// generation with a clear error, and must not emit a duplicate isNotFound
+// method into the client.
+func TestGenerateCustomErrorHelperCollision(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&TestHandlers{})
+	registry.RegisterError(ErrTestNotFound, "NotFound") // collides with built-in isNotFound
+
+	files, err := NewGenerator(registry).Generate()
+	if err == nil {
+		t.Fatal("expected a generation error for the colliding custom error helper, got nil")
+	}
+	if !strings.Contains(err.Error(), "collides") {
+		t.Errorf("error message should explain the collision, got: %v", err)
+	}
+	// Even on error the emitted client (if any) must not contain a duplicate
+	// isNotFound method definition.
+	if base, ok := files["client.ts"]; ok {
+		if strings.Count(base, "isNotFound(): boolean") > 1 {
+			t.Error("client.ts contains a duplicate isNotFound() method")
+		}
+	}
+}
+
+// A custom error whose helper name does not collide generates normally.
+func TestGenerateCustomErrorHelperNoCollision(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&TestHandlers{})
+	registry.RegisterError(ErrTestNotFound, "EntityNotFound")
+
+	files, err := NewGenerator(registry).Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	base := files["client.ts"]
+	if !strings.Contains(base, "isEntityNotFound(): boolean") {
+		t.Error("expected isEntityNotFound() helper in client.ts")
+	}
+	if strings.Count(base, "isNotFound(): boolean") != 1 {
+		t.Error("expected exactly one built-in isNotFound() method")
+	}
+}
+
 func TestGenerateMultipleFiles(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(&TestHandlers{})

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -353,7 +353,7 @@ func startSharedTask[M any](ctx context.Context, title string) (context.Context,
 	if tm == nil {
 		return newDetachedTask[M](ctx, title)
 	}
-	node := tm.create(title, conn.ID(), true, ctx)
+	node := tm.create(title, conn.ID(), conn.UserID(), true, ctx)
 	tm.broadcastNow() // first message shows CREATED
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
@@ -393,7 +393,7 @@ func SharedSubTask(ctx context.Context, title string, fn func(ctx context.Contex
 		return SubTask(ctx, title, fn)
 	}
 
-	node := tm.create(title, conn.ID(), false, ctx)
+	node := tm.create(title, conn.ID(), conn.UserID(), false, ctx)
 	tm.broadcastNow() // first message shows CREATED
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
@@ -418,22 +418,76 @@ func SharedSubTask(ctx context.Context, title string, fn func(ctx context.Contex
 	})
 }
 
-// CancelSharedTask cancels a shared task by ID. Only the connection that
-// created the task may cancel it; any other caller (including one with no
-// connection, such as the REST path) is refused with CodeForbidden. The same
-// error is returned whether the task is missing or owned by someone else, so a
-// caller can't probe for the existence of other clients' tasks.
+// CancelSharedTask cancels a shared task by ID, subject to authorization.
+//
+// When a [CancelAuthorizer] is installed (via [WithCancelAuthorizer]) it decides
+// whether the caller may cancel the task. Otherwise the default policy applies:
+// only the connection that created the task may cancel it, and any other caller
+// (including one with no connection, such as the REST path) is refused with
+// CodeForbidden. Under the default policy the same error is returned whether the
+// task is missing or owned by someone else, so a caller can't probe for the
+// existence of other clients' tasks.
 func CancelSharedTask(ctx context.Context, taskID string) error {
 	tm := taskManagerFromContext(ctx)
 	if tm == nil {
 		return aprot.NewError(aprot.CodeInternalError, "tasks not enabled")
 	}
+
+	tm.mu.Lock()
+	node, ok := tm.tasks[taskID]
+	tm.mu.Unlock()
+
+	var auth CancelAuthorizer
+	if tm.hooks != nil {
+		auth = tm.hooks.cancelAuthorizer
+	}
+	if auth != nil {
+		if !ok {
+			return aprot.NewError(aprot.CodeForbidden, "task not found: "+taskID)
+		}
+		if err := auth(ctx, node.cancelInfo()); err != nil {
+			return err
+		}
+		node.failTop("canceled")
+		return nil
+	}
+
+	// Default policy: owner-by-connection. A missing task and one owned by
+	// another connection are reported identically to prevent probing.
 	conn := aprot.Connection(ctx)
-	if conn == nil {
+	if !ok || conn == nil || node.ownerConnID != conn.ID() {
 		return aprot.NewError(aprot.CodeForbidden, "task not found: "+taskID)
 	}
-	if !tm.cancelTaskOwnedBy(taskID, conn.ID()) {
-		return aprot.NewError(aprot.CodeForbidden, "task not found: "+taskID)
-	}
+	node.failTop("canceled")
 	return nil
+}
+
+// CancelTaskByID cancels a shared task by ID from application code, bypassing
+// any [CancelAuthorizer] — use it for trusted, server-initiated cancellation
+// (an admin action, a custom cancel endpoint, shutdown). It reports whether a
+// live task with that ID was found and canceled. The task manager is resolved
+// from ctx, which must be a task or request context from an aprot handler.
+func CancelTaskByID(ctx context.Context, taskID string) bool {
+	tm := taskManagerFromContext(ctx)
+	if tm == nil {
+		return false
+	}
+	return tm.cancelTask(taskID)
+}
+
+// FindSharedTask returns the current wire state of a live shared task by ID and
+// whether it exists. It lets application code inspect a task outside a snapshot
+// broadcast. The task manager is resolved from ctx.
+func FindSharedTask(ctx context.Context, taskID string) (SharedTaskState, bool) {
+	tm := taskManagerFromContext(ctx)
+	if tm == nil {
+		return SharedTaskState{}, false
+	}
+	tm.mu.Lock()
+	node, ok := tm.tasks[taskID]
+	tm.mu.Unlock()
+	if !ok {
+		return SharedTaskState{}, false
+	}
+	return node.sharedSnapshot(), true
 }

--- a/tasks/enable.go
+++ b/tasks/enable.go
@@ -34,7 +34,7 @@ func Enable(r *aprot.Registry, opts ...EnableOption) {
 		tm := newTaskManager(s, o)
 		s.Use(taskMiddleware(tm))
 		s.OnConnect(func(ctx context.Context, conn *aprot.Conn) error {
-			states := tm.snapshotAllForConn(conn.ID())
+			states := tm.snapshotAllForConn(conn.ID(), conn.UserID())
 			if len(states) > 0 {
 				_ = conn.Push(TaskStateEvent{Tasks: states})
 			}
@@ -65,7 +65,7 @@ func EnableWithMeta[M any](r *aprot.Registry, opts ...EnableOption) {
 		tm := newTaskManager(s, o)
 		s.Use(taskMiddleware(tm))
 		s.OnConnect(func(ctx context.Context, conn *aprot.Conn) error {
-			states := tm.snapshotAllForConn(conn.ID())
+			states := tm.snapshotAllForConn(conn.ID(), conn.UserID())
 			if len(states) > 0 {
 				_ = conn.Push(TaskStateEvent{Tasks: states})
 			}

--- a/tasks/lifecycle_fixes_test.go
+++ b/tasks/lifecycle_fixes_test.go
@@ -91,7 +91,7 @@ func TestProgressThrottleCleanedUpOnRemove(t *testing.T) {
 func TestProgressThrottleCleanedUpForSubtaskOnRemove(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	parent := tm.create("parent", 1, true, context.Background())
+	parent := tm.create("parent", 1, "", true, context.Background())
 	child := parent.createChild("child")
 	child.progress(1, 10) // routes through sharedDelivery → throttles[child.id]
 
@@ -233,7 +233,7 @@ func TestCancelSharedTaskOwnerOnly(t *testing.T) {
 	const ownerID uint64 = 1
 	const otherID uint64 = 2
 
-	node := tm.create("owned task", ownerID, true, context.Background())
+	node := tm.create("owned task", ownerID, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()

--- a/tasks/options.go
+++ b/tasks/options.go
@@ -36,12 +36,32 @@ type TaskInfo struct {
 // is re-raised on the internal goroutine.
 type TaskMiddleware func(ctx context.Context, info TaskInfo, next func(context.Context) error) error
 
+// TaskCancelInfo describes a shared task whose cancellation is being
+// authorized. It is passed to a [CancelAuthorizer].
+type TaskCancelInfo struct {
+	ID          string // task ID
+	Title       string // task title
+	OwnerConnID uint64 // connection that created the task
+	OwnerUserID string // user that created the task ("" if the owner was unauthenticated)
+}
+
+// CancelAuthorizer decides whether the caller identified by ctx may cancel the
+// described shared task. Return nil to allow cancellation, or an error
+// (typically [aprot.ErrForbidden]) to deny it. The ctx is the requesting
+// caller's context, so the authorizer can read aprot.Connection(ctx).UserID()
+// and compare it against task.OwnerUserID.
+//
+// Install one with [WithCancelAuthorizer]. When none is installed the default
+// policy applies: only the connection that created the task may cancel it.
+type CancelAuthorizer func(ctx context.Context, task TaskCancelInfo) error
+
 // EnableOption configures the task system at registration time. Pass
 // options to [Enable] or [EnableWithMeta].
 type EnableOption func(*enableOptions)
 
 type enableOptions struct {
-	middleware TaskMiddleware
+	middleware       TaskMiddleware
+	cancelAuthorizer CancelAuthorizer
 }
 
 func buildEnableOptions(opts []EnableOption) *enableOptions {
@@ -77,4 +97,23 @@ func buildEnableOptions(opts []EnableOption) *enableOptions {
 //	))
 func WithTaskMiddleware(mw TaskMiddleware) EnableOption {
 	return func(o *enableOptions) { o.middleware = mw }
+}
+
+// WithCancelAuthorizer installs a policy deciding who may cancel a shared task
+// via the built-in CancelTask RPC (and [CancelSharedTask]). Without it, only
+// the connection that created a task may cancel it — a policy that also loses
+// cancel rights across a reconnect, since it is keyed by connection ID. An
+// authorizer can implement any policy, e.g. "any authenticated user" or
+// "same user, surviving reconnect":
+//
+//	tasks.EnableWithMeta[Meta](reg, tasks.WithCancelAuthorizer(
+//	    func(ctx context.Context, t tasks.TaskCancelInfo) error {
+//	        if aprot.Connection(ctx).UserID() == "" {
+//	            return aprot.ErrForbidden("not authenticated")
+//	        }
+//	        return nil // any authenticated user may cancel any task
+//	    },
+//	))
+func WithCancelAuthorizer(fn CancelAuthorizer) EnableOption {
+	return func(o *enableOptions) { o.cancelAuthorizer = fn }
 }

--- a/tasks/options_test.go
+++ b/tasks/options_test.go
@@ -345,7 +345,7 @@ func TestMiddlewareCascadeFailure(t *testing.T) {
 	_, tm := setupTestServer(t)
 	tm.hooks = opts // inject after setup since setupTestServer uses nil
 
-	root := tm.create("root", 1, true, context.Background())
+	root := tm.create("root", 1, "", true, context.Background())
 	root.mu.Lock()
 	root.status = TaskNodeStatusRunning
 	root.mu.Unlock()
@@ -420,7 +420,7 @@ func TestMiddlewareIdempotentEnd(t *testing.T) {
 	_, tm := setupTestServer(t)
 	tm.hooks = opts
 
-	node := tm.create("once", 1, true, context.Background())
+	node := tm.create("once", 1, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()
@@ -509,7 +509,7 @@ func TestMiddlewareTerminalBeforeNext(t *testing.T) {
 
 	_, tm := setupTestServer(t)
 	tm.hooks = opts
-	node := tm.create("pre-ended", 1, true, context.Background())
+	node := tm.create("pre-ended", 1, "", true, context.Background())
 
 	// Terminal signal arrives BEFORE runManaged registers its done channel.
 	node.signalMiddlewareEnd(errors.New("canceled"))

--- a/tasks/ownership_test.go
+++ b/tasks/ownership_test.go
@@ -1,0 +1,147 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marrasen/aprot"
+)
+
+// managerWithOptions builds a task manager wired to a real (test) server but
+// with custom enable options, so cancel-authorizer behavior can be exercised.
+func managerWithOptions(t *testing.T, o *enableOptions) *taskManager {
+	t.Helper()
+	registry := aprot.NewRegistry()
+	handler := &sharedTestHandler{}
+	registry.Register(handler)
+	registry.RegisterPushEventFor(handler, TaskStateEvent{})
+	registry.RegisterPushEventFor(handler, TaskUpdateEvent{})
+	server := aprot.NewServer(registry)
+	tm := newTaskManager(server, o)
+	t.Cleanup(func() {
+		tm.stop()
+		_ = server.Stop(context.Background())
+	})
+	return tm
+}
+
+// A cancel authorizer allowing any authenticated user lets a non-owner cancel
+// another user's task, while an unauthenticated caller is refused.
+func TestCancelAuthorizerAllowsAnyAuthenticatedUser(t *testing.T) {
+	authorizer := func(ctx context.Context, _ TaskCancelInfo) error {
+		if aprot.Connection(ctx).UserID() == "" {
+			return aprot.ErrForbidden("not authenticated")
+		}
+		return nil
+	}
+	tm := managerWithOptions(t, &enableOptions{cancelAuthorizer: authorizer})
+
+	node := tm.create("owned by u1", 1, "u1", true, context.Background())
+	node.mu.Lock()
+	node.status = TaskNodeStatusRunning
+	node.mu.Unlock()
+
+	// A different user on a different connection may cancel.
+	otherCtx := withTaskManager(aprot.WithTestConnectionUser(context.Background(), 2, "u2"), tm)
+	if err := CancelSharedTask(otherCtx, node.id); err != nil {
+		t.Fatalf("authorized non-owner was refused: %v", err)
+	}
+	if s := node.sharedSnapshot(); s.Status != TaskNodeStatusFailed {
+		t.Errorf("status after authorized cancel: got %v, want Failed", s.Status)
+	}
+
+	// An unauthenticated caller (no user ID) is refused by the authorizer.
+	node2 := tm.create("also u1", 1, "u1", true, context.Background())
+	node2.mu.Lock()
+	node2.status = TaskNodeStatusRunning
+	node2.mu.Unlock()
+	anonCtx := withTaskManager(aprot.WithTestConnection(context.Background(), 3), tm)
+	if err := CancelSharedTask(anonCtx, node2.id); err == nil {
+		t.Error("unauthenticated caller was allowed to cancel")
+	}
+	if s := node2.sharedSnapshot(); s.Status != TaskNodeStatusRunning {
+		t.Errorf("status after refused cancel: got %v, want Running (untouched)", s.Status)
+	}
+}
+
+// Ownership is matched by user ID when the owner was authenticated, so IsOwner
+// survives a reconnect that lands on a different connection ID.
+func TestSharedTaskOwnershipByUserSurvivesReconnect(t *testing.T) {
+	_, tm := setupTestServer(t)
+
+	node := tm.create("owned by u1", 10, "u1", true, context.Background())
+
+	// Same user, different connection ID (a reconnect): still the owner.
+	if s := node.sharedSnapshotForConn(11, "u1"); !s.IsOwner {
+		t.Error("IsOwner should be true for the same user on a new connection")
+	}
+	// Different user: not the owner, even sharing the original connection ID.
+	if s := node.sharedSnapshotForConn(10, "u2"); s.IsOwner {
+		t.Error("IsOwner should be false for a different user")
+	}
+}
+
+// When the owner was unauthenticated (no user ID), ownership falls back to the
+// creating connection ID, preserving the pre-existing behavior.
+func TestSharedTaskOwnershipFallsBackToConn(t *testing.T) {
+	_, tm := setupTestServer(t)
+
+	node := tm.create("anon task", 7, "", true, context.Background())
+
+	if s := node.sharedSnapshotForConn(7, ""); !s.IsOwner {
+		t.Error("IsOwner should be true for the creating connection when owner is unauthenticated")
+	}
+	if s := node.sharedSnapshotForConn(8, ""); s.IsOwner {
+		t.Error("IsOwner should be false for a different connection")
+	}
+}
+
+// CancelTaskByID cancels regardless of authorizer or connection, and reports
+// whether a live task was found.
+func TestCancelTaskByID(t *testing.T) {
+	tm := managerWithOptions(t, &enableOptions{
+		cancelAuthorizer: func(context.Context, TaskCancelInfo) error {
+			return aprot.ErrForbidden("nobody may cancel via RPC")
+		},
+	})
+
+	node := tm.create("server-cancelable", 1, "u1", true, context.Background())
+	node.mu.Lock()
+	node.status = TaskNodeStatusRunning
+	node.mu.Unlock()
+
+	ctx := withTaskManager(context.Background(), tm)
+	if !CancelTaskByID(ctx, node.id) {
+		t.Fatal("CancelTaskByID returned false for a live task")
+	}
+	if s := node.sharedSnapshot(); s.Status != TaskNodeStatusFailed {
+		t.Errorf("status after CancelTaskByID: got %v, want Failed", s.Status)
+	}
+	if CancelTaskByID(ctx, "no-such-task") {
+		t.Error("CancelTaskByID returned true for a missing task")
+	}
+}
+
+// FindSharedTask returns the current wire state of a live task, and reports
+// absence for unknown IDs.
+func TestFindSharedTask(t *testing.T) {
+	_, tm := setupTestServer(t)
+
+	node := tm.create("findable", 1, "u1", true, context.Background())
+	node.progress(3, 10)
+
+	state, ok := FindSharedTask(withTaskManager(context.Background(), tm), node.id)
+	if !ok {
+		t.Fatal("FindSharedTask did not find a live task")
+	}
+	if state.ID != node.id || state.Title != "findable" {
+		t.Errorf("unexpected state: %+v", state)
+	}
+	if state.Current != 3 || state.Total != 10 {
+		t.Errorf("progress not reflected: got %d/%d, want 3/10", state.Current, state.Total)
+	}
+
+	if _, ok := FindSharedTask(withTaskManager(context.Background(), tm), "missing"); ok {
+		t.Error("FindSharedTask reported a missing task as present")
+	}
+}

--- a/tasks/shared_task.go
+++ b/tasks/shared_task.go
@@ -58,7 +58,7 @@ func (tm *taskManager) allocID() string {
 	return "st" + itoa(n)
 }
 
-func (tm *taskManager) create(title string, connID uint64, topLevel bool, ctx context.Context) *taskNode {
+func (tm *taskManager) create(title string, connID uint64, userID string, topLevel bool, ctx context.Context) *taskNode {
 	taskCtx, cancel := context.WithCancel(ctx)
 
 	id := tm.allocID()
@@ -72,6 +72,7 @@ func (tm *taskManager) create(title string, connID uint64, topLevel bool, ctx co
 		ctx:         taskCtx,
 		manager:     tm,
 		ownerConnID: connID,
+		ownerUserID: userID,
 		topLevel:    topLevel,
 		hooks:       tm.hooks,
 	}
@@ -181,20 +182,6 @@ func (tm *taskManager) cancelTask(id string) bool {
 	return true
 }
 
-// cancelTaskOwnedBy cancels a task only if it is owned by connID. It reports
-// whether the task was found and canceled. ownerConnID is set once at creation
-// and never mutated, so it is safe to read without the task lock.
-func (tm *taskManager) cancelTaskOwnedBy(id string, connID uint64) bool {
-	tm.mu.Lock()
-	node, ok := tm.tasks[id]
-	tm.mu.Unlock()
-	if !ok || node.ownerConnID != connID {
-		return false
-	}
-	node.failTop("canceled")
-	return true
-}
-
 func (tm *taskManager) snapshotAll() []SharedTaskState {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
@@ -205,12 +192,12 @@ func (tm *taskManager) snapshotAll() []SharedTaskState {
 	return states
 }
 
-func (tm *taskManager) snapshotAllForConn(connID uint64) []SharedTaskState {
+func (tm *taskManager) snapshotAllForConn(connID uint64, userID string) []SharedTaskState {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	states := make([]SharedTaskState, 0, len(tm.tasks))
 	for _, node := range tm.tasks {
-		states = append(states, node.sharedSnapshotForConn(connID))
+		states = append(states, node.sharedSnapshotForConn(connID, userID))
 	}
 	return states
 }
@@ -218,7 +205,7 @@ func (tm *taskManager) snapshotAllForConn(connID uint64) []SharedTaskState {
 // broadcastNow sends the full task state to all clients immediately.
 func (tm *taskManager) broadcastNow() {
 	tm.server.ForEachConn(func(conn *aprot.Conn) {
-		states := tm.snapshotAllForConn(conn.ID())
+		states := tm.snapshotAllForConn(conn.ID(), conn.UserID())
 		_ = conn.Push(TaskStateEvent{Tasks: states})
 	})
 }

--- a/tasks/shared_task_test.go
+++ b/tasks/shared_task_test.go
@@ -51,7 +51,7 @@ func findTaskByID(states []SharedTaskState, id string) (SharedTaskState, bool) {
 func TestSharedTaskBasic(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("basic task", 1, true, context.Background())
+	node := tm.create("basic task", 1, "", true, context.Background())
 	id := node.id
 
 	states := tm.snapshotAll()
@@ -82,7 +82,7 @@ func TestSharedTaskBasic(t *testing.T) {
 func TestSharedTaskProgress(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("progress task", 1, true, context.Background())
+	node := tm.create("progress task", 1, "", true, context.Background())
 
 	node.progress(3, 10)
 
@@ -100,7 +100,7 @@ func TestSharedTaskProgress(t *testing.T) {
 func TestSharedTaskSubTask(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("parent task", 1, true, context.Background())
+	node := tm.create("parent task", 1, "", true, context.Background())
 	child := node.createChild("child task")
 
 	if child == nil {
@@ -141,7 +141,7 @@ func TestSharedTaskSubTask(t *testing.T) {
 func TestSharedTaskCancel(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("cancel task", 1, true, context.Background())
+	node := tm.create("cancel task", 1, "", true, context.Background())
 	id := node.id
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
@@ -193,7 +193,7 @@ func TestSharedTaskCancelNonExistent(t *testing.T) {
 func TestSharedTaskFail(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("fail task", 1, true, context.Background())
+	node := tm.create("fail task", 1, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()
@@ -223,7 +223,7 @@ func TestSharedTaskErr(t *testing.T) {
 	t.Run("nil error completes", func(t *testing.T) {
 		_, tm := setupTestServer(t)
 
-		node := tm.create("err nil task", 1, true, context.Background())
+		node := tm.create("err nil task", 1, "", true, context.Background())
 		node.mu.Lock()
 		node.status = TaskNodeStatusRunning
 		node.mu.Unlock()
@@ -247,7 +247,7 @@ func TestSharedTaskErr(t *testing.T) {
 	t.Run("non-nil error fails", func(t *testing.T) {
 		_, tm := setupTestServer(t)
 
-		node := tm.create("err non-nil task", 1, true, context.Background())
+		node := tm.create("err non-nil task", 1, "", true, context.Background())
 		node.mu.Lock()
 		node.status = TaskNodeStatusRunning
 		node.mu.Unlock()
@@ -278,7 +278,7 @@ func TestSharedTaskSubErr(t *testing.T) {
 	t.Run("nil error completes", func(t *testing.T) {
 		_, tm := setupTestServer(t)
 
-		node := tm.create("sub err nil", 1, true, context.Background())
+		node := tm.create("sub err nil", 1, "", true, context.Background())
 		task := &Task[string]{node: node}
 		sub := task.SubTask("sub nil")
 
@@ -296,7 +296,7 @@ func TestSharedTaskSubErr(t *testing.T) {
 	t.Run("non-nil error fails", func(t *testing.T) {
 		_, tm := setupTestServer(t)
 
-		node := tm.create("sub err non-nil", 1, true, context.Background())
+		node := tm.create("sub err non-nil", 1, "", true, context.Background())
 		task := &Task[string]{node: node}
 		sub := task.SubTask("sub fail")
 
@@ -324,7 +324,7 @@ func TestSharedTaskSetMeta(t *testing.T) {
 
 	_, tm := setupTestServer(t)
 
-	node := tm.create("meta task", 1, true, context.Background())
+	node := tm.create("meta task", 1, "", true, context.Background())
 	task := &Task[meta]{node: node}
 	task.SetMeta(meta{UserName: "alice"})
 
@@ -346,7 +346,7 @@ func TestSharedTaskSubSetMeta(t *testing.T) {
 
 	_, tm := setupTestServer(t)
 
-	node := tm.create("parent meta", 1, true, context.Background())
+	node := tm.create("parent meta", 1, "", true, context.Background())
 	task := &Task[meta]{node: node}
 	sub := task.SubTask("sub meta")
 	sub.SetMeta(meta{Step: 7})
@@ -368,7 +368,7 @@ func TestSharedTaskSubSetMeta(t *testing.T) {
 func TestSharedTaskSubSubTask(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("top", 1, true, context.Background())
+	node := tm.create("top", 1, "", true, context.Background())
 	task := &Task[struct{}]{node: node}
 
 	level1 := task.SubTask("level-1")
@@ -404,14 +404,14 @@ func TestSharedTaskSnapshotForConn(t *testing.T) {
 	const ownerID uint64 = 42
 	const otherID uint64 = 99
 
-	node := tm.create("owner task", ownerID, true, context.Background())
+	node := tm.create("owner task", ownerID, "", true, context.Background())
 
-	ownerState := node.sharedSnapshotForConn(ownerID)
+	ownerState := node.sharedSnapshotForConn(ownerID, "")
 	if !ownerState.IsOwner {
 		t.Error("IsOwner should be true for the owning connection")
 	}
 
-	otherState := node.sharedSnapshotForConn(otherID)
+	otherState := node.sharedSnapshotForConn(otherID, "")
 	if otherState.IsOwner {
 		t.Error("IsOwner should be false for a different connection")
 	}
@@ -424,9 +424,9 @@ func TestSharedTaskSnapshotForConn_NonTopLevel(t *testing.T) {
 
 	const ownerID uint64 = 42
 
-	node := tm.create("sub task", ownerID, false, context.Background())
+	node := tm.create("sub task", ownerID, "", false, context.Background())
 
-	ownerState := node.sharedSnapshotForConn(ownerID)
+	ownerState := node.sharedSnapshotForConn(ownerID, "")
 	if ownerState.IsOwner {
 		t.Error("IsOwner should be false for non-top-level tasks")
 	}
@@ -440,10 +440,10 @@ func TestSharedTaskSnapshotAllForConn(t *testing.T) {
 	const conn1 uint64 = 1
 	const conn2 uint64 = 2
 
-	node1 := tm.create("task-conn1", conn1, true, context.Background())
-	node2 := tm.create("task-conn2", conn2, true, context.Background())
+	node1 := tm.create("task-conn1", conn1, "", true, context.Background())
+	node2 := tm.create("task-conn2", conn2, "", true, context.Background())
 
-	states1 := tm.snapshotAllForConn(conn1)
+	states1 := tm.snapshotAllForConn(conn1, "")
 	s1, ok := findTaskByID(states1, node1.id)
 	if !ok {
 		t.Fatal("task for conn1 not found in conn1 snapshot")
@@ -459,7 +459,7 @@ func TestSharedTaskSnapshotAllForConn(t *testing.T) {
 		t.Error("conn2's task should have IsOwner=false for conn1")
 	}
 
-	states2 := tm.snapshotAllForConn(conn2)
+	states2 := tm.snapshotAllForConn(conn2, "")
 	s1InConn2, ok := findTaskByID(states2, node1.id)
 	if !ok {
 		t.Fatal("task for conn1 not found in conn2 snapshot")
@@ -481,7 +481,7 @@ func TestSharedTaskSnapshotAllForConn(t *testing.T) {
 func TestSubTaskWithSharedContext(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("shared root", 1, true, context.Background())
+	node := tm.create("shared root", 1, "", true, context.Background())
 	ctx := withDelivery(context.Background(), node.delivery)
 	ctx = withTaskNode(ctx, node)
 
@@ -521,7 +521,7 @@ func TestSubTaskWithSharedContext(t *testing.T) {
 func TestTaskProgressSharedContext(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("progress root", 1, true, context.Background())
+	node := tm.create("progress root", 1, "", true, context.Background())
 	child := node.createChild("progress node")
 
 	ctx := withDelivery(context.Background(), child.delivery)
@@ -547,7 +547,7 @@ func TestTaskProgressSharedContext(t *testing.T) {
 func TestStepTaskProgressSharedContext(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("step root", 1, true, context.Background())
+	node := tm.create("step root", 1, "", true, context.Background())
 	child := node.createChild("step node")
 	child.mu.Lock()
 	child.current = 2
@@ -573,7 +573,7 @@ func TestStepTaskProgressSharedContext(t *testing.T) {
 func TestSubTaskWithSharedContextNested(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("nested root", 1, true, context.Background())
+	node := tm.create("nested root", 1, "", true, context.Background())
 	ctx := withDelivery(context.Background(), node.delivery)
 	ctx = withTaskNode(ctx, node)
 
@@ -609,7 +609,7 @@ func TestSubTaskWithSharedContextNested(t *testing.T) {
 func TestSubTaskWithSharedContextError(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("error root", 1, true, context.Background())
+	node := tm.create("error root", 1, "", true, context.Background())
 	ctx := withDelivery(context.Background(), node.delivery)
 	ctx = withTaskNode(ctx, node)
 
@@ -700,7 +700,7 @@ func TestSharedSubTaskWithoutConnection(t *testing.T) {
 func TestSharedSubTaskRoutesThroughSharedContext(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("existing shared", 1, true, context.Background())
+	node := tm.create("existing shared", 1, "", true, context.Background())
 	ctx := withDelivery(context.Background(), node.delivery)
 	ctx = withTaskNode(ctx, node)
 
@@ -739,7 +739,7 @@ func TestCancelSharedTaskViaAPI(t *testing.T) {
 	}
 
 	// Known running task owned by the caller should be canceled successfully.
-	node := tm.create("cancel-api", ownerID, true, context.Background())
+	node := tm.create("cancel-api", ownerID, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()
@@ -792,7 +792,7 @@ func TestSharedTaskAllocID(t *testing.T) {
 func TestSharedTaskContextCanceledOnClose(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("ctx cancel", 1, true, context.Background())
+	node := tm.create("ctx cancel", 1, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()
@@ -815,7 +815,7 @@ func TestSharedTaskContextCanceledOnClose(t *testing.T) {
 func TestSharedTaskWithContext(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("with-ctx", 1, true, context.Background())
+	node := tm.create("with-ctx", 1, "", true, context.Background())
 	task := &Task[struct{}]{node: node}
 
 	derived := task.WithContext(context.Background())
@@ -839,7 +839,7 @@ func TestSharedTaskWithContext(t *testing.T) {
 func TestSharedTaskID(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("id task", 1, true, context.Background())
+	node := tm.create("id task", 1, "", true, context.Background())
 	task := &Task[struct{}]{node: node}
 
 	if task.ID() != node.id {
@@ -852,7 +852,7 @@ func TestSharedTaskID(t *testing.T) {
 func TestSharedTaskSubTaskProgress(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("sub-progress root", 1, true, context.Background())
+	node := tm.create("sub-progress root", 1, "", true, context.Background())
 	task := &Task[struct{}]{node: node}
 	sub := task.SubTask("sub progress")
 
@@ -875,7 +875,7 @@ func TestSharedTaskSubTaskProgress(t *testing.T) {
 func TestSharedTaskFailIdempotent(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("fail-idempotent", 1, true, context.Background())
+	node := tm.create("fail-idempotent", 1, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()
@@ -1068,7 +1068,7 @@ func TestSharedTaskCancelFailsChildren(t *testing.T) {
 	t.Run("direct children", func(t *testing.T) {
 		_, tm := setupTestServer(t)
 
-		root := tm.create("root", 1, true, context.Background())
+		root := tm.create("root", 1, "", true, context.Background())
 		root.mu.Lock()
 		root.status = TaskNodeStatusRunning
 		root.mu.Unlock()
@@ -1117,7 +1117,7 @@ func TestSharedTaskCancelFailsChildren(t *testing.T) {
 	t.Run("nested grandchildren", func(t *testing.T) {
 		_, tm := setupTestServer(t)
 
-		root := tm.create("root", 1, true, context.Background())
+		root := tm.create("root", 1, "", true, context.Background())
 		root.mu.Lock()
 		root.status = TaskNodeStatusRunning
 		root.mu.Unlock()
@@ -1154,7 +1154,7 @@ func TestSharedTaskCancelFailsChildren(t *testing.T) {
 func TestSharedTaskCloseIdempotent(t *testing.T) {
 	_, tm := setupTestServer(t)
 
-	node := tm.create("close-idempotent", 1, true, context.Background())
+	node := tm.create("close-idempotent", 1, "", true, context.Background())
 	node.mu.Lock()
 	node.status = TaskNodeStatusRunning
 	node.mu.Unlock()

--- a/tasks/task_tree.go
+++ b/tasks/task_tree.go
@@ -58,8 +58,21 @@ type taskNode struct {
 	ctx         context.Context    // task-scoped context for shared tasks
 	manager     *taskManager       // back-reference to manager (shared only)
 	ownerConnID uint64             // connection that created this task
+	ownerUserID string             // user that created this task ("" if unauthenticated)
 	topLevel    bool               // true if created by StartTask with Shared()
 
+}
+
+// cancelInfo builds the descriptor passed to a CancelAuthorizer. id, title, and
+// owner fields are set once at creation and never mutated, so they are safe to
+// read without the node lock.
+func (n *taskNode) cancelInfo() TaskCancelInfo {
+	return TaskCancelInfo{
+		ID:          n.id,
+		Title:       n.title,
+		OwnerConnID: n.ownerConnID,
+		OwnerUserID: n.ownerUserID,
+	}
 }
 
 // runScoped wraps fn with the registered task middleware (if any) and runs
@@ -419,10 +432,21 @@ func (n *taskNode) sharedSnapshot() SharedTaskState {
 	return state
 }
 
-// sharedSnapshotForConn returns a SharedTaskState with IsOwner set.
-func (n *taskNode) sharedSnapshotForConn(connID uint64) SharedTaskState {
+// sharedSnapshotForConn returns a SharedTaskState with IsOwner set for the
+// viewing connection. Ownership is matched by user ID when the task's owner was
+// authenticated (so it survives a reconnect on a new connection), and falls
+// back to the creating connection ID otherwise.
+func (n *taskNode) sharedSnapshotForConn(connID uint64, userID string) SharedTaskState {
 	state := n.sharedSnapshot()
-	state.IsOwner = n.topLevel && (n.ownerConnID == connID)
+	if !n.topLevel {
+		state.IsOwner = false
+		return state
+	}
+	if n.ownerUserID != "" {
+		state.IsOwner = userID != "" && n.ownerUserID == userID
+	} else {
+		state.IsOwner = n.ownerConnID == connID
+	}
 	return state
 }
 

--- a/testing.go
+++ b/testing.go
@@ -12,6 +12,14 @@ func WithTestConnection(ctx context.Context, id uint64) context.Context {
 	return withConnection(ctx, &Conn{id: id})
 }
 
+// WithTestConnectionUser returns a context carrying a minimal [Conn] with the
+// given connection ID and authenticated user ID. Unlike calling SetUserID, it
+// needs no server, so it is usable for tests that exercise user-based
+// ownership. Test-only.
+func WithTestConnectionUser(ctx context.Context, id uint64, userID string) context.Context {
+	return withConnection(ctx, &Conn{id: id, userID: userID})
+}
+
 // recordingTransport captures all data sent through the connection.
 type recordingTransport struct {
 	mu   sync.Mutex


### PR DESCRIPTION
Closes #249.

Extends the shared-task system so a real app can own the cancel policy and keep ownership across reconnects, plus a codegen collision fix found along the way.

## Changes
- **`WithCancelAuthorizer(CancelAuthorizer)`** — pluggable policy for who may cancel a shared task via the built-in `CancelTask` RPC / `CancelSharedTask`. Nil keeps the existing owner-by-connection default (unchanged behavior + test).
- **User-based ownership** — a task now records the owner's user ID (`conn.UserID()`); `IsOwner` matches by user ID when the owner was authenticated, so it survives a reconnect onto a new connection ID, and falls back to connection ID when unauthenticated.
- **`CancelTaskByID` / `FindSharedTask`** — public, authorizer-bypassing entry points for trusted server-side cancellation and inspection by task ID.
- **`WithTestConnectionUser`** test helper for user-scoped ownership tests.
- **Codegen fix** — a custom error whose generated helper collides with a built-in `ApiError` method (e.g. registering `"NotFound"` → duplicate `isNotFound()`) now fails generation with a clear message and skips the colliding helper, instead of emitting a `client.ts` that doesn't compile.

## Tests
New `tasks/ownership_test.go` (authorizer allow/deny, reconnect ownership, conn fallback, `CancelTaskByID`, `FindSharedTask`) and two `generate_test.go` cases (collision fails; non-colliding name generates cleanly). Existing owner-only behavior test still passes. Full suite + `go vet` + `gofmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)