### PR TITLE
Skip unexported and json:"-" fields when collecting types

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1510,9 +1510,16 @@ func (g *Generator) collectType(t reflect.Type) {
 	}
 	g.types[t] = t.Name()
 
-	// Recursively collect field types, flattening embedded structs
+	// Recursively collect field types, flattening embedded structs.
+	// Mirror collectInterfaceFields: unexported and json:"-" fields never
+	// appear in the emitted interfaces, so their types must not be collected
+	// either — an unexported `mu sync.Mutex` field would otherwise emit empty
+	// Mutex/noCopy interfaces into a shared sync.ts.
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
+		if !field.IsExported() || shouldSkipField(field) {
+			continue
+		}
 		if field.Anonymous {
 			ft := field.Type
 			if ft.Kind() == reflect.Ptr {
@@ -1522,7 +1529,11 @@ func (g *Generator) collectType(t reflect.Type) {
 				// Don't register as separate interface — fields are flattened.
 				// But recurse into its fields to collect nested types.
 				for j := 0; j < ft.NumField(); j++ {
-					g.collectNestedType(ft.Field(j).Type)
+					ef := ft.Field(j)
+					if !ef.IsExported() || shouldSkipField(ef) {
+						continue
+					}
+					g.collectNestedType(ef.Type)
 				}
 			}
 			continue

--- a/generate_test.go
+++ b/generate_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1736,6 +1737,79 @@ func TestGenerateEmbeddedPointerStruct(t *testing.T) {
 	}
 
 	t.Logf("Generated TypeScript (pointer-embedded struct):\n%s", output)
+}
+
+// Unexported and json:"-" fields never appear in the emitted interfaces, so
+// their types must not be collected either. An unexported `mu sync.Mutex`
+// previously emitted empty Mutex interfaces (sync.Mutex plus the
+// internal/sync.Mutex it embeds — both land in sync.ts) and noCopy.
+type unexportedHiddenState struct {
+	N int `json:"N"`
+}
+
+type UnexportedSkippedState struct {
+	X int `json:"X"`
+}
+
+type UnexportedFieldResponse struct {
+	mu     sync.Mutex             //nolint:unused // exercises unexported-field collection
+	hidden unexportedHiddenState  //nolint:unused // exercises unexported-field collection
+	Ignore UnexportedSkippedState `json:"-"`
+	Value  string                 `json:"Value"`
+}
+
+type UnexportedEmbedded struct {
+	inner unexportedHiddenState //nolint:unused // exercises unexported-field collection
+	Label string                `json:"Label"`
+}
+
+type UnexportedFieldOuter struct {
+	UnexportedEmbedded
+	Extra string `json:"Extra"`
+}
+
+type UnexportedFieldHandlers struct{}
+
+func (h *UnexportedFieldHandlers) Get(ctx context.Context, req *UnexportedFieldOuter) (*UnexportedFieldResponse, error) {
+	return &UnexportedFieldResponse{}, nil
+}
+
+func TestGenerateUnexportedFieldTypesNotCollected(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&UnexportedFieldHandlers{})
+
+	gen := NewGenerator(registry)
+
+	var buf bytes.Buffer
+	if err := gen.GenerateTo(&buf); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	output := buf.String()
+
+	if strings.Contains(output, "interface Mutex") {
+		t.Error("sync.Mutex from an unexported field should not be emitted")
+	}
+	if strings.Contains(output, "noCopy") {
+		t.Error("sync.noCopy should not be emitted")
+	}
+	if strings.Contains(output, "unexportedHiddenState") {
+		t.Error("type of an unexported field should not be emitted")
+	}
+	if strings.Contains(output, "UnexportedSkippedState") {
+		t.Error("type of a json:\"-\" field should not be emitted")
+	}
+
+	// The exported fields must still generate normally.
+	if !strings.Contains(output, "Value: string") {
+		t.Error("Expected 'Value: string' field")
+	}
+	if !strings.Contains(output, "Label: string") {
+		t.Error("Expected flattened 'Label: string' from embedded struct")
+	}
+	if !strings.Contains(output, "Extra: string") {
+		t.Error("Expected 'Extra: string' field")
+	}
 }
 
 // Invalid-identifier field name: a json tag like "my-field" is not a valid JS

--- a/generate_test.go
+++ b/generate_test.go
@@ -1743,7 +1743,7 @@ func TestGenerateEmbeddedPointerStruct(t *testing.T) {
 // their types must not be collected either. An unexported `mu sync.Mutex`
 // previously emitted empty Mutex interfaces (sync.Mutex plus the
 // internal/sync.Mutex it embeds — both land in sync.ts) and noCopy.
-type unexportedHiddenState struct {
+type unexportedHiddenState struct { //nolint:unused // referenced only via reflection through unexported fields
 	N int `json:"N"`
 }
 


### PR DESCRIPTION
## Problem

Generated output contained a `sync.ts` with two empty `Mutex` interfaces and a `noCopy` interface, none of them referenced anywhere:

```ts
// Code generated by aprot. DO NOT EDIT.
// Shared types from package: sync

export interface Mutex {
}

export interface Mutex {
}

export interface noCopy {
}
```

This happens whenever a registered struct has an unexported field like `mu sync.Mutex`. `collectInterfaceFields` correctly skips unexported and `json:"-"` fields when emitting interface fields, but `collectType` recursed into **every** field when deciding which types need a TS interface. So the mutex type got registered (empty, since all its fields are unexported) even though no field references it.

There are two `Mutex` interfaces because `sync.Mutex` embeds `internal/sync.Mutex` (Go 1.24+), and both package paths shorten to `sync`, so both land in `sync.ts` under the same name. It compiled silently because TypeScript merges duplicate interface declarations and nothing imported the file.

## Fix

Apply the same field filter (`IsExported` + `shouldSkipField`) in `collectType`, in both the plain-field path and the embedded-struct flattening branch, so only types that can actually appear in emitted interfaces are collected.

## Test

`TestGenerateUnexportedFieldTypesNotCollected` covers an unexported `sync.Mutex` field, an unexported field of a local struct type, a `json:"-"` field, and an unexported field inside an embedded struct, and verifies exported fields still generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)