### PR TITLE
Let WebSocket clients decline binary frames per connection

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -130,6 +130,8 @@ Return `aprot.Blob` / `*aprot.Blob` as the **top-level result** and the generate
 
 **Non-generated WS clients must decode the binary frame** (`[4-byte BE header length][JSON header][raw payload]`, header `{version, type, id, contentType}`) — a client that handles only text frames drops `Blob` responses silently, so the call hangs forever with no server-side trace, and `Blob` subscriptions just stop refreshing. Format spec + reference decoder: `docs/binary-frames.md`.
 
+**Opting out (#279):** dial with `?binary=0` (`wss://host/ws?binary=0`) and that connection gets `Blob` results as the JSON `$blob` envelope instead — same shape SSE/stream use, costs base64 inflation. Values `1/true/yes/on` and `0/false/no/off`, case-insensitive; anything else fails the upgrade with `400` (a typo must not silently restore the hang). The `config` frame now carries `binaryFrames: bool` (always emitted, `false` on SSE/stream) so a client can confirm the negotiated mode before its first call; a missing field means a server predating the negotiation. Generated TS clients always take binary and need no changes.
+
 ## Input Transformation
 
 `transform:"…"` ops run after JSON decoding, before validation. Statically checked at `Register` time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+### Added
+
+- Per-connection opt-out from WebSocket binary frames. A client that does not
+  decode binary can dial with `?binary=0` on the upgrade URL and receive `Blob`
+  results as the JSON `{"$blob": {contentType, data}}` envelope instead — the
+  same representation SSE and byte-stream already use — at the cost of base64
+  inflation. Accepted values are `1`/`true`/`yes`/`on` and `0`/`false`/`no`/
+  `off` (case-insensitive); an unrecognized value fails the upgrade with
+  `400 Bad Request` rather than silently defaulting to binary, since a typo
+  that re-enabled binary frames would reinstate the hang the parameter exists
+  to prevent. Omitting the parameter keeps the existing behavior, so generated
+  TypeScript clients are unaffected. (#279)
+- `ConfigMessage.BinaryFrames` (`binaryFrames` on the wire) reports whether
+  `Blob` results will arrive as binary frames on this connection. Always
+  emitted, including when false, and always false on SSE and byte-stream. It
+  reaches the client before any request can be made, which makes it the one
+  point at which a client that cannot decode binary frames can fail loudly
+  instead of hanging on the first `Blob` response — aprot cannot detect a
+  dropped frame server-side. A missing field means a server predating the
+  negotiation. (#279)
+
 ### Documentation
 
 - `docs/binary-frames.md` documents the WebSocket binary frame format used for

--- a/README.md
+++ b/README.md
@@ -661,6 +661,14 @@ Over WebSocket the payload travels as a binary frame (a 4-byte header length, a 
 
 If you are writing your own WebSocket client rather than using the generated one, see **[docs/binary-frames.md](docs/binary-frames.md)** for the frame format and a reference decoder. A client that handles only text frames silently drops `Blob` responses: the call never settles and there is no server-side trace, which is easily mistaken for a server deadlock.
 
+A client that would rather not decode binary at all can decline it for the lifetime of the connection by passing `binary=0` on the upgrade URL:
+
+```js
+const ws = new WebSocket('wss://example.com/ws?binary=0');
+```
+
+`Blob` results then arrive as the same JSON `$blob` envelope SSE and stream use, at the cost of base64 inflation. The `config` frame the server sends immediately after the upgrade reports the mode in effect as `binaryFrames`, so a client can confirm what it negotiated before making its first call rather than discovering it by hanging. An unrecognized value fails the upgrade with `400 Bad Request` — a typo that silently re-enabled binary frames would reinstate the very hang the parameter prevents.
+
 Binary delivery is opt-in via the `Blob` type and applies to top-level results only. A plain `[]byte` result keeps its base64 string encoding, and a `Blob` nested inside another struct, streamed as an item, or passed as a parameter travels as ordinary JSON (`{contentType?, data}` with base64 `data`).
 
 ## Subscription Patches

--- a/blob_negotiation_test.go
+++ b/blob_negotiation_test.go
@@ -1,0 +1,204 @@
+package aprot
+
+import (
+	"context"
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-json-experiment/json"
+	"github.com/gorilla/websocket"
+)
+
+type BlobNegotiationHandler struct{}
+
+func (h *BlobNegotiationHandler) GetAvatar(ctx context.Context) (Blob, error) {
+	return Blob{ContentType: "text/plain", Data: []byte("hello")}, nil
+}
+
+// dialBlobNegotiation starts a server, dials it with the given query string
+// (empty for none), and returns the connection plus the config frame.
+func dialBlobNegotiation(t *testing.T, query string) (*websocket.Conn, ConfigMessage) {
+	t.Helper()
+	registry := NewRegistry()
+	registry.Register(&BlobNegotiationHandler{})
+	ts := httptest.NewServer(NewServer(registry))
+	t.Cleanup(ts.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + query
+	ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial %q: %v", query, err)
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+
+	var cfg ConfigMessage
+	if err := ws.ReadJSON(&cfg); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	return ws, cfg
+}
+
+func requestAvatar(t *testing.T, ws *websocket.Conn) (messageType int, data []byte) {
+	t.Helper()
+	req := map[string]any{
+		"type":   "request",
+		"id":     "1",
+		"method": "BlobNegotiationHandler.GetAvatar",
+		"params": []any{},
+	}
+	if err := ws.WriteJSON(req); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	mt, data, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return mt, data
+}
+
+// Without the parameter, nothing changes: WebSocket clients keep getting the
+// efficient binary frame, and the config frame says so.
+func TestWSBlobDefaultsToBinaryFrame(t *testing.T) {
+	ws, cfg := dialBlobNegotiation(t, "")
+	if !cfg.BinaryFrames {
+		t.Fatalf("config binaryFrames = false, want true by default")
+	}
+
+	mt, data := requestAvatar(t, ws)
+	if mt != websocket.BinaryMessage {
+		t.Fatalf("message type = %d, want binary (%d)", mt, websocket.BinaryMessage)
+	}
+	headerLen := int(binary.BigEndian.Uint32(data[:4]))
+	var header binaryFrameHeader
+	if err := json.Unmarshal(data[4:4+headerLen], &header); err != nil {
+		t.Fatalf("unmarshal header: %v", err)
+	}
+	if header.ID != "1" || header.ContentType != "text/plain" {
+		t.Fatalf("unexpected header: %+v", header)
+	}
+	if payload := string(data[4+headerLen:]); payload != "hello" {
+		t.Fatalf("payload = %q, want %q", payload, "hello")
+	}
+}
+
+// A client that declines binary gets the JSON $blob envelope on a text frame —
+// the same representation SSE and stream already use — instead of a binary
+// frame it would silently drop.
+func TestWSBinaryOptOutDeliversJSONBlobEnvelope(t *testing.T) {
+	ws, cfg := dialBlobNegotiation(t, "?binary=0")
+	if cfg.BinaryFrames {
+		t.Fatalf("config binaryFrames = true, want false after opting out")
+	}
+
+	mt, data := requestAvatar(t, ws)
+	if mt != websocket.TextMessage {
+		t.Fatalf("message type = %d, want text (%d): %q", mt, websocket.TextMessage, data)
+	}
+	var msg struct {
+		Type   string `json:"type"`
+		ID     string `json:"id"`
+		Result struct {
+			Blob *struct {
+				ContentType string `json:"contentType"`
+				Data        []byte `json:"data"`
+			} `json:"$blob"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("expected JSON response, got %q: %v", data, err)
+	}
+	if msg.Type != "response" || msg.ID != "1" {
+		t.Fatalf("unexpected envelope: %+v", msg)
+	}
+	if msg.Result.Blob == nil {
+		t.Fatalf("result missing $blob marker: %s", data)
+	}
+	if msg.Result.Blob.ContentType != "text/plain" || string(msg.Result.Blob.Data) != "hello" {
+		t.Fatalf("unexpected $blob payload: %+v", msg.Result.Blob)
+	}
+}
+
+// A typo must not quietly fall back to binary frames — that would reinstate
+// the exact silent hang the parameter exists to prevent.
+func TestWSInvalidBinaryParamRejectsUpgrade(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&BlobNegotiationHandler{})
+	ts := httptest.NewServer(NewServer(registry))
+	defer ts.Close()
+
+	for _, value := range []string{"fasle", "", "2"} {
+		wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "?binary=" + value
+		ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err == nil {
+			_ = ws.Close()
+			t.Fatalf("binary=%q: upgrade succeeded, want rejection", value)
+		}
+		if resp == nil {
+			t.Fatalf("binary=%q: no HTTP response: %v", value, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("binary=%q: status = %d, want %d", value, resp.StatusCode, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestWSBinaryFromRequest(t *testing.T) {
+	tests := []struct {
+		query   string
+		want    bool
+		wantErr bool
+	}{
+		{query: "", want: true},
+		{query: "?binary=1", want: true},
+		{query: "?binary=true", want: true},
+		{query: "?binary=ON", want: true},
+		{query: "?binary=0", want: false},
+		{query: "?binary=false", want: false},
+		{query: "?binary=No", want: false},
+		{query: "?binary=off", want: false},
+		{query: "?binary=", wantErr: true},
+		{query: "?binary=maybe", wantErr: true},
+		{query: "?other=0", want: true},
+	}
+	for _, tt := range tests {
+		r := httptest.NewRequest(http.MethodGet, "/ws"+tt.query, nil)
+		got, err := wsBinaryFromRequest(r)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("%q: expected error, got %v", tt.query, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", tt.query, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("%q: got %v, want %v", tt.query, got, tt.want)
+		}
+	}
+}
+
+// SupportsBinary is the documented gate, but a missed check must not put an
+// undecodable frame on the wire.
+func TestWSTransportSendBinaryRefusedAfterOptOut(t *testing.T) {
+	server, _ := newWSPair(t)
+	tr := newWSTransport(server, ServerOptions{}, false)
+
+	if tr.SupportsBinary() {
+		t.Fatalf("SupportsBinary = true after opting out")
+	}
+	if err := tr.SendBinary([]byte("frame")); err != errBinaryUnsupported {
+		t.Fatalf("SendBinary error = %v, want %v", err, errBinaryUnsupported)
+	}
+	if err := tr.SendBinaryCtx(context.Background(), []byte("frame")); err != errBinaryUnsupported {
+		t.Fatalf("SendBinaryCtx error = %v, want %v", err, errBinaryUnsupported)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -100,6 +100,15 @@
 // pending with no server-side trace. See docs/binary-frames.md for the frame
 // format and a reference decoder.
 //
+// Such a client can instead decline binary frames for the lifetime of the
+// connection with a "binary=0" query parameter on the upgrade URL, which
+// routes Blob results to the JSON $blob envelope described above. Accepted
+// values are 1/true/yes/on and 0/false/no/off; an unrecognized value fails
+// the upgrade with 400 rather than silently defaulting. The config frame the
+// server sends immediately after the upgrade reports the negotiated mode as
+// "binaryFrames" (always false on SSE and stream), so a client can verify it
+// before making its first call.
+//
 // # Input Transformation
 //
 // Request struct fields can be normalized before handler dispatch using

--- a/docs/binary-frames.md
+++ b/docs/binary-frames.md
@@ -7,6 +7,9 @@ probes, bindings for other languages, quick tooling — can decode them.
 If you are using the generated TypeScript client, you do not need any of this;
 it decodes these frames already.
 
+If you would rather not decode binary at all, you can decline it per
+connection — see [Opting out](#opting-out-of-binary-frames).
+
 ## When aprot sends a binary frame
 
 Every aprot message is a **text** frame carrying JSON, with exactly one
@@ -113,18 +116,59 @@ refreshes silently never arrive and the client shows stale data forever.
 If a single RPC hangs while every other call on the same connection works,
 check whether that method returns a `Blob`.
 
-Two defenses:
+Three defenses:
 
 - Handle binary frames, per the decoder above.
+- Or decline them with `?binary=0`, and check the `config` frame to confirm.
 - Reject unknown frames instead of ignoring them. Since the header always
   carries an `id`, a client that cannot make sense of a frame can still fail
   the corresponding pending request with a clear error rather than leaving the
   caller to hang.
 
+## Opting out of binary frames
+
+A WebSocket client can decline binary frames for the lifetime of a connection
+by passing `binary=0` on the upgrade URL:
+
+```js
+const ws = new WebSocket('wss://example.com/ws?binary=0');
+```
+
+`Blob` results then arrive as ordinary text frames carrying the JSON `$blob`
+envelope below, exactly as they do on SSE and byte-stream. Nothing else about
+the connection changes. Accepted values are `1`/`true`/`yes`/`on` and
+`0`/`false`/`no`/`off`, case-insensitive; omitting the parameter means binary
+frames. **An unrecognized value fails the upgrade with `400 Bad Request`** —
+a typo that quietly re-enabled binary frames would reinstate the silent hang
+this parameter exists to prevent.
+
+The cost is base64: the payload inflates by about a third and both ends pay to
+encode and decode it. If you are moving images or files of any size, implement
+the decoder above instead.
+
+### Confirming what you negotiated
+
+The `config` frame the server sends immediately after the upgrade — before any
+request can be made — reports the mode in effect:
+
+```json
+{ "type": "config", "binaryFrames": false }
+```
+
+Read it rather than assuming. `binaryFrames` is always present on a server that
+supports negotiation, so a missing field means an older server, i.e. binary
+frames on WebSocket. On SSE and byte-stream it is always `false`.
+
+This is the one signal available before a `Blob` response can hang you: a
+client that cannot decode binary frames should check `binaryFrames` at connect
+time and fail loudly if it is `true`. aprot cannot detect a dropped frame, so
+there is no server-side equivalent.
+
 ## JSON fallback
 
-Transports without a native binary channel (SSE, byte-stream) deliver the same
-value as an ordinary text `response` frame whose result is a one-key envelope:
+Transports without a native binary channel (SSE, byte-stream) — and WebSocket
+connections that passed `binary=0` — deliver the same value as an ordinary
+text `response` frame whose result is a one-key envelope:
 
 ```json
 {

--- a/protocol.go
+++ b/protocol.go
@@ -152,4 +152,11 @@ type ConfigMessage struct {
 	ReconnectInterval    int         `json:"reconnectInterval,omitempty"`
 	ReconnectMaxInterval int         `json:"reconnectMaxInterval,omitempty"`
 	ReconnectMaxAttempts int         `json:"reconnectMaxAttempts,omitempty"`
+	// BinaryFrames reports whether Blob results will arrive on this connection
+	// as binary frames rather than the JSON $blob envelope. Deliberately not
+	// omitempty: false is the informative value, and a client that must decode
+	// binary frames needs to learn that before the first Blob response rather
+	// than by hanging on one. An absent field means a server predating the
+	// negotiation, i.e. binary frames on WebSocket.
+	BinaryFrames bool `json:"binaryFrames"`
 }

--- a/server.go
+++ b/server.go
@@ -2,8 +2,10 @@ package aprot
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -547,6 +549,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Negotiate before upgrading so a malformed value is reported as a plain
+	// HTTP error the client can actually read.
+	binaryFrames, err := wsBinaryFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	ws, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
@@ -554,7 +564,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	connID := atomic.AddUint64(&s.nextConnID, 1)
 	ctx := r.Context()
-	wst := newWSTransport(ws, s.options)
+	wst := newWSTransport(ws, s.options, binaryFrames)
 	conn := newConn(wst, s, connID, connInfoFromRequest(r), ctx)
 	// Give the transport a back-reference so it can report send-buffer pressure
 	// and write timeouts to the observer. Set before the pumps start.
@@ -580,7 +590,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send config directly before pumps start
-	sendConfigWS(ws, s.options)
+	sendConfigWS(ws, s.options, binaryFrames)
 
 	// Register the connection, but don't block forever if the server has
 	// already shut down (run() has exited and will never read s.register).
@@ -783,13 +793,37 @@ func connectionRejectedMessage(err error) ErrorMessage {
 
 // configMessage builds the server-pushed configuration frame sent to every
 // new connection before message processing starts. Shared by all transports.
-func configMessage(opts ServerOptions) ConfigMessage {
+func configMessage(opts ServerOptions, binaryFrames bool) ConfigMessage {
 	return ConfigMessage{
 		Type:                 TypeConfig,
 		ReconnectInterval:    opts.ReconnectInterval,
 		ReconnectMaxInterval: opts.ReconnectMaxInterval,
 		ReconnectMaxAttempts: opts.ReconnectMaxAttempts,
+		BinaryFrames:         binaryFrames,
 	}
+}
+
+// wsBinaryFromRequest reports whether a WebSocket connection accepts binary
+// frames, honoring an optional "binary" query parameter on the upgrade URL.
+// Absent means yes, which keeps every existing client on the efficient path.
+//
+// A client that only decodes text frames passes binary=0 and gets Blob results
+// as the JSON $blob envelope instead — the same representation SSE and stream
+// already use. An unrecognized value is an error rather than a silent default:
+// the whole point of the parameter is avoiding a silent hang, and a typo that
+// quietly re-enabled binary frames would reinstate exactly that.
+func wsBinaryFromRequest(r *http.Request) (bool, error) {
+	q := r.URL.Query()
+	if !q.Has("binary") {
+		return true, nil
+	}
+	switch strings.ToLower(q.Get("binary")) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	}
+	return false, fmt.Errorf("aprot: invalid binary query parameter %q: want one of 1/true/yes/on or 0/false/no/off", q.Get("binary"))
 }
 
 func sendConnectionRejectedWS(ws *websocket.Conn, err error) {
@@ -799,7 +833,7 @@ func sendConnectionRejectedWS(ws *websocket.Conn, err error) {
 
 // sendConfigWS sends the server configuration directly to a WebSocket connection.
 // Called before the pumps are started.
-func sendConfigWS(ws *websocket.Conn, opts ServerOptions) {
-	data, _ := json.Marshal(configMessage(opts))
+func sendConfigWS(ws *websocket.Conn, opts ServerOptions, binaryFrames bool) {
+	data, _ := json.Marshal(configMessage(opts, binaryFrames))
 	_ = ws.WriteMessage(websocket.TextMessage, data)
 }

--- a/sse_handler.go
+++ b/sse_handler.go
@@ -105,7 +105,7 @@ func (h *sseHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	sseT.sendEvent("connected", connData)
 
 	// Send config
-	configData, _ := json.Marshal(configMessage(h.server.options))
+	configData, _ := json.Marshal(configMessage(h.server.options, false))
 	sseT.sendEvent("config", configData)
 
 	// Register connection

--- a/transport_stream.go
+++ b/transport_stream.go
@@ -233,7 +233,7 @@ func (s *Server) ServeStream(ctx context.Context, rw io.ReadWriteCloser, info Co
 	// peer that isn't reading yet — a raw stream has no write deadline to
 	// bound a direct write. The send buffer is empty here, so this never
 	// blocks; the write pump flushes it once the connection is accepted.
-	if cfgData, err := json.Marshal(configMessage(s.options)); err == nil {
+	if cfgData, err := json.Marshal(configMessage(s.options, false)); err == nil {
 		_ = st.Send(cfgData)
 	}
 

--- a/transport_ws.go
+++ b/transport_ws.go
@@ -19,6 +19,10 @@ type wsTransport struct {
 	send chan outboundFrame
 	done chan struct{} // closed once to signal shutdown; makes Send a no-op
 	opts ServerOptions // read limit, write timeout, and keepalive settings
+	// binary reports whether this connection accepts binary frames. Negotiated
+	// per-connection at upgrade time rather than fixed per-transport, so a
+	// client that only decodes text can take the JSON $blob fallback path.
+	binary bool
 	// conn is a back-reference used only to report send-buffer pressure and
 	// write timeouts to the server's observer. Set after construction, before
 	// the pumps start; nil in transports created without a connection.
@@ -39,12 +43,13 @@ func (t *wsTransport) observer() Observer {
 	return t.conn.server.observer
 }
 
-func newWSTransport(ws *websocket.Conn, opts ServerOptions) *wsTransport {
+func newWSTransport(ws *websocket.Conn, opts ServerOptions, binary bool) *wsTransport {
 	return &wsTransport{
-		ws:   ws,
-		send: make(chan outboundFrame, 256),
-		done: make(chan struct{}),
-		opts: opts,
+		ws:     ws,
+		send:   make(chan outboundFrame, 256),
+		done:   make(chan struct{}),
+		opts:   opts,
+		binary: binary,
 	}
 }
 
@@ -56,13 +61,21 @@ func (t *wsTransport) SendCtx(ctx context.Context, data []byte) error {
 	return t.sendFrame(ctx, outboundFrame{messageType: websocket.TextMessage, data: data})
 }
 
-func (t *wsTransport) SupportsBinary() bool { return true }
+func (t *wsTransport) SupportsBinary() bool { return t.binary }
 
 func (t *wsTransport) SendBinary(data []byte) error {
-	return t.sendFrame(context.Background(), outboundFrame{messageType: websocket.BinaryMessage, data: data})
+	return t.SendBinaryCtx(context.Background(), data)
 }
 
+// SendBinaryCtx refuses to write when the connection declined binary frames.
+// The interface already requires callers to check SupportsBinary first; a
+// missed check would otherwise put a frame on the wire that the peer has told
+// us it cannot decode, which is the silent-drop failure this negotiation
+// exists to prevent. Failing here surfaces it as an error instead.
 func (t *wsTransport) SendBinaryCtx(ctx context.Context, data []byte) error {
+	if !t.binary {
+		return errBinaryUnsupported
+	}
 	return t.sendFrame(ctx, outboundFrame{messageType: websocket.BinaryMessage, data: data})
 }
 

--- a/transport_ws_test.go
+++ b/transport_ws_test.go
@@ -51,7 +51,7 @@ func newWSPair(t *testing.T) (server, client *websocket.Conn) {
 func TestWSTransport_CloseDeliversQueuedFrames(t *testing.T) {
 	for i := 0; i < 30; i++ {
 		server, client := newWSPair(t)
-		tr := newWSTransport(server, ServerOptions{})
+		tr := newWSTransport(server, ServerOptions{}, true)
 
 		// Enqueue, then close, before the pump runs — the ordering every
 		// send-then-close caller (e.g. handleAuth) produces, with the pump


### PR DESCRIPTION
Part 2 of 2 for #279. **Stacked on #281** — based on `docs/binary-frame-format`, so review that first; this PR's own diff is the last commit. I'll retarget to `master` once #281 merges.

## Problem

Blob delivery was decided per-*transport*, not per-*connection*: `wsTransport.SupportsBinary()` was a hardcoded `return true`, so every `Blob` result over WebSocket became a binary frame with no way for a client to opt out. A text-only client drops it silently — the call never settles, and since the server considers the request complete there's no error and no server-side trace. aprot can't detect a dropped frame, so nothing can be salvaged once it's on the wire.

## Change

`SupportsBinary()` is now per-connection, negotiated at upgrade time from a `binary` query parameter, and a declining client is routed to the JSON `$blob` fallback SSE and stream already use. No new serialization, no new client-visible representation — it reuses a path that already existed and was already tested.

```js
const ws = new WebSocket('wss://example.com/ws?binary=0');
```

Omitting the parameter keeps current behavior, so generated TypeScript clients are unaffected and no templates changed (their config handling is hand-written, not derived from `ConfigMessage`).

## Three decisions worth review

**URL parameter, not a client `hello` frame or subprotocol.** The URL is what makes this race-free: the flag is known before the connection exists, so it can't arrive after the first request. It's also the only form a browser `WebSocket` can send, since that API can't set headers. Subprotocol negotiation would need `upgrader.Subprotocols` configured and correctly echoed for no gain.

**An unrecognized value fails the upgrade with `400`** instead of defaulting. A silent default is precisely what this parameter exists to prevent, and `?binary=fasle` quietly restoring binary frames would restore the hang with it. The check runs before `Upgrade`, so the error is a readable HTTP response.

**`ConfigMessage.BinaryFrames`**, deliberately without `omitempty` since `false` is the informative value. The config frame already goes out before any request can be made, which makes it the one point where a client that can't decode binary frames can fail loudly rather than hang. An absent field means a server predating the negotiation; it's always `false` on SSE and stream.

Also: `SendBinaryCtx` now returns `errBinaryUnsupported` when binary was declined. The `Transport` interface already requires callers to check `SupportsBinary` first, but a missed check would put an undecodable frame on the wire — the exact failure this removes.

## Test plan

`go test ./...`, `go vet ./...`, `gofmt -l`, plus `go build ./... && go test ./...` in the `e2e` module — all clean. New coverage in `blob_negotiation_test.go`:

- default (no param) still yields a binary frame, and config reports `binaryFrames: true`
- `?binary=0` yields a text frame carrying `$blob` with the right content type and payload, and config reports `false`
- `?binary=fasle`, `?binary=` and `?binary=2` are each rejected with `400` and no upgrade
- table test over the accepted value spellings
- `SendBinary`/`SendBinaryCtx` refuse to write after opt-out

Docs updated per the repo rules: `README.md`, `doc.go`, `APROT_AI.md`, `docs/binary-frames.md` (new "Opting out" and "Confirming what you negotiated" sections), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)