### PR TITLE
Add Server.DisconnectUser to close all connections for a user id

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -225,6 +225,8 @@ server.OnConnect(func(ctx context.Context, conn *aprot.Conn) error {
 - `Set(key, val)` / `Get(key)` / `Load(key)` — per-connection state.
 - `SetUserID(id)` / `UserID()` — push routing identity (not a security boundary; use stored principal for authz).
 
+Server-side eviction: `server.DisconnectUser(userID) int` gracefully closes every connection associated with a user id (close frame where supported, in-flight requests canceled with `ErrConnectionClosed`, disconnect hooks run via the normal teardown path) and returns the number closed — `0` for unknown ids, safe for concurrent use. Use it when removing a user or revoking access so an already-authenticated socket can't linger.
+
 Inside handlers: `conn := aprot.Connection(ctx)`.
 
 ## Push Events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Added
+
+- `Server.DisconnectUser(userID) int` — gracefully closes every connection
+  currently associated with a user id (the identity set via `Conn.SetUserID`)
+  and returns the number of connections closed. Each connection gets a close
+  frame where the transport supports one, its in-flight requests are canceled
+  with `ErrConnectionClosed`, and disconnect hooks run through the normal
+  teardown path. A no-op returning `0` for unknown ids; safe for concurrent
+  use; never closes a connection that has since re-authenticated as a
+  different user. Use it to evict removed users whose authenticated sockets
+  would otherwise linger.
+
 ## [0.49.1] - 2026-07-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Task middleware** — opt-in `WithTaskMiddleware` wraps every task with a single `func(ctx, info, next) error` callback (mirrors `aprot.Middleware`); decorate ctx with your logger of choice (slog, zerolog, zap), observe start/completion/failure in one place
 - **Progress reporting** — built-in support for long-running operations
 - **Request cancellation** — clients cancel via AbortController; handlers see cancel cause
-- **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting
+- **Connection lifecycle** — hooks for connect/disconnect, connection-scoped state, user targeting, user eviction (`DisconnectUser`)
 - **Dual transport** — WebSocket and SSE+HTTP with identical API
 - **Connection hardening** — per-request panic recovery, inbound message size limits, write timeouts that drop stalled clients, WebSocket keepalive pings, and per-connection / server-wide concurrency and subscription caps — all configurable via `ServerOptions`
 - **Cross-origin control** — WebSocket origin checking (`SetCheckOrigin`) plus a closed-by-default `CORS` middleware for the SSE and REST HTTP transports
@@ -906,6 +906,20 @@ await client.refreshAuth(freshToken);
 - **Mid-session refresh** — the same `auth` frame on a live connection updates the token/identity without reconnecting. A *failed* refresh keeps the existing session (a live connection is never downgraded).
 - **Both transports** — WebSocket sends the `auth` frame directly; SSE sends it in the first `POST /rpc` body (the `EventSource` GET can't set headers). `auth_ok`/`auth_error` arrive over the stream either way.
 - **Backward compatible** — with no `OnAuth` hook, connections behave exactly as before (URL-token via `OnConnect` still works). `ErrAuthFailed` uses code `-32005`; the TS client exposes `err.isAuthFailed()`.
+
+### Revoking access mid-session (`DisconnectUser`)
+
+Auth middleware can deny a removed user's *new* requests, but an already-open connection stays authenticated — still counted, still targetable by `PushToUser`. When you delete a user or revoke their access, close their sockets too:
+
+```go
+n := server.DisconnectUser(userID) // returns the number of connections closed
+```
+
+`DisconnectUser` closes every connection currently associated with the user ID (the identity set via `conn.SetUserID`), across all transports:
+
+- **Graceful close** — a close frame is sent where the transport supports one, and the connection's in-flight requests are canceled with `ErrConnectionClosed`.
+- **Full teardown** — subscriptions are unregistered and `OnDisconnect` hooks run through the normal disconnect path.
+- **Safe by default** — concurrent-use safe, a no-op (returning `0`) for unknown user IDs, and it never closes a connection that has since re-authenticated as a different user.
 
 ## Observability
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -247,6 +247,44 @@ func TestPushToUser_SkipsReauthenticatedConnection(t *testing.T) {
 	}
 }
 
+// DisconnectUser must not close a connection that has since re-authenticated
+// as a different user — the same momentarily-stale-snapshot identity race
+// that PushToUser guards against.
+func TestDisconnectUser_SkipsReauthenticatedConnection(t *testing.T) {
+	server := NewServer(NewRegistry())
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	conn := &Conn{
+		id:        1,
+		server:    server,
+		transport: &mockTransport{},
+		requests:  make(map[string]context.CancelCauseFunc),
+	}
+	conn.userID = "bob" // already re-authenticated as bob
+
+	// Momentarily-stale index: conn is still listed under alice.
+	server.userConns["alice"] = map[*Conn]struct{}{conn: {}}
+
+	if n := server.DisconnectUser("alice"); n != 0 {
+		t.Fatalf("DisconnectUser(alice) = %d, want 0 (conn now belongs to bob)", n)
+	}
+	if conn.isClosed() {
+		t.Fatal("alice's disconnect closed a connection now identified as bob")
+	}
+
+	// Sanity: a matching identity is closed and counted exactly once.
+	conn.userID = "alice"
+	if n := server.DisconnectUser("alice"); n != 1 {
+		t.Fatalf("DisconnectUser(alice) = %d, want 1", n)
+	}
+	if !conn.isClosed() {
+		t.Fatal("matching connection was not closed")
+	}
+	if n := server.DisconnectUser("alice"); n != 0 {
+		t.Fatalf("repeat DisconnectUser(alice) = %d, want 0 (already closed)", n)
+	}
+}
+
 // A failed refresh on a live connection reports auth_error but keeps the session.
 func TestAuth_FailedRefreshKeepsSession(t *testing.T) {
 	ts := newAuthServer(t, ServerOptions{}, tokenHook)

--- a/connection.go
+++ b/connection.go
@@ -1092,32 +1092,35 @@ func (c *Conn) handleUnsubscribe(id string) {
 }
 
 func (c *Conn) close() {
+	c.closeWithCause(ErrConnectionClosed, false)
+}
+
+func (c *Conn) closeGracefully() {
+	c.closeWithCause(ErrServerShutdown, true)
+}
+
+// closeWithCause marks the connection closed, cancels its in-flight requests
+// with cause, unregisters its subscriptions, and closes the transport (with a
+// close frame when graceful and the transport supports one). It reports
+// whether this call performed the transition; false means the connection was
+// already closed.
+func (c *Conn) closeWithCause(cause error, graceful bool) bool {
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
-		return
+		return false
 	}
 	c.closed = true
 	// Cancel all pending requests
 	for _, cancel := range c.requests {
-		cancel(ErrConnectionClosed)
+		cancel(cause)
 	}
 	c.mu.Unlock()
 	c.server.subscriptions.unregisterConn(c.id)
-	_ = c.transport.Close()
-}
-
-func (c *Conn) closeGracefully() {
-	c.mu.Lock()
-	if c.closed {
-		c.mu.Unlock()
-		return
+	if graceful {
+		_ = c.transport.CloseGracefully()
+	} else {
+		_ = c.transport.Close()
 	}
-	c.closed = true
-	for _, cancel := range c.requests {
-		cancel(ErrServerShutdown)
-	}
-	c.mu.Unlock()
-	c.server.subscriptions.unregisterConn(c.id)
-	_ = c.transport.CloseGracefully()
+	return true
 }

--- a/doc.go
+++ b/doc.go
@@ -253,8 +253,9 @@
 //	http.Handle("/sse/", server.HTTPTransport())
 //
 // Both transports can run simultaneously and share connection tracking —
-// [Server.Broadcast], [Server.PushToUser], and [Server.ConnectionCount] work
-// across all connections regardless of transport.
+// [Server.Broadcast], [Server.PushToUser], [Server.DisconnectUser], and
+// [Server.ConnectionCount] work across all connections regardless of
+// transport.
 //
 // For byte streams HTTP can't reach, [Server.ServeStream] serves one
 // connection over any io.ReadWriteCloser using newline-delimited JSON
@@ -397,6 +398,13 @@
 // [Conn.SetUserID] / [Conn.UserID] is a routing identity used for push
 // targeting ([Server.PushToUser]). It is not a security boundary — use the
 // stored principal for authorization decisions.
+//
+// To revoke access mid-session — e.g. when an admin deletes a user who still
+// holds an authenticated connection — [Server.DisconnectUser] gracefully
+// closes every connection currently associated with a user ID and returns the
+// number closed. Each connection's in-flight requests are canceled with
+// [ErrConnectionClosed] and its disconnect hooks run through the normal
+// teardown path; other users' connections are untouched.
 //
 // # Observability
 //

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -3,6 +3,7 @@ package aprot
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -178,6 +179,93 @@ func TestSSEConnectHookRejectionAfterSetUserIDDisassociates(t *testing.T) {
 	defer resp.Body.Close()
 
 	waitForUserConnCount(t, server, "u1", 0, 2*time.Second)
+}
+
+// --- Server.DisconnectUser ---
+
+// DisconnectUser must close every connection of the target user — sending a
+// close frame and running their disconnect hooks — while leaving other users'
+// connections untouched.
+func TestDisconnectUserClosesAllUserConnections(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&IntegrationHandlers{})
+	server := NewServer(registry)
+	server.OnConnect(func(ctx context.Context, conn *Conn) error {
+		conn.SetUserID(conn.Info().Header.Get("X-User"))
+		return nil
+	})
+	var mu sync.Mutex
+	disconnects := map[string]int{}
+	server.OnDisconnect(func(ctx context.Context, conn *Conn) {
+		mu.Lock()
+		disconnects[conn.UserID()]++
+		mu.Unlock()
+	})
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+	defer server.Stop(context.Background())
+
+	dial := func(user string) *websocket.Conn {
+		t.Helper()
+		ws, _, err := websocket.DefaultDialer.Dial(wsURL(ts.URL), http.Header{"X-User": {user}})
+		if err != nil {
+			t.Fatalf("dial as %q: %v", user, err)
+		}
+		return ws
+	}
+	a1, a2, b := dial("A"), dial("A"), dial("B")
+	defer a1.Close()
+	defer a2.Close()
+	defer b.Close()
+	waitForUserConnCount(t, server, "A", 2, 2*time.Second)
+	waitForUserConnCount(t, server, "B", 1, 2*time.Second)
+
+	if n := server.DisconnectUser("A"); n != 2 {
+		t.Fatalf("DisconnectUser(A) = %d, want 2", n)
+	}
+
+	// Both A sockets must observe a close frame, not just a dead TCP conn.
+	for i, ws := range []*websocket.Conn{a1, a2} {
+		_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+		var err error
+		for err == nil {
+			_, _, err = ws.ReadMessage()
+		}
+		if !websocket.IsCloseError(err, websocket.CloseGoingAway) {
+			t.Errorf("A conn %d: read error = %v, want close frame (CloseGoingAway)", i+1, err)
+		}
+	}
+
+	// Teardown must run disconnect hooks for both A connections and free the
+	// user index entry.
+	waitForUserConnCount(t, server, "A", 0, 2*time.Second)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		aHooks, bHooks := disconnects["A"], disconnects["B"]
+		mu.Unlock()
+		if aHooks == 2 {
+			if bHooks != 0 {
+				t.Fatalf("disconnect hooks ran %d time(s) for B, want 0", bHooks)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("disconnect hooks ran %d time(s) for A, want 2", aHooks)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// B is untouched, and repeated / unknown-id calls are no-ops.
+	if got := userConnCount(server, "B"); got != 1 {
+		t.Errorf("userConns[B] = %d, want 1", got)
+	}
+	if n := server.DisconnectUser("A"); n != 0 {
+		t.Errorf("second DisconnectUser(A) = %d, want 0", n)
+	}
+	if n := server.DisconnectUser("nobody"); n != 0 {
+		t.Errorf("DisconnectUser(nobody) = %d, want 0", n)
+	}
 }
 
 // --- Re-subscribe params freshness (#207 P2) ---

--- a/server.go
+++ b/server.go
@@ -422,6 +422,46 @@ func (s *Server) PushToUser(userID string, data any) {
 	}
 }
 
+// DisconnectUser closes every active connection currently associated with
+// userID (set via [Conn.SetUserID]) and returns the number of connections it
+// closed. Each connection is closed gracefully — a close frame where the
+// transport supports one — and its in-flight requests are canceled with
+// [ErrConnectionClosed]; disconnect hooks then run through the normal
+// teardown path as each connection's read loop exits. Safe for concurrent
+// use; a no-op returning 0 for an unknown user ID.
+//
+// Use it to evict a user whose account has been removed or whose access has
+// been revoked, so a previously authenticated socket cannot linger.
+func (s *Server) DisconnectUser(userID string) int {
+	if userID == "" {
+		return 0
+	}
+
+	// Snapshot under the lock, close outside it (same discipline as
+	// PushToUser): transport teardown must not run while holding s.mu.
+	s.mu.RLock()
+	conns := make([]*Conn, 0, len(s.userConns[userID]))
+	for conn := range s.userConns[userID] {
+		conns = append(conns, conn)
+	}
+	s.mu.RUnlock()
+
+	closed := 0
+	for _, conn := range conns {
+		// Same identity re-check as PushToUser: a mid-session SetUserID can
+		// leave the snapshot momentarily stale, and a disconnect aimed at one
+		// user must never close a connection that has since re-authenticated
+		// as a different user.
+		if conn.UserID() != userID {
+			continue
+		}
+		if conn.closeWithCause(ErrConnectionClosed, true) {
+			closed++
+		}
+	}
+	return closed
+}
+
 // associateUser registers a connection with a user ID.
 func (s *Server) associateUser(conn *Conn, userID string) {
 	s.mu.Lock()


### PR DESCRIPTION
## Motivation

Downstream consumers (ParticleView5's admin user removal) need to evict a user whose account was just deleted: auth middleware denies the removed user's *new* requests immediately, but their already-open authenticated socket lingers — still counted as a session, still a target for `PushToUser`/`Broadcast`. aprot exposed enough to *find* a user's connections (`ForEachConn`, `Conn.UserID`, the `userConns` index behind `PushToUser`) but no exported way to *close* them.

## API

```go
// DisconnectUser closes every active connection currently associated with
// userID (set via Conn.SetUserID) and returns the number of connections closed.
func (s *Server) DisconnectUser(userID string) int
```

- Snapshots `userConns[userID]` under `s.mu` and closes outside the lock — the same discipline as `PushToUser`, including the mid-session `SetUserID` re-auth guard: a connection that has since re-authenticated as a different user is never closed.
- Graceful close: close frame where the transport supports one; in-flight requests canceled with `ErrConnectionClosed`.
- Disconnect hooks and user-index cleanup flow through the existing read-loop teardown path (`unregister` → `runDisconnectHooks` → `disassociateUser`), so no bookkeeping is duplicated.
- Concurrent-use safe; a no-op returning `0` for unknown ids; works across all transports (WS, SSE, byte-stream).

Internally, `Conn.close`/`closeGracefully` are refactored into a shared `closeWithCause(cause, graceful) bool` so the disconnect path can pick the cancel cause and close style, and the return value gives an accurate closed count.

## Tests

- `TestDisconnectUserClosesAllUserConnections` — end-to-end over WebSocket: two conns as user A, one as user B; `DisconnectUser("A")` returns 2, both A sockets receive a close frame, A's disconnect hooks run exactly twice, the A index entry drains, B stays untouched; repeat and unknown-id calls return 0.
- `TestDisconnectUser_SkipsReauthenticatedConnection` — the stale-snapshot identity race, mirroring the existing `PushToUser` regression test.

`go test -race ./...` and `go vet ./...` pass.

Docs updated in README.md (new "Revoking access mid-session" section + feature bullet), doc.go (Server transports + connection-lifecycle sections), APROT_AI.md, and CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)