### PR TITLE
Fix WS writePump dropping queued frames on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Fixed
+
+- WebSocket frames enqueued just before a server-side close could be dropped:
+  `writePump` selects over the shutdown signal and the send queue, and when
+  both were ready it sometimes exited without flushing. In practice a client
+  rejected by the auth hook (or the auth timeout) could see an abnormal close
+  (1006) without ever receiving its `auth_error` frame. The pump now drains
+  frames queued before `Close` onto the wire during teardown.
+
 ## [0.48.0] - 2026-07-09
 
 ### Added

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -167,6 +167,12 @@ func (t *wsTransport) writePump() {
 	for {
 		select {
 		case <-t.done:
+			// Frames enqueued before Close happened-before done was closed,
+			// so drain them onto the wire — a send-then-close caller (e.g.
+			// handleAuth rejecting a token) relies on the final frame being
+			// delivered. Without this, the select above may observe done
+			// first and drop the queued frame.
+			t.drainSend()
 			return
 		case <-pingC:
 			if err := t.writeMessage(websocket.PingMessage, nil); err != nil {
@@ -176,6 +182,22 @@ func (t *wsTransport) writePump() {
 			if err := t.writeMessage(frame.messageType, frame.data); err != nil {
 				return
 			}
+		}
+	}
+}
+
+// drainSend writes the frames still queued at shutdown. It stops at the first
+// write error or when the queue is empty; each write is bounded by
+// WriteTimeout, so a dead peer cannot stall teardown.
+func (t *wsTransport) drainSend() {
+	for {
+		select {
+		case frame := <-t.send:
+			if err := t.writeMessage(frame.messageType, frame.data); err != nil {
+				return
+			}
+		default:
+			return
 		}
 	}
 }

--- a/transport_ws_test.go
+++ b/transport_ws_test.go
@@ -1,0 +1,74 @@
+package aprot
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newWSPair returns a connected server-side and client-side *websocket.Conn
+// backed by an httptest server. Both ends are closed via t.Cleanup.
+func newWSPair(t *testing.T) (server, client *websocket.Conn) {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	serverCh := make(chan *websocket.Conn, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		serverCh <- ws
+	}))
+	t.Cleanup(ts.Close)
+
+	url := "ws" + strings.TrimPrefix(ts.URL, "http")
+	c, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	s := <-serverCh
+	t.Cleanup(func() {
+		_ = s.Close()
+		_ = c.Close()
+	})
+	return s, c
+}
+
+// Frames enqueued before Close must still reach the peer. handleAuth (and the
+// auth-timeout path) send auth_error and then immediately close the
+// connection; Send only enqueues onto the transport's buffered channel, so
+// writePump must drain the queue when it observes done — otherwise the select
+// over done/send can exit first and the peer sees an abnormal close (1006)
+// without ever receiving the frame.
+func TestWSTransport_CloseDeliversQueuedFrames(t *testing.T) {
+	for i := 0; i < 30; i++ {
+		server, client := newWSPair(t)
+		tr := newWSTransport(server, ServerOptions{})
+
+		// Enqueue, then close, before the pump runs — the ordering every
+		// send-then-close caller (e.g. handleAuth) produces, with the pump
+		// scheduling squeezed to its worst case.
+		if err := tr.Send([]byte(`{"type":"auth_error","message":"nope"}`)); err != nil {
+			t.Fatalf("iteration %d: send: %v", i, err)
+		}
+		_ = tr.Close()
+		go tr.writePump()
+
+		_ = client.SetReadDeadline(time.Now().Add(3 * time.Second))
+		_, data, err := client.ReadMessage()
+		if err != nil {
+			t.Fatalf("iteration %d: queued frame dropped at close: %v", i, err)
+		}
+		if !strings.Contains(string(data), "auth_error") {
+			t.Fatalf("iteration %d: unexpected frame: %s", i, data)
+		}
+	}
+}


### PR DESCRIPTION
Closes #257

## Root cause

`writePump` selects over the shutdown signal (`done`) and the send queue. A send-then-close caller — `handleAuth` rejecting a token, or the auth-timeout path — enqueues the `auth_error` frame and closes `done` back-to-back, so both select cases are ready and Go picks pseudo-randomly. Picking `done` exited the pump with the final frame still queued: the client saw an abnormal close (1006) without ever receiving `auth_error`. This is what flaked as `TestAuth_InvalidTokenClosesConnection` in CI on #256.

## Fix

Frames enqueued before `Close()` happen-before `close(done)`, so when the pump observes `done` it now drains the queue onto the wire before tearing down the socket. Each drain write remains bounded by `WriteTimeout`, so a dead peer cannot stall teardown.

## Test

`TestWSTransport_CloseDeliversQueuedFrames` reproduces the race deterministically: it enqueues a frame and closes the transport before starting the pump, putting the select at its worst case. Red on the old code within one or two iterations (`close 1006 ... unexpected EOF`, the exact CI failure); green over 600 iterations with the fix. Full suite passes under `-race`.

## Scope note

`streamTransport.writePump` has the identical select race, but its `Close()` also closes the underlying stream immediately (which is what unblocks a stuck reader/writer), so a drain there needs close-ordering restructuring — tracked in #257 as a follow-up. The SSE transport writes synchronously and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)