### PR TITLE
Fix format-tag incompatibility with current go-json-experiment/json snapshots

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -45,6 +45,8 @@ Hardening (all optional, sane defaults, `-1` disables): `aprot.ServerOptions{Max
 
 **Observability**: set `ServerOptions.Observer` to an `aprot.Observer` (embed `aprot.NoopObserver`, override what you need) — nil disables it with zero hot-path cost. Events: `ConnectionOpened/Closed(*Conn)`, `RequestCompleted(RequestEvent{Method, Subscribe, Duration, Code})` (Code 0 = success; fires for client requests/subscribes, not server refreshes), `SubscriptionRegistered/Unregistered(*Conn, method, id)`, `RefreshFanout(key, matched)`, `SendBufferFull(*Conn)` (backpressure; frame not dropped), `WriteTimedOut(*Conn)`. Callbacks are synchronous on hot paths + may run concurrently — keep them fast/non-blocking. Pull-based gauges: `server.Stats()` → `ServerStats{Connections, Subscriptions}`. Streaming handlers hold their slot until stream end; `RequestCompleted.Duration` spans the full iteration.
 
+**Server-side error logging**: set `ServerOptions.Logger` (`*slog.Logger`; nil → `slog.Default()`). Currently logged at error level: response-encode failures (unmarshalable handler results), with the method name — the same failures the client sees as `CodeInternalError`.
+
 ### 3. TypeScript Generation
 ```go
 gen := aprot.NewGenerator(registry).WithOptions(aprot.GeneratorOptions{
@@ -557,6 +559,7 @@ Other type-mapping notes:
 - `map[bool]V` → `Partial<Record<"true" | "false", V>>` (boolean isn't a valid TS index type).
 - `json.RawMessage` → `unknown`.
 - `time.Duration` has no default JSON representation in the v2 encoder and is **rejected at generation time** — add a json format option (e.g. `json:"d,format:nano"`) or use a different type.
+- Per-field `format:` tags work on every runtime marshal/unmarshal path (results, params, push/refresh payloads, stream items): aprot opts in to go-json-experiment/json's format-tag support internally (json/v2 snapshots since 2026-06 made it opt-in), so consumers don't need to pin the json/v2 snapshot or call `json.ExperimentalGlobalSupportFormatTag` themselves.
 - Field names and handler param names that aren't valid TS identifiers are quoted (`"my-field"`) or suffixed (`new_`) automatically.
 
 ## Naming Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Added
+
+- `ServerOptions.Logger` (`*slog.Logger`; nil uses `slog.Default()`) — receives
+  server-side error logs. Currently logged at error level: response-encode
+  failures, with the method name and error. These were previously reported to
+  the client as `CodeInternalError` but left no server-side trace, so an
+  incident could produce zero log lines.
+
+### Fixed
+
+- Compatibility with go-json-experiment/json snapshots from 2026-06 onward,
+  which made per-field `format:` struct tags opt-in. aprot's codegen requires
+  such tags on some types (e.g. `json:"d,format:nano"` on `time.Duration`),
+  so any consumer that resolved a newer snapshot via MVS had every response
+  containing a format-tagged struct fail with ``Go struct field … has
+  unsupported `format` tag option``. aprot now opts in on every path that
+  marshals or unmarshals user data (response results, request params,
+  push/refresh payloads, stream items, the `$blob` JSON fallback, and the
+  codegen's zero-value probes) and requires the 2026-06-23 snapshot or newer.
+  Consumers that pinned go-json-experiment/json back to aprot's previous
+  version as a workaround can drop the pin.
+
 ## [0.51.0] - 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -952,6 +952,16 @@ Events: `ConnectionOpened` / `ConnectionClosed`, `RequestCompleted` (method, sub
 - **Cardinality** — `Method` is bounded by your handler set, but per-user / per-connection labels can explode a metrics backend; aggregate those.
 - **Gauges** — `server.Stats()` returns a pull-based snapshot (`Connections`, `Subscriptions`) for periodic scraping, rather than tracking those from events.
 
+### Server-side error logging
+
+Set `ServerOptions.Logger` (a `*slog.Logger`) to receive server-side error logs; nil uses `slog.Default()`. Currently logged: response-encode failures — a handler result that cannot be marshaled (e.g. a NaN float) is reported to the client as an internal error *and* logged with the method name, so operators see the failure even when no client surfaces it.
+
+```go
+server := aprot.NewServer(registry, aprot.ServerOptions{
+    Logger: slog.New(slog.NewJSONHandler(os.Stderr, nil)),
+})
+```
+
 ## REST Adapter
 
 Serve your handlers as REST/HTTP endpoints alongside WebSocket. Use `RegisterREST` for REST-only handlers, or `EnableREST` to expose a WebSocket handler via REST as well:

--- a/blob_test.go
+++ b/blob_test.go
@@ -12,7 +12,7 @@ func TestSendResponseByteSliceStaysJSON(t *testing.T) {
 	rt := &recordingTransport{}
 	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
 
-	c.sendResponse("req-1", []byte("hello"))
+	c.sendResponse("req-1", "Test.Method", []byte("hello"))
 
 	messages := rt.Messages()
 	if len(messages) != 1 {
@@ -38,7 +38,7 @@ func TestSendResponseNilBlobPointerIsJSONNull(t *testing.T) {
 	rt := &recordingTransport{}
 	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
 
-	c.sendResponse("req-1", (*Blob)(nil))
+	c.sendResponse("req-1", "Test.Method", (*Blob)(nil))
 
 	messages := rt.Messages()
 	if len(messages) != 1 {
@@ -67,7 +67,7 @@ func TestSendResponseBlobFallsBackToJSONWithoutBinarySupport(t *testing.T) {
 	rt := &noBinaryRecordingTransport{}
 	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
 
-	c.sendResponse("req-1", Blob{ContentType: "text/plain", Data: []byte("hello")})
+	c.sendResponse("req-1", "Test.Method", Blob{ContentType: "text/plain", Data: []byte("hello")})
 
 	messages := rt.Messages()
 	if len(messages) != 1 {
@@ -101,7 +101,7 @@ func TestSendResponseBlobUsesBinaryFrameWhenSupported(t *testing.T) {
 	rt := &recordingTransport{}
 	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}
 
-	c.sendResponse("req-1", Blob{ContentType: "text/plain", Data: []byte("hello")})
+	c.sendResponse("req-1", "Test.Method", Blob{ContentType: "text/plain", Data: []byte("hello")})
 
 	messages := rt.Messages()
 	if len(messages) != 1 {

--- a/connection.go
+++ b/connection.go
@@ -321,9 +321,9 @@ func (c *Conn) sendJSONCtx(ctx context.Context, v any) error {
 	return c.transport.SendCtx(ctx, data)
 }
 
-func (c *Conn) sendResponse(id string, result any) {
+func (c *Conn) sendResponse(id, method string, result any) {
 	if blob, ok := asBlob(result); ok {
-		c.sendBlobResponse(id, blob)
+		c.sendBlobResponse(id, method, blob)
 		return
 	}
 	msg := ResponseMessage{
@@ -335,6 +335,9 @@ func (c *Conn) sendResponse(id string, result any) {
 	if err != nil {
 		// A result that cannot be marshaled (e.g. a NaN float) must not leave
 		// the request pending forever: surface it as an internal error instead.
+		// Log it too — the client-facing error alone leaves no server-side
+		// trace for operators.
+		c.server.logger().Error("aprot: failed to encode response", "method", method, "id", id, "error", err)
 		c.sendError(id, CodeInternalError, "failed to encode response: "+err.Error())
 		return
 	}
@@ -367,7 +370,7 @@ type blobFallbackResult struct {
 	Blob Blob `json:"$blob"`
 }
 
-func (c *Conn) sendBlobResponse(id string, blob Blob) {
+func (c *Conn) sendBlobResponse(id, method string, blob Blob) {
 	if !c.transport.SupportsBinary() {
 		msg := ResponseMessage{
 			Type:   TypeResponse,
@@ -376,6 +379,7 @@ func (c *Conn) sendBlobResponse(id string, blob Blob) {
 		}
 		data, err := marshalJSON(msg)
 		if err != nil {
+			c.server.logger().Error("aprot: failed to encode response", "method", method, "id", id, "error", err)
 			c.sendError(id, CodeInternalError, "failed to encode response: "+err.Error())
 			return
 		}
@@ -388,6 +392,7 @@ func (c *Conn) sendBlobResponse(id string, blob Blob) {
 		ContentType: blob.ContentType,
 	}, blob.Data)
 	if err != nil {
+		c.server.logger().Error("aprot: failed to encode binary response", "method", method, "id", id, "error", err)
 		c.sendError(id, CodeInternalError, "failed to encode binary response: "+err.Error())
 		return
 	}
@@ -723,7 +728,7 @@ func (c *Conn) handleRequest(msg IncomingMessage) {
 		return
 	}
 
-	c.sendResponse(msg.ID, result)
+	c.sendResponse(msg.ID, msg.Method, result)
 
 	// Process batched refresh triggers after response is sent
 	c.server.processRefreshQueue(rq)
@@ -999,7 +1004,7 @@ func (c *Conn) handleSubscribe(msg IncomingMessage) {
 		}
 	}
 
-	c.sendResponse(msg.ID, result)
+	c.sendResponse(msg.ID, msg.Method, result)
 
 	// Process batched refresh triggers after response is sent
 	c.server.processRefreshQueue(rq)
@@ -1084,7 +1089,7 @@ func (c *Conn) refreshSubscription(sub *subscription) {
 		c.server.subscriptions.updateKeys(c.id, sub.id, keys)
 	}
 
-	c.sendResponse(sub.id, result)
+	c.sendResponse(sub.id, sub.method, result)
 }
 
 func (c *Conn) handleUnsubscribe(id string) {

--- a/doc.go
+++ b/doc.go
@@ -436,6 +436,12 @@
 // fast and non-blocking. For gauge-style values, [Server.Stats] returns a
 // pull-based snapshot of active connection and subscription counts.
 //
+// Set [ServerOptions.Logger] (a *slog.Logger; nil uses slog.Default) to
+// receive server-side error logs. Currently logged: response-encode failures —
+// a handler result that cannot be marshaled is reported to the client as an
+// internal error and logged with the method name, so the failure leaves a
+// trace operators can find.
+//
 // # Push Events
 //
 // Push events are server-to-client messages broadcast to all connected clients
@@ -846,6 +852,12 @@
 // time.Duration has no default JSON representation in the v2 encoder and is
 // rejected at generation time; add a json format option (e.g.
 // `json:"d,format:nano"`) or use a different type.
+//
+// Per-field `format:` tags are supported on every marshal/unmarshal path
+// (results, params, push/refresh payloads, stream items): aprot opts in to
+// go-json-experiment/json's format-tag support internally, so consumers do
+// not need to pin the json/v2 snapshot or set
+// json.ExperimentalGlobalSupportFormatTag themselves.
 //
 // # Wire Protocol
 //

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 // indirect
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/example/react/go.mod
+++ b/example/react/go.mod
@@ -6,7 +6,7 @@ require github.com/marrasen/aprot v0.35.1
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 // indirect
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect

--- a/example/react/go.sum
+++ b/example/react/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/example/task-middleware/go.mod
+++ b/example/task-middleware/go.mod
@@ -6,7 +6,7 @@ require github.com/marrasen/aprot v0.0.0
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 // indirect
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect

--- a/example/task-middleware/go.sum
+++ b/example/task-middleware/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/example/vanilla/go.mod
+++ b/example/vanilla/go.mod
@@ -3,7 +3,7 @@ module github.com/marrasen/aprot/example/vanilla
 go 1.26
 
 require (
-	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68
 	github.com/marrasen/aprot v0.35.1
 )
 

--- a/example/vanilla/go.sum
+++ b/example/vanilla/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
-github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/format_tag_test.go
+++ b/format_tag_test.go
@@ -1,0 +1,80 @@
+package aprot
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Handlers used by the `format:` tag tests. The codegen requires a json
+// format option on time.Duration fields (see collectInterfaceFields), so the
+// runtime must accept them: json/v2 snapshots since 2026-06 reject
+// format-tagged fields unless ExperimentalSupportFormatTag is set.
+type FormatTagHandlers struct{}
+
+type DurationPayload struct {
+	D time.Duration `json:"d,format:nano"`
+}
+
+func (h *FormatTagHandlers) EchoDuration(ctx context.Context, req *DurationPayload) (*DurationPayload, error) {
+	return &DurationPayload{D: req.D}, nil
+}
+
+// marshalJSON / unmarshalJSON must honor `format:` struct tags: nano-tagged
+// durations encode as int64 nanoseconds and decode back.
+func TestMarshalJSONFormatTagDuration(t *testing.T) {
+	data, err := marshalJSON(DurationPayload{D: 1500 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("marshalJSON failed: %v", err)
+	}
+	if string(data) != `{"d":1500000000}` {
+		t.Fatalf("marshaled %s, want {\"d\":1500000000}", data)
+	}
+
+	var back DurationPayload
+	if err := unmarshalJSON(data, &back); err != nil {
+		t.Fatalf("unmarshalJSON failed: %v", err)
+	}
+	if back.D != 1500*time.Millisecond {
+		t.Fatalf("round-tripped %v, want 1.5s", back.D)
+	}
+}
+
+// A handler whose params and result carry a format-tagged time.Duration must
+// round-trip over the wire: params decode through unmarshalJSON, the result
+// encodes through marshalJSON, and the client sees int64 nanoseconds.
+func TestFormatTagDurationRoundTrip(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&FormatTagHandlers{})
+	server := NewServer(registry)
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "FormatTagHandlers.EchoDuration", Params: jsontext.Value(`[{"d":1500000000}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp struct {
+		Type   MessageType `json:"type"`
+		ID     string      `json:"id"`
+		Result struct {
+			D int64 `json:"d"`
+		} `json:"result"`
+	}
+	if err := ws.ReadJSON(&resp); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if resp.Type != TypeResponse || resp.ID != "1" {
+		t.Fatalf("unexpected envelope: %+v", resp)
+	}
+	if resp.Result.D != int64(1500*time.Millisecond) {
+		t.Fatalf("result.d = %d, want %d nanoseconds", resp.Result.D, int64(1500*time.Millisecond))
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -52,13 +52,14 @@ func InferTypeFromMarshal(t reflect.Type) *MarshalTSType {
 		return nil
 	}
 
-	// json.Marshaler: create zero value and marshal it.
+	// json.Marshaler: create zero value and marshal it. Use the shared wire
+	// options so the probe sees the same semantics as the runtime.
 	var data []byte
 	func() {
 		defer func() { _ = recover() }() // guard against panics on zero-value marshal
 		v := reflect.New(t)
 		var err error
-		data, err = json.Marshal(v.Interface())
+		data, err = marshalJSON(v.Interface())
 		if err != nil {
 			data = nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/marrasen/aprot
 go 1.26
 
 require (
-	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/gorilla/websocket v1.5.3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/marshal_error_test.go
+++ b/marshal_error_test.go
@@ -1,10 +1,13 @@
 package aprot
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"math"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,6 +74,59 @@ func TestResponseMarshalFailureSendsError(t *testing.T) {
 	resp := readMessageOfType(t, ws, TypeResponse, 3*time.Second)
 	if resp.ID != "2" {
 		t.Errorf("expected response for request 2, got %q", resp.ID)
+	}
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer: the server logs from request
+// goroutines while the test reads from its own.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// An encode failure must be logged server-side (with the method name) in
+// addition to the CodeInternalError sent to the client — the client-facing
+// error alone leaves operators with no trace in the logs.
+func TestResponseMarshalFailureIsLogged(t *testing.T) {
+	var logs syncBuffer
+	registry := NewRegistry()
+	registry.Register(&MarshalHandlers{})
+	server := NewServer(registry, ServerOptions{
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+
+	ws := connectWS(t, ts)
+	defer ws.Close()
+
+	if err := ws.WriteJSON(IncomingMessage{Type: TypeRequest, ID: "1", Method: "MarshalHandlers.NaN", Params: jsontext.Value(`[{"message":"hi"}]`)}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	errMsg := readMessageOfType(t, ws, TypeError, 3*time.Second)
+	if errMsg.Code != CodeInternalError {
+		t.Errorf("expected CodeInternalError, got %d", errMsg.Code)
+	}
+
+	got := logs.String()
+	if !strings.Contains(got, "failed to encode response") {
+		t.Errorf("expected encode failure in server log, got %q", got)
+	}
+	if !strings.Contains(got, "MarshalHandlers.NaN") {
+		t.Errorf("expected method name in server log, got %q", got)
 	}
 }
 

--- a/rest.go
+++ b/rest.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 )
 
@@ -343,7 +342,7 @@ func marshalJSONParams(params []any) (jsontext.Value, error) {
 		if raw, ok := p.(jsontext.Value); ok {
 			parts = append(parts, string(raw))
 		} else {
-			data, err := json.Marshal(p)
+			data, err := marshalJSON(p)
 			if err != nil {
 				return nil, err
 			}
@@ -408,7 +407,8 @@ func writeJSONErrorData(w http.ResponseWriter, status int, code int, message str
 		Message: message,
 		Data:    data,
 	}
-	out, _ := json.Marshal(resp)
+	// Data may carry user error payloads, so use the shared wire options.
+	out, _ := marshalJSON(resp)
 	_, _ = w.Write(out)
 }
 

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package aprot
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -87,6 +88,11 @@ type ServerOptions struct {
 	// send-buffer events for metrics/observability. Nil (the default) disables
 	// all observation with no hot-path cost. See [Observer].
 	Observer Observer
+	// Logger receives server-side error logs — currently response-encode
+	// failures, which are also reported to the client as CodeInternalError but
+	// would otherwise leave no server-side trace. Nil (the default) uses
+	// [slog.Default].
+	Logger *slog.Logger
 	// AuthTimeout is how long a connection may stay unauthenticated after
 	// connecting when an [AuthHook] is registered via [Server.OnAuth]. A
 	// connection that has not sent a valid auth frame within this window is
@@ -216,6 +222,9 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 		if opt.Observer != nil {
 			options.Observer = opt.Observer
 		}
+		if opt.Logger != nil {
+			options.Logger = opt.Logger
+		}
 		if opt.AuthTimeout != 0 {
 			options.AuthTimeout = opt.AuthTimeout
 		}
@@ -273,6 +282,15 @@ func NewServer(registry *Registry, opts ...ServerOptions) *Server {
 
 	go s.run()
 	return s
+}
+
+// logger returns the configured [ServerOptions.Logger], falling back to
+// [slog.Default].
+func (s *Server) logger() *slog.Logger {
+	if s.options.Logger != nil {
+		return s.options.Logger
+	}
+	return slog.Default()
 }
 
 // Use adds middleware to the chain.

--- a/sql_null.go
+++ b/sql_null.go
@@ -186,12 +186,27 @@ var sqlNullOptions = json.JoinOptions(
 	json.WithUnmarshalers(sqlNullUnmarshalers),
 )
 
-// marshalJSON marshals v to JSON with sql.Null* type support.
+// wireJSONOptions is the single options set applied everywhere aprot marshals
+// or unmarshals user data: response results, request params, push/refresh
+// payloads, stream items, the $blob JSON fallback, and the codegen's
+// zero-value marshaling probes. It combines the sql.Null* overrides with the
+// go-json-experiment/json opt-in for per-field `format:` struct tags:
+// snapshots since 2026-06 reject format-tagged fields at marshal/unmarshal
+// time unless this option is set, and aprot's codegen requires such tags on
+// some types (e.g. `json:"d,format:nano"` on time.Duration).
+var wireJSONOptions = json.JoinOptions(
+	sqlNullOptions,
+	json.ExperimentalSupportFormatTag(true),
+)
+
+// marshalJSON marshals v to JSON with aprot's wire semantics: sql.Null* type
+// support and `format:` struct tag support.
 func marshalJSON(v any) ([]byte, error) {
-	return json.Marshal(v, sqlNullOptions)
+	return json.Marshal(v, wireJSONOptions)
 }
 
-// unmarshalJSON unmarshals data into v with sql.Null* type support.
+// unmarshalJSON unmarshals data into v with aprot's wire semantics: sql.Null*
+// type support and `format:` struct tag support.
 func unmarshalJSON(data []byte, v any) error {
-	return json.Unmarshal(data, v, sqlNullOptions)
+	return json.Unmarshal(data, v, wireJSONOptions)
 }


### PR DESCRIPTION
## Problem

json/v2 snapshots from 2026-06 onward made per-field `format:` struct tags **opt-in** — fields carrying one fail at marshal/unmarshal time with ``Go struct field … has unsupported `format` tag option`` unless `ExperimentalSupportFormatTag` is set. aprot's codegen *requires* such tags on some types (`json:"d,format:nano"` on `time.Duration`), so any consumer that resolved a newer snapshot via MVS had every response containing a format-tagged struct fail. particleview5 hit this (`FilterHandlers.GetFilters` errored, blank Edit page) and worked around it by pinning json/v2 back to aprot's version. The incident also produced **zero server-side log lines**, because `Conn.sendResponse` reported encode failures to the client but never logged them.

## Changes

- **Bump** `github.com/go-json-experiment/json` to `v0.0.0-20260623181947-01eb4420fa68` (root, examples, e2e).
- **Opt in to format tags centrally**: new `wireJSONOptions` (sql.Null* overrides + `json.ExperimentalSupportFormatTag(true)`) used by the shared `marshalJSON`/`unmarshalJSON` helpers — covering response results, request params, push/refresh payloads, stream items, and the `$blob` JSON fallback. Routed the remaining user-data marshal sites through the helpers: REST param marshaling (`marshalJSONParams`), REST error responses (`Data` may carry user payloads), and the codegen's zero-value marshaling probe (`InferTypeFromMarshal`), so generation sees the same semantics as the runtime.
- **Fix the silent-failure logging gap**: new `ServerOptions.Logger` (`*slog.Logger`, nil → `slog.Default()`); `sendResponse`/`sendBlobResponse` now log encode failures at error level with the method name, alongside the `CodeInternalError` already sent to the client.
- **Regression tests**: format-tagged `time.Duration` round-trips over the wire as int64 nanoseconds (unit + WS integration); encode failures are asserted logged server-side *and* surfaced as `CodeInternalError`.
- Docs updated: README, doc.go, APROT_AI.md, CHANGELOG (consumers may drop json/v2 pins).

## Snapshot behavior audit (Feb → June)

Probed both snapshots side by side for the behaviors aprot's comments reference: unnamed `[]byte`/named `[]byte`/`[N]byte` base64 handling, `[]NamedByteType` number arrays, bool map keys, nil slice/map (`[]`/`{}`), NaN rejection. **The two snapshots behave identically on all of them** — the format-tag opt-in is the only change affecting aprot. Binary Blob delivery is raw bytes, so no JSON path is affected there.

Two pre-existing discrepancies surfaced by the audit (identical under both snapshots, so out of scope here, but worth follow-up issues):
- `type Foo []byte` (named slice of builtin byte) marshals as a **base64 string** at runtime, but codegen emits `number[]` (`isUnnamedByteSlice` gates the string shape to unnamed slices only; only `[]NamedByteType` is a number array).
- `map[bool]V` **fails to marshal at runtime** ("object member name must be a string"), while the docs/codegen promise `Partial<Record<"true" | "false", V>>`.

## Verification

- `go test ./...` and `go test -race ./...` green; gofmt clean; `go vet` clean.
- Regenerated vanilla/react example clients and the e2e clients — output unchanged; `npx tsc --noEmit` green; full e2e vitest suite green (98 tests).
- Downstream: built marraw against this branch via a temporary local replace — MVS resolved json/v2 to the new snapshot (the exact pv5 failure setup) and everything compiles; replace reverted. particleview5 verification (drop its json/v2 pin + smoke test) still needs to run on the machine that has that checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)