### PR TITLE
Release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-08-08
+
 ### Added
 
 - Per-connection opt-out from WebSocket binary frames. A client that does not
@@ -482,7 +484,10 @@ This file was introduced at v0.44.0; for the history of earlier releases see the
   resource-exhaustion blast radius of a single misbehaving connection (#222).
 - Static analysis (`gosec`) and vulnerability scanning (`govulncheck`) added to CI (#207 P3).
 
-[Unreleased]: https://github.com/marrasen/aprot/compare/v0.50.0...HEAD
+[Unreleased]: https://github.com/marrasen/aprot/compare/v0.53.0...HEAD
+[0.53.0]: https://github.com/marrasen/aprot/compare/v0.52.0...v0.53.0
+[0.52.0]: https://github.com/marrasen/aprot/compare/v0.51.0...v0.52.0
+[0.51.0]: https://github.com/marrasen/aprot/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/marrasen/aprot/compare/v0.49.1...v0.50.0
 [0.49.1]: https://github.com/marrasen/aprot/compare/v0.49.0...v0.49.1
 [0.49.0]: https://github.com/marrasen/aprot/compare/v0.48.0...v0.49.0


### PR DESCRIPTION
Rolls the `[Unreleased]` section into **0.53.0**.

## Why a minor bump

Everything since v0.52.0 is under **Added**, **Fixed** and **Documentation** — new server options and generated-client APIs, two reconnect fixes, and docs. No `Changed` or `Removed`, and no behavior change for existing callers, so a minor bump is right.

## What's in it

**Auth for short-lived JWTs (#283)** — the bulk of the release. `getConnectParams` resolves query parameters fresh on every connection attempt so a token can't freeze into a static URL; `reconnectOnRejected` retries a rejected connection instead of treating it as terminal; `getLastRejection()` / `useConnectionRejection()` / `useConnectionError()` let a UI distinguish "session expired" from "server unreachable"; `ServerOptions.AllowAnonymous` admits unauthenticated connections while an `OnAuth` hook is registered. `docs/auth.md` is the recipe, and the React example is rewired off the racy pattern it used to demonstrate.

**WebSocket binary frame opt-out (#279)** — clients that can't decode binary can dial `?binary=0` and get the JSON `$blob` envelope instead; `ConfigMessage.BinaryFrames` reports the negotiated answer before any request can be made. `docs/binary-frames.md` documents the frame format for non-generated clients.

**Reconnect fixes (#287)** — `connect()` during a backoff left the pending timer armed, which could replace a live socket up to 30 s later and strand an in-flight request unsettled. Attempts are now serialized. `useConnectionState` / `useConnection` / `useIsLoading` moved to `useSyncExternalStore`, fixing a stale-forever state when the connection completed between first render and the subscribing effect. Adds `reconnectNow()`.

Plus the CI and tooling work from #290 and #291, and the grouped Dependabot bumps.

## Also fixed here

The comparison links at the bottom of the changelog had gone stale: **0.51.0 and 0.52.0 shipped without link entries**, and `[Unreleased]` still pointed at `v0.50.0`. Backfilled both and repointed `[Unreleased]` at `v0.53.0`.

## Verification

- `go test ./...` — pass
- `gofmt -l .` — clean
- Regenerated all three clients (vanilla, react, e2e): **no drift**, so the committed generated output matches the templates this release ships.

## After merge

Needs `git tag v0.53.0` on master plus a GitHub release — say the word and I'll do it, or it's yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)