### PR TITLE
Fix shared tasks-package type clobbered by the tasks.ts runtime file

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -638,9 +638,13 @@ func (g *Generator) Generate() (map[string]string, error) {
 	// (e.g. package "settings" + handler "Settings" both -> "settings.ts"), the
 	// handler file — written later — would silently overwrite the shared file,
 	// dropping its type/enum definitions and leaving every referencing file
-	// importing a type nobody defines (issue #206). Give any colliding shared
-	// file a distinct "{pkg}.types" base instead. A kebab-cased handler file
-	// name can never contain a dot, so the alternate base is collision-free.
+	// importing a type nobody defines (issue #206). The same collision happens
+	// against a file a runtime's OnGenerate hook writes — e.g. a shared type in
+	// package "tasks" lands in "tasks.ts", which the task runtime overwrites
+	// wholesale — so reserved client files (see ReserveClientFile) are treated
+	// like handler files here. Give any colliding shared file a distinct
+	// "{pkg}.types" base instead. A kebab-cased handler file name can never
+	// contain a dot, so the alternate base is collision-free.
 	handlerFileNames := make(map[string]bool)
 	for _, group := range g.registry.Groups() {
 		handlerFileNames[g.naming().FileName(group.Name)] = true
@@ -648,7 +652,7 @@ func (g *Generator) Generate() (map[string]string, error) {
 	pkgBase := make(map[string]string, len(sortedPkgs))
 	for _, pkg := range sortedPkgs {
 		base := pkg
-		if handlerFileNames[base] {
+		if handlerFileNames[base] || g.registry.reservedClientFiles[base] {
 			base = pkg + ".types"
 		}
 		pkgBase[pkg] = base

--- a/handler.go
+++ b/handler.go
@@ -171,6 +171,11 @@ type Registry struct {
 	serverInitHooks []func(s *Server)                                  // hooks run during NewServer
 	validator       StructValidator                                    // optional struct validator (nil = disabled)
 	restGroups      map[string]bool                                    // groups registered via RegisterREST
+	// reservedClientFiles are generated client file bases (without .ts) owned
+	// by a runtime's OnGenerate hook — e.g. the task system owns "tasks". The
+	// shared per-package type file namer steers clear of these, so a hook that
+	// writes the reserved file can never clobber a shared type declaration.
+	reservedClientFiles map[string]bool
 	// fieldTypeOverrides maps a struct type and Go field name to the concrete
 	// type code generation should use in place of the field's declared dynamic
 	// (interface) type. Codegen-only: runtime serialization is unaffected.
@@ -180,16 +185,17 @@ type Registry struct {
 // NewRegistry creates a new handler registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		handlers:           make(map[string]*HandlerInfo),
-		groups:             make(map[string]*HandlerGroup),
-		pushEvents:         []PushEventInfo{},
-		pushEventTypes:     make(map[reflect.Type]string),
-		errorCodes:         []ErrorCodeInfo{},
-		errorMappings:      []errorMapping{},
-		nextErrorCode:      1000, // Start custom codes at 1000
-		enumTypes:          make(map[reflect.Type]*EnumInfo),
-		restGroups:         make(map[string]bool),
-		fieldTypeOverrides: make(map[reflect.Type]map[string]reflect.Type),
+		handlers:            make(map[string]*HandlerInfo),
+		groups:              make(map[string]*HandlerGroup),
+		pushEvents:          []PushEventInfo{},
+		pushEventTypes:      make(map[reflect.Type]string),
+		errorCodes:          []ErrorCodeInfo{},
+		errorMappings:       []errorMapping{},
+		nextErrorCode:       1000, // Start custom codes at 1000
+		enumTypes:           make(map[reflect.Type]*EnumInfo),
+		restGroups:          make(map[string]bool),
+		fieldTypeOverrides:  make(map[reflect.Type]map[string]reflect.Type),
+		reservedClientFiles: make(map[string]bool),
 	}
 }
 
@@ -644,6 +650,19 @@ func (r *Registry) SetValidator(v StructValidator) {
 // Hooks can modify existing entries or add new files.
 func (r *Registry) OnGenerate(hook func(results map[string]string, mode OutputMode)) {
 	r.generateHooks = append(r.generateHooks, hook)
+}
+
+// ReserveClientFile marks a generated client file base name (without the .ts
+// extension) as owned by a runtime — e.g. the task system, whose OnGenerate
+// hook writes tasks.ts, reserves "tasks". A shared per-package type file whose
+// Go package short name matches a reserved base is emitted as "{pkg}.types.ts"
+// instead, so the hook can never overwrite the shared file and strand its type
+// declarations (which would leave consumers importing a type nobody exports).
+func (r *Registry) ReserveClientFile(base string) {
+	if r.reservedClientFiles == nil {
+		r.reservedClientFiles = make(map[string]bool)
+	}
+	r.reservedClientFiles[base] = true
 }
 
 // OnServerInit registers a hook called during NewServer after the server is

--- a/tasks/enable.go
+++ b/tasks/enable.go
@@ -43,6 +43,10 @@ func Enable(r *aprot.Registry, opts ...EnableOption) {
 	r.RegisterPushEventFor(handler, RequestTaskTreeEvent{})
 	r.RegisterPushEventFor(handler, RequestTaskOutputEvent{})
 	r.RegisterPushEventFor(handler, RequestTaskProgressEvent{})
+	// The convenience hook below writes tasks.ts wholesale; reserve that file
+	// so a shared type in the tasks package (e.g. a handler returning
+	// *tasks.TaskRef) is emitted as tasks.types.ts instead of being clobbered.
+	r.ReserveClientFile("tasks")
 	r.OnGenerate(func(results map[string]string, mode aprot.OutputMode) {
 		appendTaskConvenienceCode(results, mode, nil)
 	})
@@ -80,6 +84,9 @@ func EnableWithMeta[M any](r *aprot.Registry, opts ...EnableOption) {
 	r.RegisterPushEventFor(handler, RequestTaskTreeEvent{})
 	r.RegisterPushEventFor(handler, RequestTaskOutputEvent{})
 	r.RegisterPushEventFor(handler, RequestTaskProgressEvent{})
+	// See Enable: reserve tasks.ts so a shared tasks-package type (e.g. a
+	// handler returning *tasks.TaskRef) is not clobbered by the convenience hook.
+	r.ReserveClientFile("tasks")
 	r.OnGenerate(func(results map[string]string, mode aprot.OutputMode) {
 		appendTaskConvenienceCode(results, mode, metaType)
 	})

--- a/tasks/generate_test.go
+++ b/tasks/generate_test.go
@@ -62,6 +62,81 @@ func TestGenerateWithTasks(t *testing.T) {
 	}
 }
 
+// taskRefStarterA and taskRefStarterB are two separate handler groups that both
+// return *TaskRef. Because the shared type is used by more than one group, the
+// main generator promotes TaskRef to a shared per-package file. That package's
+// short name is "tasks", which collides with the reserved task-runtime tasks.ts
+// — the convenience hook overwrites tasks.ts wholesale, so before the fix the
+// TaskRef declaration was dropped, leaving every consumer with a dangling
+// `import type { TaskRef } from './tasks'`.
+type taskRefStarterA struct{}
+
+func (h *taskRefStarterA) StartA(ctx context.Context) (*TaskRef, error) { return &TaskRef{}, nil }
+
+type taskRefStarterB struct{}
+
+func (h *taskRefStarterB) StartB(ctx context.Context) (*TaskRef, error) { return &TaskRef{}, nil }
+
+// TestGenerateSharedTaskRefFileRuntimeCollision guards the fix for a shared
+// tasks-package type colliding with the reserved task-runtime tasks.ts. TaskRef
+// must be declared in exactly one file, that file must not be the overwritten
+// tasks.ts, and every import of TaskRef must resolve to the defining file.
+func TestGenerateSharedTaskRefFileRuntimeCollision(t *testing.T) {
+	registry := aprot.NewRegistry()
+	registry.Register(&taskRefStarterA{})
+	registry.Register(&taskRefStarterB{})
+	Enable(registry)
+
+	results, err := aprot.NewGenerator(registry).Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	defFiles := make([]string, 0)
+	for name, content := range results {
+		if strings.Contains(content, "export interface TaskRef {") {
+			defFiles = append(defFiles, name)
+		}
+	}
+	if len(defFiles) != 1 {
+		names := make([]string, 0, len(results))
+		for name := range results {
+			names = append(names, name)
+		}
+		t.Fatalf("expected TaskRef defined in exactly one file, found in %v (files: %v)", defFiles, names)
+	}
+	if defFiles[0] == "tasks.ts" {
+		t.Fatalf("TaskRef declared in tasks.ts, which the task-runtime hook overwrites wholesale")
+	}
+	defModule := "./" + strings.TrimSuffix(defFiles[0], ".ts")
+
+	// Every import of TaskRef must resolve to the defining module — no dangling
+	// import, no file importing the type from itself.
+	for name, content := range results {
+		selfModule := "./" + strings.TrimSuffix(name, ".ts")
+		for _, line := range strings.Split(content, "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), "import") || !strings.Contains(line, "TaskRef") {
+				continue
+			}
+			from := "from '"
+			i := strings.LastIndex(line, from)
+			if i < 0 {
+				continue
+			}
+			module := line[i+len(from):]
+			if j := strings.IndexByte(module, '\''); j >= 0 {
+				module = module[:j]
+			}
+			if module == selfModule {
+				t.Errorf("%s imports TaskRef from itself (%q)", name, module)
+			}
+			if module != defModule {
+				t.Errorf("%s imports TaskRef from %q, but it is defined in %q", name, module, defModule)
+			}
+		}
+	}
+}
+
 // TestGenerateWithTasksMultiFile verifies multi-file generation with tasks enabled.
 // The generator must create a tasks.ts file with task convenience code and must
 // not modify client.ts with any task-specific code.


### PR DESCRIPTION
## Problem

When two or more handler groups return the same shared type from the `tasks` package (e.g. `*tasks.TaskRef`), the main generator promotes it to the shared per-package file `tasks.ts` and records `import type { TaskRef } from './tasks'` in every consumer. The task runtime's `OnGenerate` hook then does `results["tasks.ts"] = code` (`tasks/codegen.go`), overwriting the file wholesale — dropping the shared declaration and leaving consumers importing a type nobody exports:

```
Module './tasks' has no exported member 'TaskRef'.
```

This is the same collision class as #206 (shared per-package file vs. handler file), but against a file a **runtime hook** owns rather than a handler, so the existing guard (which only checks handler file names) missed it.

## Fix

Make the runtime's ownership of `tasks.ts` explicit:

- `Registry.ReserveClientFile(base)` — marks a client file base as owned by a runtime hook.
- `tasks.Enable` / `EnableWithMeta` reserve `"tasks"`.
- The shared-file namer treats reserved bases like handler files, so a shared `tasks`-package type is emitted as `tasks.types.ts` and imported from `./tasks.types` — untouched by the runtime hook.

## Test

Adds `TestGenerateSharedTaskRefFileRuntimeCollision` (two groups returning `*tasks.TaskRef`, tasks enabled): asserts `TaskRef` is declared exactly once, not in the overwritten `tasks.ts`, and every import resolves to the defining file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)