### PR TITLE
Cancel the reconnect backoff when a connection is started manually

### DIFF
--- a/APROT_AI.md
+++ b/APROT_AI.md
@@ -74,7 +74,9 @@ const client = new ApiClient(getWebSocketUrl());
 client.connect(); // REQUIRED once. `await` optional: requests issued while connecting are buffered and flushed on ready.
 ```
 
-React: create the client at module scope, call `client.connect()` there (or in a `useEffect`), then mount `<ApiClientProvider value={client}>`. `connect()` is a no-op when already connected/connecting; after the first successful call, auto-reconnect handles drops — never call it again for reconnection.
+React: create the client at module scope, call `client.connect()` there (or in a `useEffect`), then mount `<ApiClientProvider value={client}>`. After the first successful call, auto-reconnect handles drops, so no reconnect loop of your own is needed.
+
+`connect()` is cheap and idempotent — a no-op while connected/connecting, and an immediate attempt otherwise, **including while a reconnect backoff is pending** (the backoff is abandoned rather than waited out). Call it whenever the connection needs to be live (after signing in, on resume) rather than caching an "already connected" flag: such a flag skips the call exactly when the socket has since dropped, and nothing opens a new one — the symptom is a UI that waits with no `/ws` request in the network panel. `client.reconnectNow()` is the same thing without the connected/connecting no-op; reach for it only when a socket the runtime left half-open still reports `'connected'`. Neither drops subscriptions or rejects in-flight requests, unlike `disconnect()` + `connect()`.
 
 **StrictMode rule (#283):** create + `connect()` fire-and-forget + provide the client **synchronously**. Never gate rendering on the connect promise (`connect().then(() => setClient(c))` / `setConnected(true)`) — StrictMode's double mount can leave a disconnected client in the tree and the UI waiting forever. Requests buffer while connecting, so render immediately and show a slim banner driven by `useConnection()` instead of unmounting the app.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,9 +72,26 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
   expired, sign in again" distinctly from "server unreachable" while retries
   run. React gains `useConnectionRejection()` and `useConnectionError()`, and
   `useConnection()` now also returns `error` and `rejection`. (#283)
+- `client.reconnectNow()` on the generated TypeScript client: abandon a pending
+  reconnect backoff and attempt a connection immediately, keeping subscriptions
+  and in-flight requests. `connect()` already does this; `reconnectNow()` adds
+  only the case `connect()` reads as "nothing to do" — a socket the runtime
+  left half-open still reports `'connected'` until its close event lands. Until
+  now the only way to cut a backoff short was `disconnect()` + `connect()`,
+  which drops every subscription and rejects in-flight requests. (#287)
 
 ### Fixed
 
+- `connect()` called during a reconnect backoff left the pending timer armed.
+  It connected immediately, as intended, but up to `reconnectMaxInterval` later
+  (30 s by default) the timer fired and replaced the live socket. The transport
+  detaches the replaced socket's handlers, so its close was never reported and
+  any request in flight at that moment never settled — it neither resolved nor
+  rejected. A manual `connect()` now cancels the backoff, and connection
+  attempts are serialized: at most one runs at a time, and a live socket is
+  never replaced. Requests bound to a socket that *is* replaced (the page-wake
+  path, where the runtime left it half-open) now reject with a
+  `ConnectionError` instead of hanging. (#287)
 - `useConnectionState` (and `useConnection`, which wraps it) could report a
   stale state forever. It seeded `useState` from the client at first render and
   only subscribed in an effect, so a connection that completed in between was
@@ -88,6 +105,15 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ### Documentation
 
+- The `connect()` docs said it is called "once after constructing the client"
+  and "never needs to be called again". True for keeping a connection alive,
+  misleading for "make sure we are connected now" — it led a consumer app to
+  wrap it in a module-level `if (connected) return` cache, which no-ops exactly
+  when the socket has dropped and the client is in a backoff. The symptom was a
+  ~30 s sign-in with no `/ws` request in the network panel at all. `README.md`,
+  `doc.go`, `APROT_AI.md`, `docs/auth.md` and the generated client's own doc
+  comments now state that `connect()` is cheap and idempotent and should be
+  called whenever the connection needs to be live. (#287)
 - `docs/auth.md` is the recipe for authenticating the generated TypeScript
   client with short-lived JWTs (Clerk, Auth0, Firebase). Two consumer apps
   independently hit the same three traps and one shipped the broken version:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Open the component in two browser tabs, click "Add job" in one, and the other up
 - **Cross-origin control** — WebSocket origin checking (`SetCheckOrigin`) plus a closed-by-default `CORS` middleware for the SSE and REST HTTP transports
 - **First-message auth** — authenticate with a token sent over the connection (`OnAuth`) instead of in the URL, with a pending-auth timeout, mid-session token refresh, and an `AllowAnonymous` mode for apps mixing public and protected APIs; works over WebSocket and SSE
 - **Observability** — opt-in `Observer` hooks (connections, request latency/errors, subscriptions, refresh fan-out, send-buffer pressure) plus a pull-based `Stats()` snapshot, with zero hot-path cost when unset
-- **Automatic reconnection** — page visibility + network-aware, with exponential backoff; `getConnectParams` (or a dynamic URL function) mints a fresh token on every attempt, and `reconnectOnRejected` opts into retrying a rejected connection
+- **Automatic reconnection** — page visibility + network-aware, with exponential backoff; `getConnectParams` (or a dynamic URL function) mints a fresh token on every attempt, `reconnectOnRejected` opts into retrying a rejected connection, and `connect()` / `reconnectNow()` cut a pending backoff short
 - **Struct validation** — opt-in server-side validation via `go-playground/validator` struct tags, automatically enforced before handler dispatch
 - **Input transformation** — declarative `transform` struct tags (`trim`, `trimleft`, `trimright`, `uppercase`, `lowercase`, `removeempty`) normalize fields before validation runs
 - **Zod schema generation** — opt-in generation of Zod validation schemas alongside TypeScript interfaces
@@ -328,6 +328,8 @@ function UsersList() {
 ```
 
 > **⚠️ The client never connects automatically.** `new ApiClient(...)` only configures it, and `<ApiClientProvider>` is a plain context provider — neither opens the connection. If you skip `client.connect()`, nothing works: every hook and request fails with a `ConnectionError` (`'Not connected'`). Calling `client.connect()` without `await` (e.g. at module scope, as above) is fine — requests issued while connecting are buffered and flushed once the connection is ready. After the first successful `connect()`, auto-reconnect handles drops.
