### PR TITLE
Document the WebSocket binary frame format for Blob results

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -128,6 +128,8 @@ func (h *H) GetAvatar(ctx context.Context, userID string) (aprot.Blob, error) {
 ```
 Return `aprot.Blob` / `*aprot.Blob` as the **top-level result** and the generated method is typed `Promise<Blob>`, resolving a DOM `Blob` on every transport: WS sends a raw binary frame (no base64); SSE/stream fall back to a `{"$blob": {contentType, data}}` JSON envelope that the client converts back automatically. Subscription refreshes (`subscribeGetAvatar`, `useGetAvatar`) also deliver `Blob`s. Opt-in only: a plain `[]byte` result stays a base64 string, and a `Blob` nested in a struct, streamed, or used as a param travels as JSON `{ contentType?: string; data: string }`. Do not name your own generated type `Blob` — the DOM type is used verbatim.
 
+**Non-generated WS clients must decode the binary frame** (`[4-byte BE header length][JSON header][raw payload]`, header `{version, type, id, contentType}`) — a client that handles only text frames drops `Blob` responses silently, so the call hangs forever with no server-side trace, and `Blob` subscriptions just stop refreshing. Format spec + reference decoder: `docs/binary-frames.md`.
+
 ## Input Transformation
 
 `transform:"…"` ops run after JSON decoding, before validation. Statically checked at `Register` time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Documentation
+
+- `docs/binary-frames.md` documents the WebSocket binary frame format used for
+  `Blob` results — layout, header fields, reference decoders (JS and Python),
+  and the JSON `$blob` fallback — for anyone writing a WebSocket client other
+  than the generated TypeScript one. A client that handles only text frames
+  drops `Blob` responses silently: the call never settles, and because the
+  server considers the request complete there is no error and no server-side
+  trace, which is easily mistaken for a server deadlock. Subscriptions to a
+  `Blob`-returning method have the same failure with no hang at all — the
+  refreshes just never arrive. (#279)
+
 ## [0.52.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -659,6 +659,8 @@ imgEl.src = URL.createObjectURL(avatar); // avatar.type === 'image/png'
 
 Over WebSocket the payload travels as a binary frame (a 4-byte header length, a small JSON header, then the raw bytes). Transports without binary frames (SSE, byte-stream) fall back to a JSON envelope carrying base64 data, which the client converts back into a `Blob` automatically — the resolved type never depends on the transport. Subscription refreshes (`subscribeGetAvatar`, `useGetAvatar`) deliver `Blob`s the same way.
 
+If you are writing your own WebSocket client rather than using the generated one, see **[docs/binary-frames.md](docs/binary-frames.md)** for the frame format and a reference decoder. A client that handles only text frames silently drops `Blob` responses: the call never settles and there is no server-side trace, which is easily mistaken for a server deadlock.
+
 Binary delivery is opt-in via the `Blob` type and applies to top-level results only. A plain `[]byte` result keeps its base64 string encoding, and a `Blob` nested inside another struct, streamed as an item, or passed as a parameter travels as ordinary JSON (`{contentType?, data}` with base64 `data`).
 
 ## Subscription Patches

--- a/blob_test.go
+++ b/blob_test.go
@@ -97,6 +97,16 @@ func TestSendResponseBlobFallsBackToJSONWithoutBinarySupport(t *testing.T) {
 	}
 }
 
+// TestBinaryFrameVersionMatchesDocumentedFormat guards docs/binary-frames.md,
+// which specifies version 1 for third-party client implementers. Bumping the
+// constant is a wire-format change: update that document (and give clients a
+// way to recognize the new version) in the same change.
+func TestBinaryFrameVersionMatchesDocumentedFormat(t *testing.T) {
+	if binaryFrameVersion != 1 {
+		t.Fatalf("binaryFrameVersion = %d, but docs/binary-frames.md documents version 1", binaryFrameVersion)
+	}
+}
+
 func TestSendResponseBlobUsesBinaryFrameWhenSupported(t *testing.T) {
 	rt := &recordingTransport{}
 	c := &Conn{transport: rt, requests: make(map[string]context.CancelCauseFunc)}

--- a/doc.go
+++ b/doc.go
@@ -95,6 +95,11 @@
 // another struct, streamed as an item, or used as a parameter travels as
 // ordinary JSON ({contentType?, data}).
 //
+// Hand-written WebSocket clients must decode the binary frame; one that
+// handles only text frames drops Blob responses silently, leaving the call
+// pending with no server-side trace. See docs/binary-frames.md for the frame
+// format and a reference decoder.
+//
 // # Input Transformation
 //
 // Request struct fields can be normalized before handler dispatch using

--- a/docs/binary-frames.md
+++ b/docs/binary-frames.md
@@ -1,0 +1,140 @@
+# Binary Frames on the Wire
+
+This document specifies the WebSocket binary frame aprot uses to deliver
+`Blob` results, so that clients other than the generated TypeScript one — test
+probes, bindings for other languages, quick tooling — can decode them.
+
+If you are using the generated TypeScript client, you do not need any of this;
+it decodes these frames already.
+
+## When aprot sends a binary frame
+
+Every aprot message is a **text** frame carrying JSON, with exactly one
+exception: a handler whose top-level result is `aprot.Blob` (or `*aprot.Blob`)
+is delivered over WebSocket as a **binary** frame.
+
+That covers two cases:
+
+- the response to a unary call of a `Blob`-returning method, and
+- every server-driven refresh of a subscription to a `Blob`-returning method.
+
+Everything else stays text JSON — including a `Blob` nested inside another
+struct, streamed as an item, or passed as a parameter, and including a plain
+`[]byte` result. Those travel as `{contentType?, data}` with base64 `data`.
+
+A `nil` `*Blob` result is not a blob: it takes the ordinary JSON path and
+arrives as a `null` result, like any other nil pointer.
+
+## Frame layout
+
+```
+┌────────────┬──────────────────────┬─────────────────────────┐
+│  4 bytes   │     headerLen bytes  │    rest of the frame    │
+│ headerLen  │     JSON header      │     raw payload bytes   │
+│ big-endian │                      │  (no base64, no framing)│
+└────────────┴──────────────────────┴─────────────────────────┘
+```
+
+- **`headerLen`** — unsigned 32-bit, **big-endian** (network byte order). The
+  byte length of the JSON header that follows.
+- **JSON header** — UTF-8 JSON object, see below.
+- **payload** — the raw `Blob.Data` bytes, from offset `4 + headerLen` to the
+  end of the frame. The payload length is implied by the frame length; it is
+  not encoded in the header.
+
+## Header fields
+
+```json
+{ "version": 1, "type": "response", "id": "42", "contentType": "image/png" }
+```
+
+| Field         | Type   | Notes                                                        |
+| ------------- | ------ | ------------------------------------------------------------ |
+| `version`     | number | Frame format version. Currently always `1`.                   |
+| `type`        | string | Currently always `"response"`.                                |
+| `id`          | string | Correlates with the `id` of the originating request, or with the subscription id for a refresh. Same id space as text `response` frames. |
+| `contentType` | string | Omitted when the handler left `Blob.ContentType` empty.       |
+
+Clients should treat a frame whose `version` is not `1`, or whose `type` is not
+`"response"`, as an error and **fail the pending request for that `id`** rather
+than ignoring the frame — see the pitfall below. The header is guaranteed to
+carry an `id` even for otherwise unrecognized frames.
+
+## Reference decoder
+
+JavaScript / TypeScript (browser `WebSocket` or `ws` in Node):
+
+```js
+// ws.binaryType = 'arraybuffer';  // browsers default to 'blob'
+function decodeBinaryFrame(buffer) {
+  const view = new DataView(buffer);
+  const headerLen = view.getUint32(0, false); // false = big-endian
+  const header = JSON.parse(
+    new TextDecoder().decode(new Uint8Array(buffer, 4, headerLen)),
+  );
+  const payload = new Uint8Array(buffer, 4 + headerLen);
+  return { header, payload };
+}
+```
+
+Wiring it into a message handler that already parses text frames:
+
+```js
+ws.onmessage = (ev) => {
+  if (typeof ev.data === 'string') {
+    handleJSON(JSON.parse(ev.data));
+    return;
+  }
+  const { header, payload } = decodeBinaryFrame(ev.data);
+  settle(header.id, { contentType: header.contentType, data: payload });
+};
+```
+
+Python (`websockets`), where a binary frame arrives as `bytes`:
+
+```python
+import json, struct
+
+def decode_binary_frame(frame: bytes):
+    (header_len,) = struct.unpack_from(">I", frame, 0)
+    header = json.loads(frame[4 : 4 + header_len])
+    return header, frame[4 + header_len :]
+```
+
+## Common pitfall: the silent hang
+
+A client that only handles text frames drops `Blob` responses on the floor. The
+server considers the request complete — the handler returned, the frame was
+written — so there is no error, no timeout, and no server-side trace. The
+pending request simply never settles, which looks exactly like a server
+deadlock. For a *subscription* to a `Blob` method, there isn't even a hang: the
+refreshes silently never arrive and the client shows stale data forever.
+
+If a single RPC hangs while every other call on the same connection works,
+check whether that method returns a `Blob`.
+
+Two defenses:
+
+- Handle binary frames, per the decoder above.
+- Reject unknown frames instead of ignoring them. Since the header always
+  carries an `id`, a client that cannot make sense of a frame can still fail
+  the corresponding pending request with a clear error rather than leaving the
+  caller to hang.
+
+## JSON fallback
+
+Transports without a native binary channel (SSE, byte-stream) deliver the same
+value as an ordinary text `response` frame whose result is a one-key envelope:
+
+```json
+{
+  "type": "response",
+  "id": "42",
+  "result": { "$blob": { "contentType": "image/png", "data": "iVBORw0KG..." } }
+}
+```
+
+`data` is standard base64. A client that implements this shape as well can
+reconstruct an identical value on every transport — this is exactly what the
+generated TypeScript client does, which is why its resolved type does not
+depend on the transport.


### PR DESCRIPTION
Part 1 of 2 for #279. This is the piece that has no API surface and no compatibility risk, and it serves the consumer who *wants* binary — the point of `Blob` is avoiding base64 inflation, so the fix shouldn't only be "opt out of binary".

## Problem

A WebSocket client that doesn't decode binary frames silently hangs on any RPC returning a top-level `Blob`. The handler completes, `sendBlobResponse` writes the frame, the server considers the request done — a text-only client drops it and the promise never settles. No response, no error, no server-side trace, indistinguishable from a server deadlock.

The issue undersells one case: `sendResponse` is also called from the subscription refresh path (`connection.go:1092`), so a subscription to a `Blob`-returning method fails without even hanging. The refreshes silently never arrive and the client shows stale data forever.

The format was previously described only in passing — "a 4-byte header length, a small JSON header, then the raw bytes" — which is not enough to implement against (no byte order, no header schema, no correlation rule).

## Changes

- **`docs/binary-frames.md`** — which frames are binary and which aren't, the normative layout, the header field table, reference decoders in JS and Python, the `$blob` JSON fallback shape, and the silent-hang pitfall.
- Links from the three places that describe `Blob` delivery as unconditional binary over WS: `README.md`, `doc.go`, `APROT_AI.md`.
- `TestBinaryFrameVersionMatchesDocumentedFormat` asserts `binaryFrameVersion == 1` against the literal rather than the constant, so bumping the wire version fails until the document is updated.

One recommendation in the doc worth calling out: clients should **reject** an unrecognized frame by `id` rather than ignore it. The header always carries an `id`, so even a client that can't parse the rest can fail the pending request with a clear error instead of leaving the caller to hang. The generated TS client already does this (`_client-common.ts.tmpl:1182-1190`); the doc now makes it advice for everyone else.

## Not in this PR

The per-connection binary opt-out (proposal 1 in the issue) follows separately, since it changes behavior and wants its own review. This doc will get the negotiation section then.

## Test plan

- `go test ./...`
- Docs-only otherwise; no generated-client output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)