### PR TITLE
Export selectWithPreviousData (the keepPreviousData core) for hand-written stores

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -496,6 +496,19 @@ const isLoading = useIsLoading();               // any in-flight request anywher
 import { useQuery, useStream, usePushEvent } from './api/client';
 ```
 
+### keepPreviousData outside hooks — `selectWithPreviousData`
+
+`useQuery` defaults to `keepPreviousData: true` (opt out per hook with `{ keepPreviousData: false }`): on a params-keyed reload the hook keeps surfacing the previous data instead of flashing empty. The pure selector behind it is exported for hand-written stores (e.g. zustand outside React) that call the generated RPC functions imperatively:
+
+```ts
+import { selectWithPreviousData, type SubscriptionSnapshot } from './api/client';
+
+const prev: { current: SubscriptionSnapshot<Draft> | null } = { current: null };
+const effective = selectWithPreviousData(prev, { data, error, isLoading });
+```
+
+Invariant it centralizes: the returned snapshot carries the previous `data` through the null gap but the **current** `error`/`isLoading` flags — kept data never masks loading or error state. Don't re-derive this in store code; import it.
+
 ## Vanilla Output
 
 Per-handler standalone functions plus `subscribe`/`unsubscribe` helpers for live data:

--- a/README.md
+++ b/README.md
@@ -352,6 +352,19 @@ function App() {
 
 A single generic hook handles every handler — no per-method Suspense hook is generated. The hook opens a server subscription on first read (using the same `TriggerRefresh` machinery as `useQuery`), suspends until the first response arrives, then replaces the cached promise on each subsequent push so live updates flow without re-suspending. Errors propagate to the nearest error boundary. Requires React 19+.
 
+**Keeping previous data across param changes** — query hooks default to `keepPreviousData: true`: when a param change starts a reload, the hook keeps showing the previous params' data instead of flashing an empty loading state (opt out per hook with `{ keepPreviousData: false }`). The selector behind it is exported for hand-written stores that call the generated RPC functions imperatively — a state store outside React that re-derives this pattern tends to get it subtly wrong:
+
+```typescript
+import { selectWithPreviousData, type SubscriptionSnapshot } from './api/client';
+
+const prev: { current: SubscriptionSnapshot<Draft> | null } = { current: null };
+
+// On each store update, derive what the UI should show:
+const effective = selectWithPreviousData(prev, { data, error, isLoading });
+```
+
+The returned snapshot carries the previous `data` through the reload's null gap but always the **current** `error` and `isLoading` flags — kept data never masks the loading or error state, which is the invariant worth centralizing.
+
 **With auth tokens** (dynamic URL for automatic token refresh on reconnect):
 
 ```typescript

--- a/doc.go
+++ b/doc.go
@@ -759,6 +759,26 @@
 // or the raw async function) — only queries fit the Suspense paradigm
 // cleanly.
 //
+// # Keep Previous Data (React)
+//
+// Query hooks default to `keepPreviousData: true`: when a param change
+// starts a params-keyed reload, the hook keeps returning the previous
+// params' data instead of flashing an empty loading state (opt out per
+// hook with `{ keepPreviousData: false }`). The pure selector behind the
+// option, `selectWithPreviousData`, is exported from the generated client
+// along with its `SubscriptionSnapshot<T>` type, so hand-written stores
+// that call the generated RPC functions imperatively can reuse the same
+// semantics instead of re-deriving them:
+//
+//	import { selectWithPreviousData, type SubscriptionSnapshot } from './api/client'
+//
+//	const prev: { current: SubscriptionSnapshot<Draft> | null } = { current: null }
+//	const effective = selectWithPreviousData(prev, { data, error, isLoading })
+//
+// The returned snapshot carries the previous `data` through the reload's
+// null gap but always the current `error` and `isLoading` flags — kept
+// data never masks the loading or error state.
+//
 // # Context Helpers
 //
 // Several functions extract request-scoped values from context:

--- a/e2e/tests/keep-previous-data.test.ts
+++ b/e2e/tests/keep-previous-data.test.ts
@@ -1,40 +1,13 @@
 import { describe, test, expect } from 'vitest';
+import { selectWithPreviousData, type SubscriptionSnapshot } from '../react-api/client';
 
 // ---------------------------------------------------------------------------
-// The `selectWithPreviousData` helper lives inside the generated React client
-// (templates/_client-common.ts.tmpl) and is called from `useQuery`. It's the
-// core of the `keepPreviousData` option: given a ref holding the previous
-// snapshot and the current cached snapshot, it decides whether to surface the
-// kept data or the fresh one.
-//
-// We replicate it here so we can test its behaviour with plain vitest, the
-// same way query-cache.test.ts replicates subscribeCached. No React runtime,
-// no running server, just the pure selector logic.
+// The `selectWithPreviousData` helper is exported from the generated React
+// client (templates/_client-common.ts.tmpl) and is called from `useQuery`.
+// It's the core of the `keepPreviousData` option: given a ref holding the
+// previous snapshot and the current cached snapshot, it decides whether to
+// surface the kept data or the fresh one.
 // ---------------------------------------------------------------------------