+>
+> `connect()` is cheap and idempotent: a no-op while connected or connecting, and an immediate attempt otherwise — including while a reconnect backoff is pending, in which case the backoff is abandoned rather than waited out. So call it whenever the connection needs to be live (after signing in, on resume) instead of caching an "already connected" flag; such a flag skips the call exactly when the socket has since dropped, and nothing opens a new one. `client.reconnectNow()` does the same without the connected/connecting no-op, for the rarer case where a socket the runtime left half-open still reports `'connected'`. Neither clears subscriptions or rejects in-flight requests the way `disconnect()` + `connect()` does.
 
 > aprot does **not** generate per-handler mutation hooks. Either compose mutations through a query hook's `mutate(action)` helper (above), or call the generated function directly with `useApiClient()` (see [TypeScript Mutation Patterns](#typescript-mutation-patterns)). If you're upgrading from a version that generated `useXxxMutation()`, see [`MIGRATION_MUTATION_HOOKS.md`](MIGRATION_MUTATION_HOOKS.md) for an agent-runnable rewrite prompt.
 

--- a/doc.go
+++ b/doc.go
@@ -671,6 +671,16 @@
 //	const client = new ApiClient(getWebSocketUrl());
 //	await client.connect(); // REQUIRED — never called automatically
 //
+// connect() is cheap and idempotent: a no-op while connected or connecting,
+// and an immediate attempt otherwise — including while a reconnect backoff is
+// pending, in which case the backoff is abandoned rather than waited out. Call
+// it whenever the connection needs to be live (after signing in, on resume)
+// rather than caching an "already connected" flag, which skips the call
+// exactly when the socket has since dropped. client.reconnectNow() does the
+// same without the connected/connecting no-op, for a socket the runtime left
+// half-open that still reports 'connected'. Neither clears subscriptions or
+// rejects in-flight requests the way disconnect() + connect() does.
+//
 // The generator creates split files: client.ts (base client), one file per
 // handler group, and optional shared type files for types used across groups.
 // A shared file is named after its Go package (e.g. api.ts); if that name

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -106,7 +106,7 @@ function ConnectionBanner() {
 
 > **The anti-pattern:** `client.connect().then(() => setClient(client))` — or any `setConnected(true)` that gates the tree. Under StrictMode's double mount, the effect runs twice and a disconnected client can win the race, leaving the UI waiting on a zombie forever. It is also unnecessary: requests issued while connecting are **buffered** and flushed once the connection is ready, so nothing is lost by rendering immediately.
 
-Prefer a slim banner over unmounting the app while disconnected: the UI stays interactive, in-flight work is preserved, and reconnects become invisible. `connect()` is idempotent and auto-reconnect handles drops, so it never needs calling again.
+Prefer a slim banner over unmounting the app while disconnected: the UI stays interactive, in-flight work is preserved, and reconnects become invisible. `connect()` is idempotent and auto-reconnect handles drops, so it does not need calling again — though calling it again is safe and is the right move whenever the connection needs to be live *now* (right after signing in, say). What is not safe is wrapping it in a module-level `if (connected) return` cache: that skips the call exactly when the socket has dropped and the client is sitting in a backoff, so nothing opens a socket at all and the UI waits with no `/ws` request in the network panel. Call `connect()` itself — it cancels the pending backoff and attempts immediately.
 
 Deriving the client from React state (a user id, a workspace) is fine — build it in a `useMemo`, call `connect()` in the same effect that creates it, and `disconnect()` in the cleanup. The rule is only that you never *wait* on the promise before providing the client.
 
@@ -177,6 +177,6 @@ The recipe leans on these documented behaviors:
 - A URL **function** and `getConnectParams` are both resolved on **every** connection attempt, including auto-reconnects, rejection retries, and page-wake reconnects.
 - `getAuthToken` is likewise re-invoked on every reconnect, and buffered work flushes only after `auth_ok`.
 - Requests issued while `connecting` / `reconnecting` are buffered and flushed once ready; requests issued while fully disconnected reject with a `ConnectionError`.
-- `connect()` is idempotent — a no-op while connected or connecting — and never needs to be called again after the first success.
+- `connect()` is idempotent — a no-op while connected or connecting — and does not need to be called again after the first success. Calling it during a reconnect backoff cancels the backoff and attempts immediately, so it is also the way to say "connect now" after a token refresh. `reconnectNow()` is the same without the connected/connecting no-op.
 - A rejection stops auto-reconnect unless `reconnectOnRejected` is set; `disconnect()` always cancels a pending retry.
 - `getLastRejection()` is cleared only by the next successful connect.

--- a/e2e/tests/reconnect.test.ts
+++ b/e2e/tests/reconnect.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect } from 'vitest';
+import { wsUrl } from './helpers';
+import { ApiClient, type ConnectionState } from '../api/client';
+import { listUsers, processBatch } from '../api/public-handlers';
+
+// A connection attempt started while a reconnect backoff is pending must
+// cancel that backoff. Left armed, the timer fires after the connection is
+// already up and replaces the live socket — and because the transport detaches
+// the replaced socket's handlers, its close is never reported, so anything in
+// flight at that moment never settles (issue #287).
+
+const DEAD_URL = 'ws://127.0.0.1:1/ws'; // connection refused, immediately
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+// enterBackoff builds a client whose first attempt fails, leaving it in
+// 'reconnecting' with a timer armed, then points it at the real server.
+// Returns the client plus the per-attempt URL-resolution counter, which is the
+// observable "did we open another connection" signal.
+async function enterBackoff(reconnectInterval: number): Promise<{
+    client: ApiClient;
+    attempts: () => number;
+}> {
+    let url = DEAD_URL;
+    let attempts = 0;
+    const client = new ApiClient(
+        () => {
+            attempts++;
+            return url;
+        },
+        {
+            reconnect: true,
+            reconnectInterval,
+            reconnectMaxInterval: reconnectInterval,
+        },
+    );
+
+    await client.connect();
+    expect(client.getState()).toBe('reconnecting');
+    expect(attempts).toBe(1);
+
+    url = wsUrl();
+    return { client, attempts: () => attempts };
+}
+
+describe('reconnect backoff', () => {
+    test('connect() during backoff connects now and disarms the pending timer', async () => {
+        const interval = 300;
+        const { client, attempts } = await enterBackoff(interval);
+
+        await client.connect();
+        expect(client.getState()).toBe('connected');
+        expect(attempts()).toBe(2);
+
+        // Watch for the stale timer: pre-fix it fires here, taking the client
+        // through 'connecting' again as it replaces the working socket.
+        const states: ConnectionState[] = [];
+        const off = client.onStateChange((s) => states.push(s));
+        await sleep(interval * 3);
+        off();
+
+        expect(states).toEqual([]);
+        expect(attempts()).toBe(2);
+        expect(client.getState()).toBe('connected');
+
+        // The socket that survived is the one still in use.
+        await expect(listUsers(client)).resolves.toMatchObject({ users: expect.any(Array) });
+
+        client.disconnect();
+    });
+
+    test('a request in flight when the cancelled timer would have fired still settles', async () => {
+        const interval = 300;
+        const { client } = await enterBackoff(interval);
+        await client.connect();
+
+        // A ~600ms request issued at ~interval/2 is still in flight when the
+        // stale timer fires. Pre-fix that timer replaced the socket underneath
+        // it, and since the replaced socket's close is never reported the
+        // request neither resolved nor rejected — it just hung.
+        await sleep(interval / 2);
+        const result = await Promise.race([
+            processBatch(client, ['a', 'b', 'c', 'd', 'e', 'f'], 100).then(() => 'settled'),
+            sleep(5000).then(() => 'hung'),
+        ]);
+        expect(result).toBe('settled');
+
+        client.disconnect();
+    });
+
+    test('reconnectNow() abandons a long backoff instead of waiting it out', async () => {
+        // Long enough that only cancelling the timer — not waiting for it —
+        // can get this test connected.
+        const { client, attempts } = await enterBackoff(60_000);
+
+        await client.reconnectNow();
+        expect(client.getState()).toBe('connected');
+        expect(attempts()).toBe(2);
+
+        client.disconnect();
+    });
+
+    test('reconnectNow() is a no-op on a live connection', async () => {
+        let attempts = 0;
+        const client = new ApiClient(() => {
+            attempts++;
+            return wsUrl();
+        });
+        await client.connect();
+        expect(attempts).toBe(1);
+
+        await client.reconnectNow();
+        expect(attempts).toBe(1);
+        expect(client.getState()).toBe('connected');
+        await expect(listUsers(client)).resolves.toMatchObject({ users: expect.any(Array) });
+
+        client.disconnect();
+    });
+
+    test('concurrent connection attempts share one socket', async () => {
+        const { client, attempts } = await enterBackoff(60_000);
+
+        // Both calls are made before either resolves, so the second must join
+        // the attempt in flight rather than opening a competing socket.
+        await Promise.all([client.reconnectNow(), client.reconnectNow()]);
+        expect(attempts()).toBe(2);
+        expect(client.getState()).toBe('connected');
+
+        client.disconnect();
+    });
+});

