### PR TITLE
Release v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-07-16
+
 ### Added
 
 - `ServerOptions.Logger` (`*slog.Logger`; nil uses `slog.Default()`) — receives


### PR DESCRIPTION
Prepare v0.52.0 changelog.

- Compatibility with go-json-experiment/json snapshots from 2026-06 onward (opt-in `format:` struct tags) — consumers that pinned json/v2 back to aprot's previous version can drop the pin.
- New `ServerOptions.Logger` for server-side error logging of response-encode failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)