-
-interface Snapshot<T = unknown> {
-    data: T | null;
-    error: Error | null;
-    isLoading: boolean;
-}
-
-function selectWithPreviousData<T>(
-    previousRef: { current: Snapshot<T> | null },
-    snapshot: Snapshot<T>,
-): Snapshot<T> {
-    if (snapshot.data !== null) {
-        previousRef.current = snapshot;
-        return snapshot;
-    }
-    if (previousRef.current && previousRef.current.data !== null) {
-        return {
-            data: previousRef.current.data,
-            error: snapshot.error,
-            isLoading: snapshot.isLoading,
-        };
-    }
-    return snapshot;
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -42,8 +15,8 @@ function selectWithPreviousData<T>(
 
 describe('selectWithPreviousData', () => {
     test('first mount with no previous data returns the snapshot unchanged', () => {
-        const ref: { current: Snapshot<string> | null } = { current: null };
-        const snap: Snapshot<string> = { data: null, error: null, isLoading: true };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
+        const snap: SubscriptionSnapshot<string> = { data: null, error: null, isLoading: true };
 
         const effective = selectWithPreviousData(ref, snap);
 
@@ -52,8 +25,8 @@ describe('selectWithPreviousData', () => {
     });
 
     test('fresh data updates the ref and returns the snapshot as-is', () => {
-        const ref: { current: Snapshot<string> | null } = { current: null };
-        const snap: Snapshot<string> = { data: 'alpha', error: null, isLoading: false };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
+        const snap: SubscriptionSnapshot<string> = { data: 'alpha', error: null, isLoading: false };
 
         const effective = selectWithPreviousData(ref, snap);
 
@@ -66,14 +39,14 @@ describe('selectWithPreviousData', () => {
         // showing data for week N, the user clicks forward to week N+1, and
         // the new cache entry starts empty. The previous week's data should
         // remain on screen until the new week's data arrives.
-        const ref: { current: Snapshot<string> | null } = { current: null };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
 
         // Week N data arrives.
-        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        const weekN: SubscriptionSnapshot<string> = { data: 'week-N', error: null, isLoading: false };
         selectWithPreviousData(ref, weekN);
 
         // Param change — the new cache entry is empty.
-        const weekNPlus1Loading: Snapshot<string> = { data: null, error: null, isLoading: true };
+        const weekNPlus1Loading: SubscriptionSnapshot<string> = { data: null, error: null, isLoading: true };
         const duringTransition = selectWithPreviousData(ref, weekNPlus1Loading);
 
         expect(duringTransition.data).toBe('week-N');
@@ -84,15 +57,15 @@ describe('selectWithPreviousData', () => {
     });
 
     test('kept data is replaced as soon as new data lands', () => {
-        const ref: { current: Snapshot<string> | null } = { current: null };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
 
-        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        const weekN: SubscriptionSnapshot<string> = { data: 'week-N', error: null, isLoading: false };
         selectWithPreviousData(ref, weekN);
 
-        const weekNPlus1Loading: Snapshot<string> = { data: null, error: null, isLoading: true };
+        const weekNPlus1Loading: SubscriptionSnapshot<string> = { data: null, error: null, isLoading: true };
         selectWithPreviousData(ref, weekNPlus1Loading);
 
-        const weekNPlus1Loaded: Snapshot<string> = { data: 'week-N+1', error: null, isLoading: false };
+        const weekNPlus1Loaded: SubscriptionSnapshot<string> = { data: 'week-N+1', error: null, isLoading: false };
         const effective = selectWithPreviousData(ref, weekNPlus1Loaded);
 
         expect(effective.data).toBe('week-N+1');
@@ -104,12 +77,12 @@ describe('selectWithPreviousData', () => {
         // The user switches params and the new fetch fails. We want to keep
         // the previous data on screen AND surface the error so QueryErrors
         // can render an Alert. Losing either half is a regression.
-        const ref: { current: Snapshot<string> | null } = { current: null };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
 
-        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        const weekN: SubscriptionSnapshot<string> = { data: 'week-N', error: null, isLoading: false };
         selectWithPreviousData(ref, weekN);
 
-        const weekNPlus1Failed: Snapshot<string> = {
+        const weekNPlus1Failed: SubscriptionSnapshot<string> = {
             data: null,
             error: new Error('upstream 500'),
             isLoading: false,
@@ -125,16 +98,16 @@ describe('selectWithPreviousData', () => {
         // User clicks forward then back. Week N is still in the shared cache,
         // so useSyncExternalStore hands us its snapshot directly — we want to
         // return that, not the ref which currently holds week N+1.
-        const ref: { current: Snapshot<string> | null } = { current: null };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
 
-        const weekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        const weekN: SubscriptionSnapshot<string> = { data: 'week-N', error: null, isLoading: false };
         selectWithPreviousData(ref, weekN);
 
-        const weekNPlus1: Snapshot<string> = { data: 'week-N+1', error: null, isLoading: false };
+        const weekNPlus1: SubscriptionSnapshot<string> = { data: 'week-N+1', error: null, isLoading: false };
         selectWithPreviousData(ref, weekNPlus1);
 
         // Click back — cached snapshot for week N returns instantly.
-        const backToWeekN: Snapshot<string> = { data: 'week-N', error: null, isLoading: false };
+        const backToWeekN: SubscriptionSnapshot<string> = { data: 'week-N', error: null, isLoading: false };
         const effective = selectWithPreviousData(ref, backToWeekN);
 
         expect(effective.data).toBe('week-N');
@@ -145,13 +118,13 @@ describe('selectWithPreviousData', () => {
         // Regression guard: after an initial data load, any subsequent render
         // that for whatever reason sees data: null (cache miss, unmount race,
         // strict-mode double-render) should still surface the kept data.
-        const ref: { current: Snapshot<string> | null } = { current: null };
+        const ref: { current: SubscriptionSnapshot<string> | null } = { current: null };
 
-        const initial: Snapshot<string> = { data: 'alpha', error: null, isLoading: false };
+        const initial: SubscriptionSnapshot<string> = { data: 'alpha', error: null, isLoading: false };
         selectWithPreviousData(ref, initial);
 
         for (let i = 0; i < 5; i++) {
-            const empty: Snapshot<string> = { data: null, error: null, isLoading: true };
+            const empty: SubscriptionSnapshot<string> = { data: null, error: null, isLoading: true };
             const effective = selectWithPreviousData(ref, empty);
             expect(effective.data).toBe('alpha');
         }

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -1907,7 +1907,7 @@ export function setQueryCacheEnabled(enabled: boolean): void {
     queryCacheEnabled = enabled;
 }
 
-interface SubscriptionSnapshot<T = unknown> {
+export interface SubscriptionSnapshot<T = unknown> {
     data: T | null;
     error: Error | null;
     isLoading: boolean;
@@ -2053,7 +2053,7 @@ function subscribeCached<T>(
  * aprot server. The only mutation is to the passed-in ref, which represents
  * per-hook-instance state.
  */
-function selectWithPreviousData<T>(
+export function selectWithPreviousData<T>(
     previousRef: { current: SubscriptionSnapshot<T> | null },
     snapshot: SubscriptionSnapshot<T>,
 ): SubscriptionSnapshot<T> {

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -1929,7 +1929,7 @@ export function setQueryCacheEnabled(enabled: boolean): void {
     queryCacheEnabled = enabled;
 }
 
-interface SubscriptionSnapshot<T = unknown> {
+export interface SubscriptionSnapshot<T = unknown> {
     data: T | null;
     error: Error | null;
     isLoading: boolean;
@@ -2075,7 +2075,7 @@ function subscribeCached<T>(
  * aprot server. The only mutation is to the passed-in ref, which represents
  * per-hook-instance state.
  */
-function selectWithPreviousData<T>(
+export function selectWithPreviousData<T>(
     previousRef: { current: SubscriptionSnapshot<T> | null },
     snapshot: SubscriptionSnapshot<T>,
 ): SubscriptionSnapshot<T> {


### PR DESCRIPTION
Closes #254

## What

Exports `selectWithPreviousData` and its `SubscriptionSnapshot<T>` type from the generated React client (`templates/_client-common.ts.tmpl`), so hand-written stores that call the generated RPC functions imperatively can reuse the keepPreviousData selector instead of re-deriving it.

No behavior change for `useQuery` — this purely widens the export list.

## Changes

- `templates/_client-common.ts.tmpl` — `export` on `selectWithPreviousData` and `SubscriptionSnapshot`
- `example/react/client/src/api/client.ts` — regenerated
- `e2e/tests/keep-previous-data.test.ts` — drops its local copy of the helper and imports the exported symbol from the generated e2e react client, so the tests now exercise the real implementation
- `README.md`, `APROT_AI.md`, `doc.go` — document standalone usage and the invariant the helper centralizes (kept data carries the previous `data` but the *current* `error`/`isLoading` flags)

## Acceptance criteria from #254

- [x] `selectWithPreviousData` and `SubscriptionSnapshot` exported by the generated client
- [x] e2e/tests/keep-previous-data.test.ts imports the exported symbol instead of a local copy
- [x] README + APROT_AI.md mention the standalone usage

## Verification

- `go test ./...` — pass
- e2e suite: 19 files / 98 tests — pass
- `npx tsc --noEmit` clean in both `example/react/client` and `e2e`
- `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)