--- a/example/react/client/src/api/client.ts
+++ b/example/react/client/src/api/client.ts
@@ -619,7 +619,13 @@ export type ApiClientUrl = string | (() => string | Promise<string>);
  * requests issued while connecting are buffered and flushed once the
  * connection is ready. Requests issued while fully disconnected reject with
  * a ConnectionError. After the first successful connect(), auto-reconnect
- * (when enabled) handles drops — connect() never needs to be called again.
+ * (when enabled) handles drops, so connect() does not have to be called
+ * again — but calling it again is cheap and idempotent: a no-op while
+ * connected or connecting, and an immediate attempt otherwise, including
+ * while a reconnect backoff is pending. Call it whenever the connection
+ * needs to be live (after signing in, on resume) rather than caching an
+ * "already connected" flag — such a flag skips the call exactly when the
+ * socket has since dropped, and nothing opens a new one.
  */
 export class ApiClient {
     private transport: ClientTransport;
@@ -659,6 +665,9 @@ export class ApiClient {
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // connectInFlight is the attempt doConnect() is currently running, so a
+    // second caller joins it instead of opening a competing socket.
+    private connectInFlight: Promise<void> | null = null;
     private manualDisconnect = false;
     // authWaiter resolves/rejects the in-flight auth handshake (initial connect
     // or refreshAuth) when the server's auth_ok / auth_error arrives.
@@ -712,23 +721,79 @@ export class ApiClient {
     /**
      * Opens the connection to the server. This is a required manual step:
      * it is never called automatically — not by the constructor, not by
-     * <ApiClientProvider>, not by the generated hooks/functions. Call it
-     * once after constructing the client. No-op when already connected or
-     * connecting; auto-reconnect takes over after the first successful call.
+     * <ApiClientProvider>, not by the generated hooks/functions.
+     *
+     * It is cheap and idempotent, so call it whenever the connection needs to
+     * be live (after signing in, on resume) rather than remembering that it
+     * was called: it is a no-op while connected or connecting, and otherwise
+     * attempts a connection immediately — including while a reconnect backoff
+     * is pending, in which case the backoff is abandoned rather than waited
+     * out. Auto-reconnect takes over after the first successful call.
      */
     connect(): Promise<void> {
         if (this.state === 'connected' || this.state === 'connecting') {
             return Promise.resolve();
         }
+        return this.startConnect();
+    }
+
+    /**
+     * Abandons any pending reconnect backoff and attempts a connection now,
+     * keeping subscriptions and in-flight requests — unlike disconnect() +
+     * connect(), which clears both.
+     *
+     * connect() already does this, so reach for reconnectNow() only when the
+     * client may be in a state connect() reads as "nothing to do": a socket
+     * the runtime left half-open still reports 'connected' until its close
+     * event lands. Resolves when the attempt finishes, connected or not, and
+     * joins an attempt already in flight rather than starting a second one.
+     */
+    reconnectNow(): Promise<void> {
+        return this.startConnect();
+    }
+
+    // startConnect is the manual-connect path behind connect() and
+    // reconnectNow(): a fresh start followed by an immediate attempt.
+    private startConnect(): Promise<void> {
         this.manualDisconnect = false;
         // A manual connect is a fresh start: un-park a client that exhausted
-        // its rejection retries.
+        // its rejection retries, and restart the backoff schedule.
         this.rejectionRetryAttempts = 0;
+        this.reconnectAttempts = 0;
+        // Drop a pending backoff. The caller wants a connection now, and a
+        // timer left armed would fire a second doConnect() on top of the
+        // connection this call is about to establish.
+        this.clearReconnectTimer();
         this.setupPageListeners();
         return this.doConnect();
     }
 
-    private async doConnect(): Promise<void> {
+    // doConnect serializes connection attempts: at most one runs at a time,
+    // and a live socket is never replaced. Both matter because the transports
+    // detach the previous socket's handlers before opening a new one, so the
+    // replaced socket's close is never reported and anything waiting on it
+    // would hang forever.
+    private doConnect(): Promise<void> {
+        if (this.state === 'connected' && this.transport.isConnected()) {
+            return Promise.resolve();
+        }
+        if (this.connectInFlight) return this.connectInFlight;
+        const attempt = this.runConnect().finally(() => {
+            if (this.connectInFlight === attempt) this.connectInFlight = null;
+        });
+        this.connectInFlight = attempt;
+        return attempt;
+    }
+
+    private async runConnect(): Promise<void> {
+        // Reached with state 'connected' only when the transport disagrees:
+        // the socket is half-open or already torn down (mobile wake). It is
+        // about to be replaced, and its handlers are detached in the process,
+        // so handleClose() will never run for it — settle whatever is bound to
+        // it here, or those promises never settle at all.
+        if (this.state === 'connected') {
+            this.abandonInFlight();
+        }
         const attemptId = ++this.connectAttemptId;
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
@@ -966,6 +1031,37 @@ export class ApiClient {
         }
     }
 
+    // abandonInFlight settles everything bound to a socket that is being
+    // replaced rather than closed. Subscription entries are kept: they are
+    // re-established on the new connection, exactly as after handleClose().
+    private abandonInFlight(): void {
+        if (this.pending.size === 0 && this.streams.size === 0) return;
+        const info: TransportCloseInfo = { wasClean: false };
+        const error = this.buildConnectionError(this.classifyClose(info), info);
+        const subIds = new Set(this.subscriptions.keys());
+        for (const [id, p] of this.pending) {
+            if (!subIds.has(id)) {
+                p.onSettle?.();
+                p.reject(error);
+            }
+            this.pending.delete(id);
+        }
+        const streams = Array.from(this.streams.values());
+        this.streams.clear();
+        for (const s of streams) {
+            s.end(error);
+        }
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+    }
+
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+    }
+
     private scheduleReconnect(): void {
         if (this.reconnectTimer) return;
 
@@ -1008,10 +1104,7 @@ export class ApiClient {
         if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.subscriptions.clear();
 
         // Reject in-flight requests/streams synchronously: the server may
@@ -1152,10 +1245,7 @@ export class ApiClient {
         if (this.state === 'connected' && this.transport.isConnected()) return;
         if (this.state === 'connecting') return;
 
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.reconnectAttempts = 0;
         this.doConnect().catch(() => {});
     }

--- a/example/vanilla/client/static/api/client.ts
+++ b/example/vanilla/client/static/api/client.ts
@@ -612,7 +612,13 @@ export type ApiClientUrl = string | (() => string | Promise<string>);
  * requests issued while connecting are buffered and flushed once the
  * connection is ready. Requests issued while fully disconnected reject with
  * a ConnectionError. After the first successful connect(), auto-reconnect
- * (when enabled) handles drops — connect() never needs to be called again.
+ * (when enabled) handles drops, so connect() does not have to be called
+ * again — but calling it again is cheap and idempotent: a no-op while
+ * connected or connecting, and an immediate attempt otherwise, including
+ * while a reconnect backoff is pending. Call it whenever the connection
+ * needs to be live (after signing in, on resume) rather than caching an
+ * "already connected" flag — such a flag skips the call exactly when the
+ * socket has since dropped, and nothing opens a new one.
  */
 export class ApiClient {
     private transport: ClientTransport;
@@ -652,6 +658,9 @@ export class ApiClient {
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // connectInFlight is the attempt doConnect() is currently running, so a
+    // second caller joins it instead of opening a competing socket.
+    private connectInFlight: Promise<void> | null = null;
     private manualDisconnect = false;
     // authWaiter resolves/rejects the in-flight auth handshake (initial connect
     // or refreshAuth) when the server's auth_ok / auth_error arrives.
@@ -705,23 +714,79 @@ export class ApiClient {
     /**
      * Opens the connection to the server. This is a required manual step:
      * it is never called automatically — not by the constructor, not by
-     * <ApiClientProvider>, not by the generated hooks/functions. Call it
-     * once after constructing the client. No-op when already connected or
-     * connecting; auto-reconnect takes over after the first successful call.
+     * <ApiClientProvider>, not by the generated hooks/functions.
+     *
+     * It is cheap and idempotent, so call it whenever the connection needs to
+     * be live (after signing in, on resume) rather than remembering that it
+     * was called: it is a no-op while connected or connecting, and otherwise
+     * attempts a connection immediately — including while a reconnect backoff
+     * is pending, in which case the backoff is abandoned rather than waited
+     * out. Auto-reconnect takes over after the first successful call.
      */
     connect(): Promise<void> {
         if (this.state === 'connected' || this.state === 'connecting') {
             return Promise.resolve();
         }
+        return this.startConnect();
+    }
+
+    /**
+     * Abandons any pending reconnect backoff and attempts a connection now,
+     * keeping subscriptions and in-flight requests — unlike disconnect() +
+     * connect(), which clears both.
+     *
+     * connect() already does this, so reach for reconnectNow() only when the
+     * client may be in a state connect() reads as "nothing to do": a socket
+     * the runtime left half-open still reports 'connected' until its close
+     * event lands. Resolves when the attempt finishes, connected or not, and
+     * joins an attempt already in flight rather than starting a second one.
+     */
+    reconnectNow(): Promise<void> {
+        return this.startConnect();
+    }
+
+    // startConnect is the manual-connect path behind connect() and
+    // reconnectNow(): a fresh start followed by an immediate attempt.
+    private startConnect(): Promise<void> {
         this.manualDisconnect = false;
         // A manual connect is a fresh start: un-park a client that exhausted
-        // its rejection retries.
+        // its rejection retries, and restart the backoff schedule.
         this.rejectionRetryAttempts = 0;
+        this.reconnectAttempts = 0;
+        // Drop a pending backoff. The caller wants a connection now, and a
+        // timer left armed would fire a second doConnect() on top of the
+        // connection this call is about to establish.
+        this.clearReconnectTimer();
         this.setupPageListeners();
         return this.doConnect();
     }
 
-    private async doConnect(): Promise<void> {
+    // doConnect serializes connection attempts: at most one runs at a time,
+    // and a live socket is never replaced. Both matter because the transports
+    // detach the previous socket's handlers before opening a new one, so the
+    // replaced socket's close is never reported and anything waiting on it
+    // would hang forever.
+    private doConnect(): Promise<void> {
+        if (this.state === 'connected' && this.transport.isConnected()) {
+            return Promise.resolve();
+        }
+        if (this.connectInFlight) return this.connectInFlight;
+        const attempt = this.runConnect().finally(() => {
+            if (this.connectInFlight === attempt) this.connectInFlight = null;
+        });
+        this.connectInFlight = attempt;
+        return attempt;
+    }
+
+    private async runConnect(): Promise<void> {
+        // Reached with state 'connected' only when the transport disagrees:
+        // the socket is half-open or already torn down (mobile wake). It is
+        // about to be replaced, and its handlers are detached in the process,
+        // so handleClose() will never run for it — settle whatever is bound to
+        // it here, or those promises never settle at all.
+        if (this.state === 'connected') {
+            this.abandonInFlight();
+        }
         const attemptId = ++this.connectAttemptId;
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
@@ -959,6 +1024,37 @@ export class ApiClient {
         }
     }
 
+    // abandonInFlight settles everything bound to a socket that is being
+    // replaced rather than closed. Subscription entries are kept: they are
+    // re-established on the new connection, exactly as after handleClose().
+    private abandonInFlight(): void {
+        if (this.pending.size === 0 && this.streams.size === 0) return;
+        const info: TransportCloseInfo = { wasClean: false };
+        const error = this.buildConnectionError(this.classifyClose(info), info);
+        const subIds = new Set(this.subscriptions.keys());
+        for (const [id, p] of this.pending) {
+            if (!subIds.has(id)) {
+                p.onSettle?.();
+                p.reject(error);
+            }
+            this.pending.delete(id);
+        }
+        const streams = Array.from(this.streams.values());
+        this.streams.clear();
+        for (const s of streams) {
+            s.end(error);
+        }
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+    }
+
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+    }
+
     private scheduleReconnect(): void {
         if (this.reconnectTimer) return;
 
@@ -1001,10 +1097,7 @@ export class ApiClient {
         if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.subscriptions.clear();
 
         // Reject in-flight requests/streams synchronously: the server may
@@ -1145,10 +1238,7 @@ export class ApiClient {
         if (this.state === 'connected' && this.transport.isConnected()) return;
         if (this.state === 'connecting') return;
 
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.reconnectAttempts = 0;
         this.doConnect().catch(() => {});
     }

--- a/templates/_client-common.ts.tmpl
+++ b/templates/_client-common.ts.tmpl
@@ -618,7 +618,13 @@ export type ApiClientUrl = string | (() => string | Promise<string>);
  * requests issued while connecting are buffered and flushed once the
  * connection is ready. Requests issued while fully disconnected reject with
  * a ConnectionError. After the first successful connect(), auto-reconnect
- * (when enabled) handles drops — connect() never needs to be called again.
+ * (when enabled) handles drops, so connect() does not have to be called
+ * again — but calling it again is cheap and idempotent: a no-op while
+ * connected or connecting, and an immediate attempt otherwise, including
+ * while a reconnect backoff is pending. Call it whenever the connection
+ * needs to be live (after signing in, on resume) rather than caching an
+ * "already connected" flag — such a flag skips the call exactly when the
+ * socket has since dropped, and nothing opens a new one.
  */
 export class ApiClient {
     private transport: ClientTransport;
@@ -658,6 +664,9 @@ export class ApiClient {
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // connectInFlight is the attempt doConnect() is currently running, so a
+    // second caller joins it instead of opening a competing socket.
+    private connectInFlight: Promise<void> | null = null;
     private manualDisconnect = false;
     // authWaiter resolves/rejects the in-flight auth handshake (initial connect
     // or refreshAuth) when the server's auth_ok / auth_error arrives.
@@ -711,23 +720,79 @@ export class ApiClient {
     /**
      * Opens the connection to the server. This is a required manual step:
      * it is never called automatically — not by the constructor, not by
-     * <ApiClientProvider>, not by the generated hooks/functions. Call it
-     * once after constructing the client. No-op when already connected or
-     * connecting; auto-reconnect takes over after the first successful call.
+     * <ApiClientProvider>, not by the generated hooks/functions.
+     *
+     * It is cheap and idempotent, so call it whenever the connection needs to
+     * be live (after signing in, on resume) rather than remembering that it
+     * was called: it is a no-op while connected or connecting, and otherwise
+     * attempts a connection immediately — including while a reconnect backoff
+     * is pending, in which case the backoff is abandoned rather than waited
+     * out. Auto-reconnect takes over after the first successful call.
      */
     connect(): Promise<void> {
         if (this.state === 'connected' || this.state === 'connecting') {
             return Promise.resolve();
         }
+        return this.startConnect();
+    }
+
+    /**
+     * Abandons any pending reconnect backoff and attempts a connection now,
+     * keeping subscriptions and in-flight requests — unlike disconnect() +
+     * connect(), which clears both.
+     *
+     * connect() already does this, so reach for reconnectNow() only when the
+     * client may be in a state connect() reads as "nothing to do": a socket
+     * the runtime left half-open still reports 'connected' until its close
+     * event lands. Resolves when the attempt finishes, connected or not, and
+     * joins an attempt already in flight rather than starting a second one.
+     */
+    reconnectNow(): Promise<void> {
+        return this.startConnect();
+    }
+
+    // startConnect is the manual-connect path behind connect() and
+    // reconnectNow(): a fresh start followed by an immediate attempt.
+    private startConnect(): Promise<void> {
         this.manualDisconnect = false;
         // A manual connect is a fresh start: un-park a client that exhausted
-        // its rejection retries.
+        // its rejection retries, and restart the backoff schedule.
         this.rejectionRetryAttempts = 0;
+        this.reconnectAttempts = 0;
+        // Drop a pending backoff. The caller wants a connection now, and a
+        // timer left armed would fire a second doConnect() on top of the
+        // connection this call is about to establish.
+        this.clearReconnectTimer();
         this.setupPageListeners();
         return this.doConnect();
     }
 
-    private async doConnect(): Promise<void> {
+    // doConnect serializes connection attempts: at most one runs at a time,
+    // and a live socket is never replaced. Both matter because the transports
+    // detach the previous socket's handlers before opening a new one, so the
+    // replaced socket's close is never reported and anything waiting on it
+    // would hang forever.
+    private doConnect(): Promise<void> {
+        if (this.state === 'connected' && this.transport.isConnected()) {
+            return Promise.resolve();
+        }
+        if (this.connectInFlight) return this.connectInFlight;
+        const attempt = this.runConnect().finally(() => {
+            if (this.connectInFlight === attempt) this.connectInFlight = null;
+        });
+        this.connectInFlight = attempt;
+        return attempt;
+    }
+
+    private async runConnect(): Promise<void> {
+        // Reached with state 'connected' only when the transport disagrees:
+        // the socket is half-open or already torn down (mobile wake). It is
+        // about to be replaced, and its handlers are detached in the process,
+        // so handleClose() will never run for it — settle whatever is bound to
+        // it here, or those promises never settle at all.
+        if (this.state === 'connected') {
+            this.abandonInFlight();
+        }
         const attemptId = ++this.connectAttemptId;
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
@@ -965,6 +1030,37 @@ export class ApiClient {
         }
     }
 
+    // abandonInFlight settles everything bound to a socket that is being
+    // replaced rather than closed. Subscription entries are kept: they are
+    // re-established on the new connection, exactly as after handleClose().
+    private abandonInFlight(): void {
+        if (this.pending.size === 0 && this.streams.size === 0) return;
+        const info: TransportCloseInfo = { wasClean: false };
+        const error = this.buildConnectionError(this.classifyClose(info), info);
+        const subIds = new Set(this.subscriptions.keys());
+        for (const [id, p] of this.pending) {
+            if (!subIds.has(id)) {
+                p.onSettle?.();
+                p.reject(error);
+            }
+            this.pending.delete(id);
+        }
+        const streams = Array.from(this.streams.values());
+        this.streams.clear();
+        for (const s of streams) {
+            s.end(error);
+        }
+        this.notifyLoadingChange();
+        this.notifyConnectionError(error);
+    }
+
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+    }
+
     private scheduleReconnect(): void {
         if (this.reconnectTimer) return;
 
@@ -1007,10 +1103,7 @@ export class ApiClient {
         if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.subscriptions.clear();
 
         // Reject in-flight requests/streams synchronously: the server may
@@ -1151,10 +1244,7 @@ export class ApiClient {
         if (this.state === 'connected' && this.transport.isConnected()) return;
         if (this.state === 'connecting') return;
 
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.reconnectAttempts = 0;
         this.doConnect().catch(() => {});
     }

--- a/templates/client-react.ts.tmpl
+++ b/templates/client-react.ts.tmpl
@@ -155,7 +155,12 @@ class SSETransport implements ClientTransport {
  * while connecting are buffered and flushed once the connection is ready.
  * Requests issued while fully disconnected reject with a ConnectionError.
  * After the first successful connect(), auto-reconnect (when enabled)
- * handles drops — connect() never needs to be called again.
+ * handles drops, so connect() does not have to be called again — but calling
+ * it again is cheap and idempotent: a no-op while connected or connecting,
+ * and an immediate attempt otherwise, including while a reconnect backoff is
+ * pending. Call it whenever the connection needs to be live rather than
+ * caching an "already connected" flag — such a flag skips the call exactly
+ * when the socket has dropped.
  *
  * NOTE: this single-file output is a legacy build (Generator.GenerateTo) whose
  * client has drifted from the multi-file one. First-message auth
@@ -190,6 +195,9 @@ export class ApiClient {
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // connectInFlight is the attempt doConnect() is currently running, so a
+    // second caller joins it instead of opening a competing socket.
+    private connectInFlight: Promise<void> | null = null;
     private manualDisconnect = false;
     private pendingRejection: ApiError | null = null;
     private lastConnectionError: ConnectionError | null = null;
@@ -209,20 +217,67 @@ export class ApiClient {
     /**
      * Opens the connection to the server. This is a required manual step:
      * it is never called automatically — not by the constructor, not by
-     * <ApiClientProvider>, not by the generated hooks/functions. Call it
-     * once after constructing the client. No-op when already connected or
-     * connecting; auto-reconnect takes over after the first successful call.
+     * <ApiClientProvider>, not by the generated hooks/functions.
+     *
+     * It is cheap and idempotent, so call it whenever the connection needs to
+     * be live (after signing in, on resume) rather than remembering that it
+     * was called: it is a no-op while connected or connecting, and otherwise
+     * attempts a connection immediately — including while a reconnect backoff
+     * is pending, in which case the backoff is abandoned rather than waited
+     * out. Auto-reconnect takes over after the first successful call.
      */
     connect(): Promise<void> {
         if (this.state === 'connected' || this.state === 'connecting') {
             return Promise.resolve();
         }
+        return this.startConnect();
+    }
+
+    /**
+     * Abandons any pending reconnect backoff and attempts a connection now,
+     * keeping in-flight requests — unlike disconnect() + connect(), which
+     * rejects them.
+     *
+     * connect() already does this, so reach for reconnectNow() only when the
+     * client may be in a state connect() reads as "nothing to do": a socket
+     * the runtime left half-open still reports 'connected' until its close
+     * event lands. Resolves when the attempt finishes, connected or not, and
+     * joins an attempt already in flight rather than starting a second one.
+     */
+    reconnectNow(): Promise<void> {
+        return this.startConnect();
+    }
+
+    // startConnect is the manual-connect path behind connect() and
+    // reconnectNow(): a fresh start followed by an immediate attempt.
+    private startConnect(): Promise<void> {
         this.manualDisconnect = false;
+        this.reconnectAttempts = 0;
+        // Drop a pending backoff. The caller wants a connection now, and a
+        // timer left armed would fire a second doConnect() on top of the
+        // connection this call is about to establish.
+        this.clearReconnectTimer();
         this.setupPageListeners();
         return this.doConnect();
     }
 
-    private async doConnect(): Promise<void> {
+    // doConnect serializes connection attempts: at most one runs at a time,
+    // and a live socket is never replaced. A second attempt would leave the
+    // first socket open behind it, and that socket's eventual close then tears
+    // down the connection that replaced it.
+    private doConnect(): Promise<void> {
+        if (this.state === 'connected' && this.transport.isConnected()) {
+            return Promise.resolve();
+        }
+        if (this.connectInFlight) return this.connectInFlight;
+        const attempt = this.runConnect().finally(() => {
+            if (this.connectInFlight === attempt) this.connectInFlight = null;
+        });
+        this.connectInFlight = attempt;
+        return attempt;
+    }
+
+    private async runConnect(): Promise<void> {
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
         // getConnectParams is resolved per attempt so every reconnect can
@@ -339,6 +394,13 @@ export class ApiClient {
         }
     }
 
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+    }
+
     private scheduleReconnect(): void {
         if (this.reconnectTimer) return;
 
@@ -359,10 +421,7 @@ export class ApiClient {
         if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
 
         // Reject in-flight requests synchronously: the server may still
         // respond between transport.disconnect() and the close event
@@ -467,10 +526,7 @@ export class ApiClient {
         if (this.state === 'connected' && this.transport.isConnected()) return;
         if (this.state === 'connecting') return;
 
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.reconnectAttempts = 0;
         this.doConnect().catch(() => {});
     }

--- a/templates/client.ts.tmpl
+++ b/templates/client.ts.tmpl
@@ -146,8 +146,12 @@ class SSETransport implements ClientTransport {
  * client into 'connecting', and requests issued while connecting are buffered
  * and flushed once the connection is ready. Requests issued while fully
  * disconnected reject with a ConnectionError. After the first successful
- * connect(), auto-reconnect (when enabled) handles drops — connect() never
- * needs to be called again.
+ * connect(), auto-reconnect (when enabled) handles drops, so connect() does
+ * not have to be called again — but calling it again is cheap and idempotent:
+ * a no-op while connected or connecting, and an immediate attempt otherwise,
+ * including while a reconnect backoff is pending. Call it whenever the
+ * connection needs to be live rather than caching an "already connected"
+ * flag — such a flag skips the call exactly when the socket has dropped.
  *
  * NOTE: this single-file output is a legacy build (Generator.GenerateTo) whose
  * client has drifted from the multi-file one. First-message auth
@@ -182,6 +186,9 @@ export class ApiClient {
     private state: ConnectionState = 'disconnected';
     private reconnectAttempts = 0;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // connectInFlight is the attempt doConnect() is currently running, so a
+    // second caller joins it instead of opening a competing socket.
+    private connectInFlight: Promise<void> | null = null;
     private manualDisconnect = false;
     private pendingRejection: ApiError | null = null;
     private lastConnectionError: ConnectionError | null = null;
@@ -201,20 +208,67 @@ export class ApiClient {
     /**
      * Opens the connection to the server. This is a required manual step:
      * it is never called automatically — not by the constructor, not by the
-     * generated functions. Call it once after constructing the client. No-op
-     * when already connected or connecting; auto-reconnect takes over after
-     * the first successful call.
+     * generated functions.
+     *
+     * It is cheap and idempotent, so call it whenever the connection needs to
+     * be live (after signing in, on resume) rather than remembering that it
+     * was called: it is a no-op while connected or connecting, and otherwise
+     * attempts a connection immediately — including while a reconnect backoff
+     * is pending, in which case the backoff is abandoned rather than waited
+     * out. Auto-reconnect takes over after the first successful call.
      */
     connect(): Promise<void> {
         if (this.state === 'connected' || this.state === 'connecting') {
             return Promise.resolve();
         }
+        return this.startConnect();
+    }
+
+    /**
+     * Abandons any pending reconnect backoff and attempts a connection now,
+     * keeping in-flight requests — unlike disconnect() + connect(), which
+     * rejects them.
+     *
+     * connect() already does this, so reach for reconnectNow() only when the
+     * client may be in a state connect() reads as "nothing to do": a socket
+     * the runtime left half-open still reports 'connected' until its close
+     * event lands. Resolves when the attempt finishes, connected or not, and
+     * joins an attempt already in flight rather than starting a second one.
+     */
+    reconnectNow(): Promise<void> {
+        return this.startConnect();
+    }
+
+    // startConnect is the manual-connect path behind connect() and
+    // reconnectNow(): a fresh start followed by an immediate attempt.
+    private startConnect(): Promise<void> {
         this.manualDisconnect = false;
+        this.reconnectAttempts = 0;
+        // Drop a pending backoff. The caller wants a connection now, and a
+        // timer left armed would fire a second doConnect() on top of the
+        // connection this call is about to establish.
+        this.clearReconnectTimer();
         this.setupPageListeners();
         return this.doConnect();
     }
 
-    private async doConnect(): Promise<void> {
+    // doConnect serializes connection attempts: at most one runs at a time,
+    // and a live socket is never replaced. A second attempt would leave the
+    // first socket open behind it, and that socket's eventual close then tears
+    // down the connection that replaced it.
+    private doConnect(): Promise<void> {
+        if (this.state === 'connected' && this.transport.isConnected()) {
+            return Promise.resolve();
+        }
+        if (this.connectInFlight) return this.connectInFlight;
+        const attempt = this.runConnect().finally(() => {
+            if (this.connectInFlight === attempt) this.connectInFlight = null;
+        });
+        this.connectInFlight = attempt;
+        return attempt;
+    }
+
+    private async runConnect(): Promise<void> {
         this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
         // getConnectParams is resolved per attempt so every reconnect can
@@ -333,6 +387,13 @@ export class ApiClient {
         }
     }
 
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+    }
+
     private scheduleReconnect(): void {
         if (this.reconnectTimer) return;
 
@@ -353,10 +414,7 @@ export class ApiClient {
         if (this.manualDisconnect) return;
         this.manualDisconnect = true;
         this.teardownPageListeners();
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
 
         // Reject in-flight requests synchronously: the server may still
         // respond between transport.disconnect() and the close event
@@ -461,10 +519,7 @@ export class ApiClient {
         if (this.state === 'connected' && this.transport.isConnected()) return;
         if (this.state === 'connecting') return;
 
-        if (this.reconnectTimer) {
-            clearTimeout(this.reconnectTimer);
-            this.reconnectTimer = null;
-        }
+        this.clearReconnectTimer();
         this.reconnectAttempts = 0;
         this.doConnect().catch(() => {});
     }


### PR DESCRIPTION
Fixes #287.

## The bug

`connect()` during a reconnect backoff connected immediately — as intended — but left the pending `reconnectTimer` armed. Up to `reconnectMaxInterval` later (30 s by default) that timer fired `doConnect()` again and replaced a live socket. `WebSocketTransport.connect()` detaches the previous socket's handlers before replacing it, so `handleClose()` never ran for the replaced socket and **any request in flight at that moment never settled** — it neither resolved nor rejected. Subscriptions re-established on the new connection, so a hanging promise was the only symptom.

## The fix

- A manual connect cancels the pending backoff (`startConnect()`, shared by `connect()` and `reconnectNow()`).
- Connection attempts are serialized. `doConnect()` returns the attempt already in flight instead of opening a competing socket, and returns early rather than replacing a socket the transport reports as live. That closes the same hole for the narrower race where `connect()` lands while a timer-fired attempt is mid-handshake.
- Requests bound to a socket that genuinely *is* replaced — the page-wake path, where the runtime left it half-open — now reject with a `ConnectionError` instead of hanging (`abandonInFlight()`). Same failure mode as the reported one, different trigger.

## `reconnectNow()`

New public method: abandon a pending backoff and connect now, keeping subscriptions and in-flight requests. `connect()` already does this after the fix, so `reconnectNow()` adds only the case `connect()` reads as "nothing to do" — a socket the runtime left half-open still reports `'connected'` until its close event lands. Previously the only way to cut a backoff short was `disconnect()` + `connect()`, which drops every subscription and rejects in-flight requests.

## Docs

The `connect()` doc said it is called "once after constructing the client" and "never needs to be called again". True for keeping a connection alive, misleading for "make sure we are connected now" — per the issue it led a consumer app to a module-level `if (connected) return` wrapper, which no-ops exactly when the socket has dropped. Result there was a ~30 s sign-in with no `/ws` request in the network panel at all. `README.md`, `doc.go`, `APROT_AI.md`, `docs/auth.md`, `CHANGELOG.md` and the generated client's own doc comments now state that `connect()` is cheap and idempotent and should be called whenever the connection needs to be live.

## Scope

Applied to `templates/_client-common.ts.tmpl` (multi-file output) and to both legacy single-file templates, `client.ts.tmpl` / `client-react.ts.tmpl`. Those two have their own older client whose transport does not detach the replaced socket's handlers — there the same stale timer leaks a socket whose later close tears down the connection that replaced it — so they get the timer fix, the serialization and `reconnectNow()`, with comments matching their actual failure mode, but not `abandonInFlight()`.

## Testing

New `e2e/tests/reconnect.test.ts` (5 tests). All five fail against the pre-fix generated client and pass after; the in-flight test hangs for the full 5 s timeout pre-fix, which is the reported symptom reproduced.

- `go test ./...` — pass
- `e2e`: 114 tests / 23 files — pass; `eslint` clean, `tsc --noEmit` clean
- `example/react/client` `tsc --noEmit` — pass
- Legacy single-file output type-checks with the same 6 pre-existing strict-mode errors as before the change (documented drift, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)