### PR TITLE
Prepare v0.50.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-07-15
+
 ### Added
 
 - `Registry.OverrideFieldType(owner, goFieldName, concrete)` — refine a
@@ -307,7 +309,8 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
   resource-exhaustion blast radius of a single misbehaving connection (#222).
 - Static analysis (`gosec`) and vulnerability scanning (`govulncheck`) added to CI (#207 P3).
 
-[Unreleased]: https://github.com/marrasen/aprot/compare/v0.49.1...HEAD
+[Unreleased]: https://github.com/marrasen/aprot/compare/v0.50.0...HEAD
+[0.50.0]: https://github.com/marrasen/aprot/compare/v0.49.1...v0.50.0
 [0.49.1]: https://github.com/marrasen/aprot/compare/v0.49.0...v0.49.1
 [0.49.0]: https://github.com/marrasen/aprot/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/marrasen/aprot/compare/v0.47.1...v0.48.0


### PR DESCRIPTION
Cuts the v0.50.0 release: moves the `[Unreleased]` entries into a dated `[0.50.0] - 2026-07-15` section and updates the compare links.

## Included since v0.49.1

### Added
- `Registry.OverrideFieldType` — refine a dynamic (`any`/`interface{}`) struct field to a concrete type in generated TypeScript (#267).
- `tasks.EnableWithMeta[M]` now wires `M` into generated `TaskNode.meta` / `SharedTaskState.meta` types instead of `any` (#267).
- `Server.DisconnectUser(userID) int` — gracefully closes every connection associated with a user id (#268).

### Changed
- **Generated TypeScript contains no `any`** — dynamic fields now emit `unknown` and Zod fallbacks use `z.unknown()` (validation- and wire-neutral) (#267).

After merge: tag `v0.50.0` on the merge commit and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)