### PR TITLE
Prepare v0.49.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+## [0.49.1] - 2026-07-14
+
+### Fixed
+
+- TypeScript generation no longer collects types that are only reachable
+  through unexported or `json:"-"` struct fields. A registered struct with an
+  unexported `mu sync.Mutex` field produced a stray `sync.ts` containing empty
+  `Mutex`/`noCopy` interfaces (duplicated, since Go 1.24's `sync.Mutex` embeds
+  `internal/sync.Mutex` and both package paths shorten to `sync`). `collectType`
+  now applies the same exported + non-skipped field filter as interface
+  emission, so only types that can actually appear in generated interfaces are
+  collected (#260).
+
 ## [0.49.0] - 2026-07-13
 
 ### Added
@@ -257,7 +270,8 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
   resource-exhaustion blast radius of a single misbehaving connection (#222).
 - Static analysis (`gosec`) and vulnerability scanning (`govulncheck`) added to CI (#207 P3).
 
-[Unreleased]: https://github.com/marrasen/aprot/compare/v0.49.0...HEAD
+[Unreleased]: https://github.com/marrasen/aprot/compare/v0.49.1...HEAD
+[0.49.1]: https://github.com/marrasen/aprot/compare/v0.49.0...v0.49.1
 [0.49.0]: https://github.com/marrasen/aprot/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/marrasen/aprot/compare/v0.47.1...v0.48.0
 [0.47.1]: https://github.com/marrasen/aprot/compare/v0.47.0...v0.47.1


### PR DESCRIPTION
Release prep for v0.49.1.

- Adds the `[0.49.1] - 2026-07-14` section with the changelog entry for the unexported-field type-collection fix (#260)
- Updates the compare links

After merge: tag `v0.49.1` and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)