### PR TITLE
Bump CI Node from 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate vanilla client
         run: cd example/vanilla/tools/generate && go run main.go
@@ -136,7 +136,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate E2E client
         run: cd e2e/generate && go run main.go


### PR DESCRIPTION
## Why

Dependabot PR #285 (jsdom 29.1.1 → 30.0.1) fails `e2e-tests`, but not because of anything in this repo. `jsdom@30.0.1` declares:

```
engines: { node: '^22.22.2 || ^24.15.0 || >=26.0.0' }
```

CI pins `node-version: '20'`, so jsdom's bundled undici blows up at import time:

```
TypeError: webidl.util.markAsUncloneable is not a function
  ❯ new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17
  ❯ Object.<anonymous> node_modules/jsdom/lib/api.js:12:33
```

That kills the vitest forks workers for the jsdom-environment suites, so those tests never run — CI on #285 reports 17 files / 96 tests passed plus 2 worker errors instead of the full suite.

## Change

`node-version: '20'` → `'24'` in both the `typescript-compile` and `e2e-tests` jobs. Node 24 is the current Active LTS and satisfies jsdom 30's range.

## Verification

Ran the #285 branch locally on Node v24.18.0 with jsdom 30.0.1:

```
Test Files  19 passed (19)
     Tests  98 passed (98)
```

No worker errors — the two suites that crashed on Node 20 now run.

## Follow-up

Once this merges, #285 should go green after a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)