### PR TITLE
Type-check the vanilla example via its own project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,23 @@ updates:
         patterns: ["*"]
 
   # npm packages for the example/e2e clients (only directories with a lockfile).
+  #
+  # The three TypeScript-consuming projects sit on different major versions
+  # (vanilla 5.x, e2e 6.x, react client 7.x). Generated clients are the
+  # library's public surface, so compiling them across three majors is the only
+  # signal we have that codegen output works for consumers on older toolchains.
+  # The vanilla client is pinned to 5.x by hand to hold the low end of that
+  # range; e2e and the react client still take TypeScript majors from Dependabot.
+  - package-ecosystem: npm
+    directory: /example/vanilla/client
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types: [minor, patch]
+    ignore:
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
   - package-ecosystem: npm
     directory: /e2e
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,11 @@ jobs:
       - name: Generate vanilla client
         run: cd example/vanilla/tools/generate && go run main.go
 
+      - name: Install vanilla example deps
+        run: cd example/vanilla/client && npm ci
+
       - name: Check vanilla client compiles
-        run: |
-          cd example/vanilla/client/static/api
-          npm init -y > /dev/null 2>&1
-          npm install typescript@^5.7.0 --save-dev > /dev/null 2>&1
-          npx tsc --noEmit --strict --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck *.ts
+        run: cd example/vanilla/client && npx tsc --noEmit
 
       - name: Generate react client
         run: cd example/react/tools/generate && go run main.go

--- a/example/vanilla/client/package-lock.json
+++ b/example/vanilla/client/package-lock.json
@@ -8,7 +8,8 @@
       "name": "aprot-vanilla-client",
       "version": "1.0.0",
       "devDependencies": {
-        "esbuild": "^0.28.0"
+        "esbuild": "^0.28.0",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -493,6 +494,20 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/example/vanilla/client/package.json
+++ b/example/vanilla/client/package.json
@@ -7,6 +7,7 @@
     "watch": "esbuild static/app.ts --bundle --outfile=static/app.js --format=iife --target=es2020 --watch"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0"
+    "esbuild": "^0.28.0",
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Follow-up to #290 — tidies the TypeScript tooling gaps that surfaced while triaging the Dependabot queue.

## The problem

The vanilla compile check built a throwaway npm project *inside the generated output directory* on every CI run:

```yaml
cd example/vanilla/client/static/api
npm init -y
npm install typescript@^5.7.0 --save-dev
npx tsc --noEmit --strict --target ES2022 --module ESNext --moduleResolution bundler --skipLibCheck *.ts
```

Three things fall out of that:

1. **The TypeScript version was invisible to Dependabot.** Nothing recorded it in a lockfile, so `^5.7.0` floated to whatever 5.x was newest that day, with no PR trail.
2. **The inline flags duplicated `tsconfig.json` and had already diverged** — `--target ES2022` against the project's `ES2020`. The check wasn't testing the configuration the example actually ships.
3. **`static/app.ts` was never type-checked.** Globbing `*.ts` inside `static/api` covers only generated files; `app.ts` is the code that actually *consumes* the generated client, which is the more interesting half.

`example/vanilla/client` already had `package.json`, `package-lock.json` and `tsconfig.json` sitting right there, all git-tracked. The check just wasn't using them.

## The change

- Add `typescript` as a tracked devDependency of the vanilla client (resolved to `^5.9.3`, now lockfile-pinned).
- Replace the inline step with `npm ci` + `npx tsc --noEmit`, which picks up `tsconfig.json` — same shape as the react example's check.
- Register `/example/vanilla/client` with Dependabot. It has a lockfile, so it was already in scope for the config's stated *"only directories with a lockfile"* rule, but was never listed — `esbuild` was unmanaged there too.

## On the TypeScript version spread

The three TS-consuming projects sit on different majors: vanilla 5.x, e2e 6.x, react client 7.x. That started out accidental, but it's worth keeping — generated clients are the library's public surface, and compiling them across three majors is the only signal we have that codegen output still works for consumers on older toolchains.

So the vanilla entry ignores TypeScript **majors** (minor/patch still flow) to hold the low end deliberately, with the reasoning written into `dependabot.yml`. e2e and the react client are untouched and still take TS majors from Dependabot.

## Verification

Locally on Node 24, running exactly what CI runs:

```
npm ci   → exit 0
tsc      → exit 0   (app.ts + api/*.ts)
```

Also confirmed the generator is idempotent — regenerating leaves the committed `static/api/*.ts` unchanged.

## Not changed

- **The e2e ↔ react-client type duplication.** Checked after #284/#286 merged: `react`, `react-dom`, `@types/react` and `@types/react-dom` are already identical across both. The duplication is inherent to two separate npm projects, and the grouped Dependabot PRs are keeping them aligned, so no machinery seemed worth adding.
- **No `README.md` / `doc.go` / `APROT_AI.md` updates** — this is CI tooling only, no user-facing API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)